### PR TITLE
Fix db instructions litemaas_db

### DIFF
--- a/docs/deployment/openshift-deployment.md
+++ b/docs/deployment/openshift-deployment.md
@@ -250,7 +250,7 @@ oc create secret generic postgres-secret \
 
 # Create backend secret
 oc create secret generic backend-secret \
-  --from-literal=database-url="postgresql://litemaas_admin:$POSTGRES_PASSWORD@postgres:5432/litemaas_db" \
+  --from-literal=database-url="postgresql://litemaas_admin:$POSTGRES_PASSWORD@postgres:5432/litemaas_db?sslmode=disable" \
   --from-literal=cors-origin="https://litemaas-$NAMESPACE.$CLUSTER_DOMAIN" \
   --from-literal=jwt-secret="$JWT_SECRET" \
   --from-literal=oauth-client-id="$OAUTH_CLIENT_ID" \

--- a/docs/deployment/openshift-deployment.md
+++ b/docs/deployment/openshift-deployment.md
@@ -250,7 +250,7 @@ oc create secret generic postgres-secret \
 
 # Create backend secret
 oc create secret generic backend-secret \
-  --from-literal=database-url="postgresql://litemaas_admin:$POSTGRES_PASSWORD@postgres:5432/litemaas" \
+  --from-literal=database-url="postgresql://litemaas_admin:$POSTGRES_PASSWORD@postgres:5432/litemaas_db" \
   --from-literal=cors-origin="https://litemaas-$NAMESPACE.$CLUSTER_DOMAIN" \
   --from-literal=jwt-secret="$JWT_SECRET" \
   --from-literal=oauth-client-id="$OAUTH_CLIENT_ID" \


### PR DESCRIPTION
one liner to match script - else we end up with this error

```bash
backend-5469bcc9b-glxhc backend {"level":40,"time":1754863688007,"pid":12,"hostname":"backend-5469bcc9b-glxhc","err":{"type":"DatabaseError","message":"database \"litemaas\" does not exist","stack":"error: database \"litemaas\" does not exist\n    at /app/node_modules/pg-pool/index.js:45:11\n    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)\n    at async Object.<anonymous> (/app/backend/dist/plugins/database.js:53:32)","length":94,"name":"error","severity":"FATAL","code":"3D000","file":"postinit.c","line":"1021","routine":"InitPostgres"},"msg":"PostgreSQL not available, using mock data for development"}
```