### PR TITLE
fix(admin/models): add support for updating restricted access flag

### DIFF
--- a/backend/src/routes/admin-models.ts
+++ b/backend/src/routes/admin-models.ts
@@ -61,6 +61,7 @@ const adminModelsRoutes: FastifyPluginAsync = async (fastify) => {
         supports_function_calling,
         supports_parallel_function_calling,
         supports_tool_choice,
+        restrictedAccess,
       } = request.body;
 
       try {
@@ -112,6 +113,7 @@ const adminModelsRoutes: FastifyPluginAsync = async (fastify) => {
               supports_function_calling,
               supports_parallel_function_calling,
               supports_tool_choice,
+              restrictedAccess,
             }),
           ],
         );
@@ -124,6 +126,14 @@ const adminModelsRoutes: FastifyPluginAsync = async (fastify) => {
           if (description) {
             await fastify.dbUtils.query('UPDATE models SET description = $1 WHERE id = $2', [
               description,
+              model_name,
+            ]);
+          }
+
+          // Update the restrictedAccess flag if provided
+          if (restrictedAccess !== undefined) {
+            await fastify.dbUtils.query('UPDATE models SET restricted_access = $1 WHERE id = $2', [
+              restrictedAccess,
               model_name,
             ]);
           }


### PR DESCRIPTION
The POST /api/v1/admin/models endpoint was missing support for
the restrictedAccess parameter. When creating models,
the restricted access flag was not being extracted from the request
body or persisted to the database. However it was properly working in an update operation.

Changes:
- Extract restrictedAccess from request body
- Add restrictedAccess to LiteLLM synchronization params
- Implement database update for restricted_access flag
- Update occurs after model creation/sync completes

This enables administrators to properly manage model access
restrictions through the admin API, which is required for the
subscription approval workflow feature.

Related to restricted model subscription approval feature.

---
Signed-off-by: Guillaume Moutier <guimou@users.noreply.github.com>
Co-authored-by: Claude
