### PR TITLE
feat(auth/oauth): add optional TLS verification bypass for k8s API

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -38,6 +38,15 @@ OAUTH_ISSUER=https://your-openshift-cluster.com
 # Set this to your primary development URL:
 OAUTH_CALLBACK_URL=http://localhost:3000/api/auth/callback
 
+# Kubernetes API TLS Verification
+# ⚠️ WARNING: Only enable this in development or with trusted clusters!
+# Skip TLS certificate verification for Kubernetes API calls (OAuth user info endpoint)
+# This is useful when the K8s API endpoint (https://api.<cluster>:6443) lacks proper SSL certificates
+# while Ingress/Routes have valid certificates.
+# Default: SSL verification enabled (secure)
+# K8S_API_SKIP_TLS_VERIFY=true
+
+
 # JWT Configuration
 JWT_SECRET=your-super-secret-jwt-key
 JWT_EXPIRES_IN=24h

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -112,6 +112,7 @@ For details, see [`docs/features/user-roles-administration.md`](../docs/features
 - **Admin**: AdminService
 
 **Admin Analytics Architecture**: Uses specialized service architecture with orchestrator pattern:
+
 - `AdminUsageStatsService` - Main orchestrator
 - `AdminUsageAggregationService` - Multi-dimensional filtering and aggregation
 - `AdminUsageEnrichmentService` - Data enrichment with batch queries

--- a/backend/src/plugins/env.ts
+++ b/backend/src/plugins/env.ts
@@ -27,6 +27,7 @@ const envSchema = Type.Object({
   OAUTH_CLIENT_SECRET: Type.String(),
   OAUTH_ISSUER: Type.String(),
   OAUTH_CALLBACK_URL: Type.String({ default: 'http://localhost:8081/api/auth/callback' }),
+  K8S_API_SKIP_TLS_VERIFY: Type.Optional(Type.String()),
 
   // LiteLLM
   LITELLM_API_URL: Type.String({ default: 'http://localhost:4000' }),

--- a/backend/src/types/fastify.ts
+++ b/backend/src/types/fastify.ts
@@ -26,6 +26,7 @@ declare module 'fastify' {
       OAUTH_CLIENT_SECRET: string;
       OAUTH_ISSUER: string;
       OAUTH_CALLBACK_URL: string;
+      K8S_API_SKIP_TLS_VERIFY?: string;
 
       // LiteLLM
       LITELLM_API_URL: string;

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -36,12 +36,13 @@ DB_CONNECTION_TIMEOUT=10000
 
 ## OAuth Configuration
 
-| Variable              | Description                   | Default                                   | Required |
-| --------------------- | ----------------------------- | ----------------------------------------- | -------- |
-| `OAUTH_CLIENT_ID`     | OpenShift OAuth client ID     | -                                         | Yes      |
-| `OAUTH_CLIENT_SECRET` | OpenShift OAuth client secret | -                                         | Yes      |
-| `OAUTH_ISSUER`        | OAuth provider URL            | -                                         | Yes      |
-| `OAUTH_CALLBACK_URL`  | OAuth callback URL            | `http://localhost:8081/api/auth/callback` | No       |
+| Variable                  | Description                                                          | Default                                   | Required |
+| ------------------------- | -------------------------------------------------------------------- | ----------------------------------------- | -------- |
+| `OAUTH_CLIENT_ID`         | OpenShift OAuth client ID                                            | -                                         | Yes      |
+| `OAUTH_CLIENT_SECRET`     | OpenShift OAuth client secret                                        | -                                         | Yes      |
+| `OAUTH_ISSUER`            | OAuth provider URL                                                   | -                                         | Yes      |
+| `OAUTH_CALLBACK_URL`      | OAuth callback URL                                                   | `http://localhost:8081/api/auth/callback` | No       |
+| `K8S_API_SKIP_TLS_VERIFY` | Skip TLS verification for Kubernetes API calls (⚠️ Use with caution) | -                                         | No       |
 
 ### OAuth Flow Architecture
 
@@ -130,6 +131,37 @@ grantMethod: prompt
 ```
 
 **Note**: The application automatically selects the correct callback URL based on request origin. This allows the same deployment to work across different environments without configuration changes.
+
+### Kubernetes API TLS Verification
+
+In some OpenShift/Kubernetes environments, the API server endpoint (`https://api.<cluster>:6443`) may not have proper SSL certificates configured, even though Ingress routes and load balancers do. This can cause SSL verification errors when the backend fetches user information from the Kubernetes API during OAuth authentication.
+
+**Environment Variable**: `K8S_API_SKIP_TLS_VERIFY`
+
+**Default**: SSL verification is **ENABLED** (secure, recommended for production)
+
+**When to use**: Set to `true` only when:
+
+- You're in a development/testing environment
+- The Kubernetes API endpoint lacks proper SSL certificates
+- You're experiencing SSL certificate verification errors during login
+- You trust the network and cluster (e.g., internal corporate network)
+
+⚠️ **Security Warning**:
+
+- Only use this in **trusted environments**
+- This affects **only** the Kubernetes API user info endpoint
+- OAuth token exchange and other endpoints are not affected
+- Never use in production unless absolutely necessary and the risk is understood
+
+**Example**:
+
+```bash
+# Only enable if experiencing SSL errors with K8s API
+K8S_API_SKIP_TLS_VERIFY=true
+```
+
+**Logging**: When enabled, the backend will log a warning message indicating that TLS verification is being skipped for visibility and security audit purposes.
 
 ## JWT Configuration
 

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -256,12 +256,14 @@ npm run check:translations  # Check all locale files for missing keys
 **Framework**: Vitest with React Testing Library and centralized test utilities in `src/test/test-utils.tsx`.
 
 **Key Patterns**:
+
 - **Auth Testing**: Use `renderWithAuth()` helper with `mockUser`, `mockAdminUser`, `mockAdminReadonlyUser`
 - **ConfigContext**: Mock entire context (not just service) to avoid loading state
 - **PatternFly 6**: Modals/dropdowns work in JSDOM; modals use `role="dialog"`, dropdowns use `role="menuitem"`
 - **Debugging**: Use `screen.debug()` to inspect DOM, `npm test -- File.test.tsx` for specific files
 
 **Test Guides**:
+
 - [`docs/development/pf6-guide/testing-patterns/modals.md`](../docs/development/pf6-guide/testing-patterns/modals.md) - Modal testing patterns
 - [`docs/development/pf6-guide/testing-patterns/dropdowns-pagination.md`](../docs/development/pf6-guide/testing-patterns/dropdowns-pagination.md) - Dropdown/pagination patterns
 - [`docs/development/pf6-guide/testing-patterns/context-dependent-components.md`](../docs/development/pf6-guide/testing-patterns/context-dependent-components.md) - Context-dependent components


### PR DESCRIPTION
Add K8S_API_SKIP_TLS_VERIFY configuration option to support
development environments where Kubernetes API server endpoints
lack proper SSL certificates while Ingress routes have valid ones.

Changes:
- Add K8S_API_SKIP_TLS_VERIFY environment variable to env plugin
- Implement conditional HTTPS agent in OAuth service for K8s API calls
- Add comprehensive documentation in authentication.md
- Include security warnings and recommended production alternatives
- Update configuration.md with new environment variable details

Security Considerations:
- Feature includes prominent warnings about security implications
- Backend logs warning message when TLS verification is skipped
- Documentation emphasizes this is for development/trusted networks only
- Provides alternative production-ready solutions

Closes #58

---
Signed-off-by: Guillaume Moutier <guimou@users.noreply.github.com>
Co-authored-by: Claude
