### PR TITLE
feat: add CI/CD pipeline with GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,140 @@
+name: CI
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint backend
+        run: npm run lint --workspace=backend
+
+      - name: Lint frontend
+        run: npm run lint --workspace=frontend
+
+  typecheck:
+    name: Typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck backend
+        run: npm run build --workspace=backend
+
+      - name: Typecheck frontend
+        run: npx tsc --noEmit --project frontend/tsconfig.json
+
+  test-backend:
+    name: Backend Tests
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: litemaas_test
+          POSTGRES_PASSWORD: litemaas_test
+          POSTGRES_DB: litemaas_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U litemaas_test"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+    env:
+      DATABASE_URL: postgresql://litemaas_test:litemaas_test@localhost:5432/litemaas_test
+      NODE_ENV: test
+      JWT_SECRET: ci-test-secret
+      MOCK_AUTH: "true"
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run backend unit tests
+        run: npm run test:unit --workspace=backend
+
+      - name: Run backend integration tests
+        run: npm run test:integration --workspace=backend
+
+      - name: Run backend security tests
+        run: npm run test:security --workspace=backend
+
+  test-frontend:
+    name: Frontend Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run frontend tests
+        run: npm run test --workspace=frontend
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    needs: [lint, typecheck, test-backend, test-frontend]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build backend
+        run: npm run build --workspace=backend
+
+      - name: Build frontend
+        run: npm run build --workspace=frontend
+
+      - name: Build backend container image
+        run: |
+          docker build -f backend/Containerfile -t litemaas-backend:ci .
+
+      - name: Build frontend container image
+        run: |
+          docker build -f frontend/Containerfile -t litemaas-frontend:ci .

--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -1,0 +1,66 @@
+name: Helm Lint
+
+on:
+  push:
+    branches: [main, dev]
+    paths:
+      - "deployment/helm/**"
+  pull_request:
+    branches: [main, dev]
+    paths:
+      - "deployment/helm/**"
+
+jobs:
+  helm-lint:
+    name: Lint & Template Validation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.16.0
+
+      - name: Lint Helm chart
+        run: helm lint deployment/helm/litemaas/
+
+      - name: Template with default values
+        run: |
+          helm template litemaas deployment/helm/litemaas/ \
+            --set backend.secrets.jwtSecret=test-secret \
+            --set backend.secrets.adminApiKeys=test-key \
+            --set backend.secrets.litellmApiKey=test-key \
+            --set postgresql.password=test-password \
+            --set litellm.masterKey=test-key \
+            --set litellm.uiPassword=test-password \
+            > /dev/null
+
+      - name: Template with OpenShift route enabled
+        run: |
+          helm template litemaas deployment/helm/litemaas/ \
+            --set backend.secrets.jwtSecret=test-secret \
+            --set backend.secrets.adminApiKeys=test-key \
+            --set backend.secrets.litellmApiKey=test-key \
+            --set postgresql.password=test-password \
+            --set litellm.masterKey=test-key \
+            --set litellm.uiPassword=test-password \
+            --set backend.route.enabled=true \
+            --set frontend.route.enabled=true \
+            > /dev/null
+
+      - name: Template with existing secrets
+        run: |
+          helm template litemaas deployment/helm/litemaas/ \
+            --set backend.existingSecret=my-secret \
+            --set postgresql.existingSecret=my-pg-secret \
+            --set litellm.existingSecret=my-litellm-secret \
+            > /dev/null
+
+      - name: Validate no default passwords in template output
+        run: |
+          OUTPUT=$(helm template litemaas deployment/helm/litemaas/)
+          if echo "$OUTPUT" | grep -q "changeme"; then
+            echo "WARNING: Default 'changeme' passwords found in template output."
+            echo "Ensure production deployments override these values."
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,85 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+env:
+  REGISTRY: quay.io/rh-aiservices-bu
+  BACKEND_IMAGE: litemaas-backend
+  FRONTEND_IMAGE: litemaas-frontend
+
+jobs:
+  build-and-push:
+    name: Build & Push Container Images
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run backend tests
+        run: npm run test --workspace=backend
+        env:
+          NODE_ENV: test
+          MOCK_AUTH: "true"
+          JWT_SECRET: ci-test-secret
+
+      - name: Run frontend tests
+        run: npm run test --workspace=frontend
+
+      - name: Extract version from tag
+        id: version
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to Quay.io
+        uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push backend image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: backend/Containerfile
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE }}:${{ steps.version.outputs.VERSION }}
+            ${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE }}:latest
+          platforms: linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build and push frontend image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: frontend/Containerfile
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.FRONTEND_IMAGE }}:${{ steps.version.outputs.VERSION }}
+            ${{ env.REGISTRY }}/${{ env.FRONTEND_IMAGE }}:latest
+          platforms: linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          tag_name: ${{ github.ref_name }}


### PR DESCRIPTION
## Summary

- **CI workflow** (`ci.yml`): Runs lint, typecheck, backend tests (unit/integration/security with PostgreSQL service), frontend tests, and container image builds on every PR and push to `main`/`dev`. Jobs run in parallel with a final build gate.
- **Release workflow** (`release.yml`): Triggered on version tags (`v*`). Runs tests, builds and pushes backend/frontend images to `quay.io/rh-aiservices-bu` with version + `latest` tags, and creates a GitHub Release with auto-generated notes.
- **Helm lint workflow** (`helm-lint.yml`): Validates the Helm chart on changes to `deployment/helm/`. Tests template rendering with default values, OpenShift routes enabled, and existing secrets configurations. Warns if default `changeme` passwords leak into templates.

### Why

The project has comprehensive test infrastructure (Vitest unit tests, integration tests, security tests, ESLint, TypeScript checking) but zero automated CI/CD. All builds, tests, and deployments are manual. This is the highest-priority DevOps gap identified during a full-stack review.

### Setup Required

For the **release workflow** to push images, the following repository secrets must be configured:
- `QUAY_USERNAME` — Quay.io robot account username
- `QUAY_PASSWORD` — Quay.io robot account token

## Test plan

- [ ] CI workflow triggers on PR to `main` — verify lint, typecheck, and test jobs pass
- [ ] Helm lint job validates chart templates without errors
- [ ] Release workflow triggers on `v*` tag push (test with a pre-release tag)
- [ ] Container images are pushed to Quay.io with correct version and `latest` tags
- [ ] GitHub Release is created with auto-generated notes