### PR TITLE
fix(migrations): skip inactive keys in litellm_key_alias backfill

### DIFF
--- a/backend/src/lib/database-migrations.ts
+++ b/backend/src/lib/database-migrations.ts
@@ -637,6 +637,7 @@ COMMENT ON COLUMN subscriptions.status_changed_by IS 'Existing subscriptions mig
 export const backfillLiteLLMKeyAlias = async (dbUtils: DatabaseUtils, liteLLMService: any) => {
   try {
     // Find all API keys that don't have litellm_key_alias set
+    // Only process active keys to avoid 404s from inactive/revoked keys
     const keysToBackfill = await dbUtils.queryMany<{
       id: string;
       lite_llm_key_value: string;
@@ -644,7 +645,8 @@ export const backfillLiteLLMKeyAlias = async (dbUtils: DatabaseUtils, liteLLMSer
       `SELECT id, lite_llm_key_value
        FROM api_keys
        WHERE litellm_key_alias IS NULL
-         AND lite_llm_key_value IS NOT NULL`,
+         AND lite_llm_key_value IS NOT NULL
+         AND is_active = true`,
       [],
     );
 


### PR DESCRIPTION
The backfill migration was processing all API keys including inactive
ones, causing 404 errors from LiteLLM. After 5 consecutive failures,
the circuit breaker would open, preventing active keys from being
processed.

Changes:
- Add is_active = true filter to backfill query
- Add explanatory comment about skipping inactive keys
- Prevent circuit breaker from opening on orphaned keys

This ensures only functional API keys are processed during backfill,
avoiding failures from inactive/revoked keys that don't exist in
LiteLLM database.

---
Signed-off-by: Guillaume Moutier <guimou@users.noreply.github.com>
Co-authored-by: Claude
