### PR TITLE
fix: correct admin-readonly role handling and permissions

### DIFF
--- a/backend/tests/unit/services/oauth.service.test.ts
+++ b/backend/tests/unit/services/oauth.service.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { OAuthService } from '../../../src/services/oauth.service.js';
+import { FastifyInstance } from 'fastify';
+
+// Mock Fastify instance
+const createMockFastify = () =>
+  ({
+    dbUtils: {
+      queryOne: vi.fn(),
+      query: vi.fn(),
+    },
+    log: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    },
+  }) as unknown as FastifyInstance;
+
+describe('OAuthService', () => {
+  let service: OAuthService;
+  let mockFastify: FastifyInstance;
+  let mockLiteLLMService: any;
+  let mockDefaultTeamService: any;
+
+  beforeEach(() => {
+    mockFastify = createMockFastify();
+    mockLiteLLMService = {
+      createUser: vi.fn(),
+    };
+    mockDefaultTeamService = {
+      ensureUserMembership: vi.fn(),
+    };
+
+    service = new OAuthService(mockFastify, mockLiteLLMService, mockDefaultTeamService);
+  });
+
+  describe('mapGroupsToRoles', () => {
+    it('should map litemaas-admins to admin and user roles', () => {
+      // Access private method for testing
+      const result = (service as any).mapGroupsToRoles(['litemaas-admins']);
+      expect(result).toEqual(['user', 'admin']);
+    });
+
+    it('should map litemaas-readonly to admin-readonly and user roles', () => {
+      const result = (service as any).mapGroupsToRoles(['litemaas-readonly']);
+      expect(result).toEqual(['user', 'admin-readonly']);
+    });
+
+    it('should map litemaas-users to user role only', () => {
+      const result = (service as any).mapGroupsToRoles(['litemaas-users']);
+      expect(result).toEqual(['user']);
+    });
+
+    it('should handle multiple groups correctly', () => {
+      const result = (service as any).mapGroupsToRoles(['litemaas-admins', 'litemaas-readonly']);
+      expect(result).toContain('user');
+      expect(result).toContain('admin');
+      expect(result).toContain('admin-readonly');
+      expect(result).toHaveLength(3);
+    });
+
+    it('should return user role for unknown groups', () => {
+      const result = (service as any).mapGroupsToRoles(['unknown-group']);
+      expect(result).toEqual(['user']);
+    });
+
+    it('should return user role for empty groups array', () => {
+      const result = (service as any).mapGroupsToRoles([]);
+      expect(result).toEqual(['user']);
+    });
+
+    it('should always include user role as base', () => {
+      const testCases = [
+        ['litemaas-admins'],
+        ['litemaas-readonly'],
+        ['developers'],
+        ['viewers'],
+        ['unknown-group'],
+        [],
+      ];
+
+      testCases.forEach((groups) => {
+        const result = (service as any).mapGroupsToRoles(groups);
+        expect(result).toContain('user');
+      });
+    });
+  });
+
+  describe('mergeRoles', () => {
+    it('should preserve existing application-set roles', () => {
+      const existingRoles = ['admin', 'customRole'];
+      const openShiftRoles = ['user'];
+
+      const result = (service as any).mergeRoles(existingRoles, openShiftRoles);
+
+      expect(result).toContain('admin');
+      expect(result).toContain('customRole');
+      expect(result).toContain('user');
+    });
+
+    it('should add new OpenShift roles to existing roles', () => {
+      const existingRoles = ['user'];
+      const openShiftRoles = ['admin-readonly', 'user'];
+
+      const result = (service as any).mergeRoles(existingRoles, openShiftRoles);
+
+      expect(result).toContain('user');
+      expect(result).toContain('admin-readonly');
+      expect(result).toHaveLength(2);
+    });
+
+    it('should handle empty existing roles', () => {
+      const existingRoles: string[] = [];
+      const openShiftRoles = ['admin-readonly', 'user'];
+
+      const result = (service as any).mergeRoles(existingRoles, openShiftRoles);
+
+      expect(result).toContain('user');
+      expect(result).toContain('admin-readonly');
+    });
+
+    it('should handle empty OpenShift roles', () => {
+      const existingRoles = ['admin', 'customRole'];
+      const openShiftRoles: string[] = [];
+
+      const result = (service as any).mergeRoles(existingRoles, openShiftRoles);
+
+      expect(result).toContain('user'); // Always ensure user role
+      expect(result).toContain('admin');
+      expect(result).toContain('customRole');
+    });
+
+    it('should deduplicate roles', () => {
+      const existingRoles = ['user', 'admin'];
+      const openShiftRoles = ['user', 'admin-readonly'];
+
+      const result = (service as any).mergeRoles(existingRoles, openShiftRoles);
+
+      expect(result.filter((role) => role === 'user')).toHaveLength(1);
+      expect(result).toContain('admin');
+      expect(result).toContain('admin-readonly');
+    });
+
+    it('should always ensure user role is present', () => {
+      const testCases = [
+        [['admin'], ['admin-readonly']],
+        [['customRole'], ['anotherCustomRole']],
+        [[], []],
+        [['admin'], []],
+        [[], ['admin-readonly']],
+      ];
+
+      testCases.forEach(([existingRoles, openShiftRoles]) => {
+        const result = (service as any).mergeRoles(existingRoles, openShiftRoles);
+        expect(result).toContain('user');
+      });
+    });
+
+    it('should handle application-set admin role with OpenShift user group', () => {
+      // Scenario: User was manually made admin but OpenShift only has them in litemaas-users
+      const existingRoles = ['admin', 'user'];
+      const openShiftRoles = ['user']; // Only user from litemaas-users group
+
+      const result = (service as any).mergeRoles(existingRoles, openShiftRoles);
+
+      expect(result).toContain('admin'); // Should preserve admin role
+      expect(result).toContain('user');
+      expect(result).toHaveLength(2);
+    });
+
+    it('should handle user promoted in OpenShift but not yet in application', () => {
+      // Scenario: User added to litemaas-admins group, should get admin role
+      const existingRoles = ['user'];
+      const openShiftRoles = ['admin', 'user']; // From litemaas-admins group
+
+      const result = (service as any).mergeRoles(existingRoles, openShiftRoles);
+
+      expect(result).toContain('admin'); // Should get admin role
+      expect(result).toContain('user');
+      expect(result).toHaveLength(2);
+    });
+  });
+});

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -63,7 +63,7 @@ const Layout: React.FC = () => {
   // Helper function to get the most powerful role
   const getMostPowerfulRole = (roles: string[]): string => {
     if (roles.includes('admin')) return 'admin';
-    if (roles.includes('adminReadonly')) return 'adminReadonly';
+    if (roles.includes('admin-readonly')) return 'adminReadonly';
     if (roles.includes('user')) return 'user';
     return 'user'; // default fallback
   };

--- a/frontend/src/components/banners/BannerEditModal.tsx
+++ b/frontend/src/components/banners/BannerEditModal.tsx
@@ -30,6 +30,7 @@ interface BannerEditModalProps {
   onClose: () => void;
   onSave: (data: CreateBannerRequest) => Promise<void>;
   isLoading?: boolean;
+  canEdit?: boolean;
 }
 
 const BannerEditModal: React.FC<BannerEditModalProps> = ({
@@ -39,6 +40,7 @@ const BannerEditModal: React.FC<BannerEditModalProps> = ({
   onClose,
   onSave,
   isLoading = false,
+  canEdit = true,
 }) => {
   const { t } = useTranslation();
 
@@ -174,7 +176,13 @@ const BannerEditModal: React.FC<BannerEditModalProps> = ({
   return (
     <Modal
       variant={ModalVariant.large}
-      title={mode === 'create' ? t('pages.tools.createNewBanner') : t('pages.tools.editBanner')}
+      title={
+        !canEdit && mode === 'edit'
+          ? t('pages.tools.viewBanner')
+          : mode === 'create'
+            ? t('pages.tools.createNewBanner')
+            : t('pages.tools.editBanner')
+      }
       isOpen={isOpen}
       onClose={onClose}
     >
@@ -190,6 +198,7 @@ const BannerEditModal: React.FC<BannerEditModalProps> = ({
               placeholder={t('pages.tools.bannerNamePlaceholder')}
               isRequired
               validated={errors.name ? 'error' : 'default'}
+              isDisabled={!canEdit}
             />
             {errors.name && <FormHelperText>{errors.name}</FormHelperText>}
           </FormGroup>
@@ -219,6 +228,7 @@ const BannerEditModal: React.FC<BannerEditModalProps> = ({
                       placeholder={t('pages.tools.bannerContentPlaceholder')}
                       isRequired={lang.key === 'en'}
                       validated={errors.content && lang.key === 'en' ? 'error' : 'default'}
+                      isDisabled={!canEdit}
                     />
                     {lang.key === 'en' && (
                       <FormHelperText>{t('pages.tools.bannerEnglishRequired')}</FormHelperText>
@@ -247,6 +257,7 @@ const BannerEditModal: React.FC<BannerEditModalProps> = ({
                   ref={toggleRef}
                   onClick={() => setIsVariantSelectOpen(!isVariantSelectOpen)}
                   isExpanded={isVariantSelectOpen}
+                  isDisabled={!canEdit}
                   aria-label={t('pages.tools.bannerStyleAriaLabel')}
                 >
                   {formData.variant === 'info' && t('pages.tools.variantInfo')}
@@ -275,6 +286,7 @@ const BannerEditModal: React.FC<BannerEditModalProps> = ({
               label={t('pages.tools.allowDismiss')}
               isChecked={formData.isDismissible}
               onChange={(_event, checked) => handleFormChange('isDismissible', checked)}
+              isDisabled={!canEdit}
             />
             <FormHelperText>
               {t('pages.tools.allowDismissHelper')}&nbsp;
@@ -291,6 +303,7 @@ const BannerEditModal: React.FC<BannerEditModalProps> = ({
               label={t('pages.tools.enableMarkdown')}
               isChecked={formData.markdownEnabled}
               onChange={(_event, checked) => handleFormChange('markdownEnabled', checked)}
+              isDisabled={!canEdit}
             />
             <FormHelperText>{t('pages.tools.enableMarkdownHelper')}</FormHelperText>
           </FormGroup>
@@ -305,18 +318,20 @@ const BannerEditModal: React.FC<BannerEditModalProps> = ({
             justifyContent: 'flex-end',
           }}
         >
-          <Button
-            key="save"
-            variant="primary"
-            type="submit"
-            form="banner-form"
-            isLoading={isLoading}
-            isDisabled={isLoading}
-          >
-            {mode === 'create' ? t('pages.tools.createBanner') : t('pages.tools.saveBanner')}
-          </Button>
+          {canEdit && (
+            <Button
+              key="save"
+              variant="primary"
+              type="submit"
+              form="banner-form"
+              isLoading={isLoading}
+              isDisabled={isLoading}
+            >
+              {mode === 'create' ? t('pages.tools.createBanner') : t('pages.tools.saveBanner')}
+            </Button>
+          )}
           <Button key="cancel" variant="link" onClick={onClose} isDisabled={isLoading}>
-            {t('common.cancel')}
+            {canEdit ? t('common.cancel') : t('common.close')}
           </Button>
         </div>
       </ModalBody>

--- a/frontend/src/components/banners/BannerTable.tsx
+++ b/frontend/src/components/banners/BannerTable.tsx
@@ -24,6 +24,7 @@ interface BannerTableProps {
   onEdit: (banner: Banner) => void;
   onDelete: (bannerId: string) => void;
   hasUnsavedChanges: boolean;
+  readOnly?: boolean;
 }
 
 const BannerTable: React.FC<BannerTableProps> = ({
@@ -33,6 +34,7 @@ const BannerTable: React.FC<BannerTableProps> = ({
   onEdit,
   onDelete,
   hasUnsavedChanges: _hasUnsavedChanges,
+  readOnly = false,
 }) => {
   const { t } = useTranslation();
   const [deleteConfirmModal, setDeleteConfirmModal] = useState<{
@@ -163,6 +165,7 @@ const BannerTable: React.FC<BannerTableProps> = ({
                           aria-label={t('pages.tools.toggleVisibility', { name: banner.name })}
                           isChecked={effectiveVisibility}
                           onChange={(_event, checked) => onVisibilityToggle(banner.id, checked)}
+                          isDisabled={readOnly}
                         />
                       </FlexItem>
                       <FlexItem>
@@ -208,7 +211,7 @@ const BannerTable: React.FC<BannerTableProps> = ({
                           aria-label={t('pages.tools.editBanner', { name: banner.name })}
                           size="sm"
                         >
-                          {t('pages.apiKeys.editKey')}
+                          {readOnly ? t('common.view') : t('pages.apiKeys.editKey')}
                         </Button>
                       </FlexItem>
                       <FlexItem>
@@ -218,6 +221,7 @@ const BannerTable: React.FC<BannerTableProps> = ({
                           onClick={() => handleDeleteClick(banner)}
                           aria-label={t('pages.tools.deleteBanner', { name: banner.name })}
                           size="sm"
+                          isDisabled={readOnly}
                         >
                           {t('pages.apiKeys.deleteKey')}
                         </Button>

--- a/frontend/src/config/navigation.tsx
+++ b/frontend/src/config/navigation.tsx
@@ -90,6 +90,7 @@ export const appConfig: AppConfig = {
           element: ToolsPage,
           label: 'nav.admin.tools',
           icon: CogIcon,
+          requiredRoles: ['admin', 'admin-readonly'],
         },
       ],
     },

--- a/frontend/src/i18n/locales/de/translation.json
+++ b/frontend/src/i18n/locales/de/translation.json
@@ -11,7 +11,9 @@
     "notAvailable": "N/V",
     "lineChart": "Liniendiagramm",
     "dataPoints": "Datenpunkte",
-    "cancel": "Abbrechen"
+    "cancel": "Abbrechen",
+    "view": "Ansehen",
+    "close": "Schließen"
   },
   "nav": {
     "home": "Startseite",

--- a/frontend/src/i18n/locales/elv/translation.json
+++ b/frontend/src/i18n/locales/elv/translation.json
@@ -11,7 +11,9 @@
     "notAvailable": "Ú-úir",
     "lineChart": "Minithith-rîn",
     "dataPoints": "Gwaed-vuin",
-    "cancel": "Daeglos"
+    "cancel": "Daeglos",
+    "view": "Cen",
+    "close": "Hortho"
   },
   "nav": {
     "home": "Eru",

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -11,7 +11,9 @@
     "notAvailable": "N/A",
     "lineChart": "line chart",
     "dataPoints": "data points",
-    "cancel": "Cancel"
+    "cancel": "Cancel",
+    "view": "View",
+    "close": "Close"
   },
   "nav": {
     "home": "Home",

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -11,7 +11,9 @@
     "notAvailable": "N/D",
     "lineChart": "gráfico de líneas",
     "dataPoints": "puntos de datos",
-    "cancel": "Cancelar"
+    "cancel": "Cancelar",
+    "view": "Ver",
+    "close": "Cerrar"
   },
   "nav": {
     "home": "Inicio",

--- a/frontend/src/i18n/locales/fr/translation.json
+++ b/frontend/src/i18n/locales/fr/translation.json
@@ -11,7 +11,9 @@
     "notAvailable": "N/D",
     "lineChart": "graphique linéaire",
     "dataPoints": "points de données",
-    "cancel": "Annuler"
+    "cancel": "Annuler",
+    "view": "Voir",
+    "close": "Fermer"
   },
   "nav": {
     "home": "Accueil",

--- a/frontend/src/i18n/locales/it/translation.json
+++ b/frontend/src/i18n/locales/it/translation.json
@@ -11,7 +11,9 @@
     "notAvailable": "N/D",
     "lineChart": "grafico a linee",
     "dataPoints": "punti dati",
-    "cancel": "Annulla"
+    "cancel": "Annulla",
+    "view": "Visualizza",
+    "close": "Chiudi"
   },
   "nav": {
     "home": "Home",

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -11,7 +11,9 @@
     "notAvailable": "N/A",
     "lineChart": "折れ線グラフ",
     "dataPoints": "データポイント",
-    "cancel": "キャンセル"
+    "cancel": "キャンセル",
+    "view": "表示",
+    "close": "閉じる"
   },
   "nav": {
     "home": "ホーム",

--- a/frontend/src/i18n/locales/ko/translation.json
+++ b/frontend/src/i18n/locales/ko/translation.json
@@ -11,7 +11,9 @@
     "notAvailable": "N/A",
     "lineChart": "선 차트",
     "dataPoints": "데이터 포인트",
-    "cancel": "취소"
+    "cancel": "취소",
+    "view": "보기",
+    "close": "닫기"
   },
   "nav": {
     "home": "홈",

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -11,7 +11,9 @@
     "notAvailable": "N/A",
     "lineChart": "折线图",
     "dataPoints": "数据点",
-    "cancel": "取消"
+    "cancel": "取消",
+    "view": "查看",
+    "close": "关闭"
   },
   "nav": {
     "home": "首页",

--- a/frontend/src/pages/ToolsPage.tsx
+++ b/frontend/src/pages/ToolsPage.tsx
@@ -83,14 +83,18 @@ const ToolsPage: React.FC = () => {
   );
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
 
-  // Check if user has admin permission (not admin-readonly)
-  const canSync = user?.roles?.includes('admin') ?? false;
-  const canUpdateLimits = user?.roles?.includes('admin') ?? false;
-  const canManageBanners = user?.roles?.includes('admin') ?? false;
+  // Check permissions - separate view from modify access
+  const canSync = user?.roles?.includes('admin') ?? false; // Only full admins can sync
+  const canViewLimits =
+    (user?.roles?.includes('admin') || user?.roles?.includes('admin-readonly')) ?? false;
+  const canUpdateLimits = user?.roles?.includes('admin') ?? false; // Only full admins can modify
+  const canViewBanners =
+    (user?.roles?.includes('admin') || user?.roles?.includes('admin-readonly')) ?? false;
+  const canManageBanners = user?.roles?.includes('admin') ?? false; // Only full admins can modify
 
   // Fetch all banners for admin management
   const { data: allBanners = [] } = useQuery(['allBanners'], () => bannerService.getAllBanners(), {
-    enabled: canManageBanners,
+    enabled: canViewBanners,
     staleTime: 30 * 1000, // 30 seconds
     cacheTime: 5 * 60 * 1000, // 5 minutes
   });
@@ -468,7 +472,7 @@ const ToolsPage: React.FC = () => {
           </Tab>
 
           {/* Limits Management Tab */}
-          {canUpdateLimits && (
+          {canViewLimits && (
             <Tab
               eventKey="limits"
               title={<TabTitleText>{t('pages.tools.limitsManagement')}</TabTitleText>}
@@ -550,6 +554,7 @@ const ToolsPage: React.FC = () => {
                             value={limitsFormData.maxBudget}
                             onChange={(_event, value) => handleLimitsFormChange('maxBudget', value)}
                             placeholder={t('pages.tools.leaveEmptyToKeep')}
+                            isDisabled={!canUpdateLimits}
                           />
                           <FormHelperText>{t('pages.tools.maxBudgetHelper')}</FormHelperText>
                         </FormGroup>
@@ -563,6 +568,7 @@ const ToolsPage: React.FC = () => {
                             value={limitsFormData.tpmLimit}
                             onChange={(_event, value) => handleLimitsFormChange('tpmLimit', value)}
                             placeholder={t('pages.tools.leaveEmptyToKeep')}
+                            isDisabled={!canUpdateLimits}
                           />
                           <FormHelperText>{t('pages.tools.tpmLimitHelper')}</FormHelperText>
                         </FormGroup>
@@ -576,6 +582,7 @@ const ToolsPage: React.FC = () => {
                             value={limitsFormData.rpmLimit}
                             onChange={(_event, value) => handleLimitsFormChange('rpmLimit', value)}
                             placeholder={t('pages.tools.leaveEmptyToKeep')}
+                            isDisabled={!canUpdateLimits}
                           />
                           <FormHelperText>{t('pages.tools.rpmLimitHelper')}</FormHelperText>
                         </FormGroup>
@@ -585,7 +592,7 @@ const ToolsPage: React.FC = () => {
                             variant="primary"
                             icon={<UsersIcon />}
                             onClick={handleLimitsFormSubmit}
-                            isDisabled={isLimitsLoading}
+                            isDisabled={!canUpdateLimits || isLimitsLoading}
                             isLoading={isLimitsLoading}
                           >
                             {isLimitsLoading
@@ -602,7 +609,7 @@ const ToolsPage: React.FC = () => {
           )}
 
           {/* Banner Management Tab */}
-          {canManageBanners && (
+          {canViewBanners && (
             <Tab
               eventKey="banners"
               title={<TabTitleText>{t('pages.tools.bannerManagement')}</TabTitleText>}
@@ -620,7 +627,7 @@ const ToolsPage: React.FC = () => {
                         variant="primary"
                         icon={<PlusIcon />}
                         onClick={handleCreateBanner}
-                        isDisabled={isBannerLoading}
+                        isDisabled={!canManageBanners || isBannerLoading}
                       >
                         {t('pages.tools.createNewBanner')}
                       </Button>
@@ -635,11 +642,12 @@ const ToolsPage: React.FC = () => {
                         onEdit={handleEditBanner}
                         onDelete={handleDeleteBanner}
                         hasUnsavedChanges={hasUnsavedChanges}
+                        readOnly={!canManageBanners}
                       />
                     </FlexItem>
 
                     {/* Apply Changes Button */}
-                    {hasUnsavedChanges && (
+                    {hasUnsavedChanges && canManageBanners && (
                       <FlexItem>
                         <Button
                           variant="primary"
@@ -722,6 +730,7 @@ const ToolsPage: React.FC = () => {
           }}
           onSave={handleModalSave}
           isLoading={isBannerLoading}
+          canEdit={canManageBanners}
         />
       </PageSection>
     </>

--- a/frontend/src/services/users.service.ts
+++ b/frontend/src/services/users.service.ts
@@ -99,18 +99,15 @@ export class UsersService {
   /**
    * Check if the current user can modify users (admin permissions)
    * This is a client-side helper to determine UI visibility
+   * Note: admin-readonly can read users but cannot modify them
    */
   canModifyUsers(currentUser?: { roles: string[] }): boolean {
     if (!currentUser?.roles) {
       return false;
     }
 
-    // Check for admin role or specific users:write permission
-    return (
-      currentUser.roles.includes('admin') ||
-      currentUser.roles.includes('users:write') ||
-      currentUser.roles.some((role) => role.startsWith('admin:'))
-    );
+    // Only full admins can modify users, not admin-readonly
+    return currentUser.roles.includes('admin') || currentUser.roles.includes('users:write');
   }
 
   /**
@@ -139,6 +136,7 @@ export class UsersService {
 
     return (
       currentUser.roles.includes('admin') ||
+      currentUser.roles.includes('admin-readonly') ||
       currentUser.roles.includes('users:read') ||
       currentUser.roles.some((role) => role.startsWith('admin:'))
     );

--- a/frontend/src/test/services/users.service.test.ts
+++ b/frontend/src/test/services/users.service.test.ts
@@ -448,16 +448,6 @@ describe('UsersService', () => {
         expect(result).toBe(true);
       });
 
-      it('should return true for users:write permission', () => {
-        const result = usersService.canModifyUsers({ roles: ['users:write'] });
-        expect(result).toBe(true);
-      });
-
-      it('should return true for admin:* permissions', () => {
-        const result = usersService.canModifyUsers({ roles: ['admin:users'] });
-        expect(result).toBe(true);
-      });
-
       it('should return false for regular user', () => {
         const result = usersService.canModifyUsers({ roles: ['user'] });
         expect(result).toBe(false);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "litemaas",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "LiteLLM User Application - Model subscription and management platform",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
Fix role mapping and permissions for admin-readonly users:
- Map OpenShift groups to 'admin-readonly' instead of 'readonly'
- Add role merging to preserve application-set roles during OAuth
- Fix frontend role detection to use 'admin-readonly'
- Allow read-only admins to view but not edit Tools page
- Add comprehensive tests for role mapping and merging logic

---
Signed-off-by: Guillaume Moutier <guimou@users.noreply.github.com>
Co-authored-by: Claude
