### PR TITLE
fix(test): handle orphaned keys and improve server startup

### DIFF
--- a/backend/src/plugins/database.ts
+++ b/backend/src/plugins/database.ts
@@ -36,38 +36,42 @@ const databasePlugin: FastifyPluginAsync = async (fastify) => {
           // Don't fail the startup, but log the error
         }
 
-        // Backfill litellm_key_alias for existing API keys
-        try {
-          const { backfillLiteLLMKeyAlias } = await import('../lib/database-migrations');
-          const { LiteLLMService } = await import('../services/litellm.service');
-          const liteLLMService = new LiteLLMService(fastify);
-          await backfillLiteLLMKeyAlias(fastify.dbUtils, liteLLMService);
-        } catch (backfillError) {
-          fastify.log.error(backfillError as Error, 'Failed to backfill litellm_key_alias');
-          // Don't fail the startup, but log the error
-        }
-
-        // Skip initial model sync in test environment
-        // Tests can explicitly sync models if needed for their scenarios
-        if (process.env.NODE_ENV !== 'test') {
-          // Sync models on startup
+        // Start LiteLLM-dependent operations in background - don't block server startup
+        setImmediate(async () => {
+          // Background task 1: Backfill litellm_key_alias for existing API keys
           try {
-            const { ModelSyncService } = await import('../services/model-sync.service');
-            const modelSyncService = new ModelSyncService(fastify);
-            const syncResult = await modelSyncService.syncModels({
-              forceUpdate: false,
-              markUnavailable: true,
-            });
-
-            fastify.log.info({
-              msg: 'Initial model sync completed',
-              ...syncResult,
-            });
-          } catch (syncError) {
-            fastify.log.error({ error: syncError }, 'Failed to sync models on startup');
-            // Don't fail startup - continue with cached models
+            fastify.log.info('Starting background backfill of litellm_key_alias');
+            const { backfillLiteLLMKeyAlias } = await import('../lib/database-migrations');
+            const { LiteLLMService } = await import('../services/litellm.service');
+            const liteLLMService = new LiteLLMService(fastify);
+            await backfillLiteLLMKeyAlias(fastify.dbUtils, liteLLMService);
+            fastify.log.info('Background backfill completed successfully');
+          } catch (backfillError) {
+            fastify.log.error(backfillError as Error, 'Background backfill failed');
           }
-        }
+
+          // Background task 2: Sync models from LiteLLM
+          // Skip in test environment
+          if (process.env.NODE_ENV !== 'test') {
+            try {
+              fastify.log.info('Starting background model sync from LiteLLM');
+              const { ModelSyncService } = await import('../services/model-sync.service');
+              const modelSyncService = new ModelSyncService(fastify);
+              const syncResult = await modelSyncService.syncModels({
+                forceUpdate: false,
+                markUnavailable: true,
+              });
+
+              fastify.log.info({
+                msg: 'Background model sync completed',
+                ...syncResult,
+              });
+            } catch (syncError) {
+              fastify.log.error({ error: syncError }, 'Background model sync failed');
+              // Continue - services will use cached models if available
+            }
+          }
+        });
 
         // Initialize LiteLLM integration service for auto-sync
         const litellmIntegrationService = new LiteLLMIntegrationService(fastify);

--- a/frontend/src/test/mocks/handlers.ts
+++ b/frontend/src/test/mocks/handlers.ts
@@ -358,6 +358,11 @@ export const handlers = [
     });
   }),
 
+  // Banner endpoint (used by BannerProvider in Layout)
+  http.get('/api/v1/banners', () => {
+    return HttpResponse.json([]);
+  }),
+
   // Error simulation endpoints
   http.get('/api/v1/test-error', () => {
     return HttpResponse.json(


### PR DESCRIPTION
Fix three issues affecting test reliability and server performance:

Backend improvements:
- Handle 404 errors for orphaned API keys in backfill migration
  by marking them with `orphaned_` prefix instead of failing
- Move LiteLLM-dependent operations to background tasks using
  setImmediate to prevent blocking server startup
- Add graceful handling for keys deleted in LiteLLM but still
  present in database

Frontend test fix:
- Add missing /api/v1/banners mock endpoint to test handlers
  to support BannerProvider in Layout component

Impact:
- Tests no longer fail due to missing banner endpoint
- Server startup is faster and more resilient
- Migration handles edge cases without verbose error logging

---
Signed-off-by: Guillaume Moutier <guimou@users.noreply.github.com>
Co-authored-by: Claude
