### PR TITLE
Updates cluster domain name example

### DIFF
--- a/docs/deployment/openshift-deployment.md
+++ b/docs/deployment/openshift-deployment.md
@@ -187,7 +187,7 @@ vi user-values.env
 
 ```bash
 LITEMAAS_VERSION=0.0.7
-CLUSTER_DOMAIN_NAME=apps.your-cluster.example.com
+CLUSTER_DOMAIN_NAME=your-cluster.example.com
 NAMESPACE=litemaas
 PG_ADMIN_PASSWORD=your-secure-db-password
 JWT_SECRET=your-secure-jwt-secret-64-chars


### PR DESCRIPTION
Corrects the example for the cluster domain name in the deployment documentation.

The `apps.` subdomain is not part of the cluster domain name,
which caused confusion.
This updates the example to accurately reflect the correct format.

---
Signed-off-by: Guillaume Moutier <guimou@users.noreply.github.com>
Co-authored-by: Claude
