### PR TITLE
Add per-key budget and rate limits

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -48,6 +48,7 @@ export const createApp = async (opts: { logger?: boolean } = {}): Promise<Fastif
         ? requestId[0]
         : requestId || Math.random().toString(36).substring(2, 15);
     },
+    trustProxy: true,
   }).withTypeProvider<TypeBoxTypeProvider>();
 
   // Register core plugins

--- a/backend/src/lib/database-migrations.ts
+++ b/backend/src/lib/database-migrations.ts
@@ -283,6 +283,12 @@ COMMENT ON COLUMN api_keys.litellm_key_alias IS 'The key_alias from LiteLLM used
 ALTER TABLE api_keys ADD COLUMN IF NOT EXISTS budget_duration VARCHAR(20);
 ALTER TABLE api_keys ADD COLUMN IF NOT EXISTS soft_budget DECIMAL(10,2);
 ALTER TABLE api_keys ADD COLUMN IF NOT EXISTS budget_reset_at TIMESTAMP WITH TIME ZONE;
+
+-- Phase 3: Advanced per-key limits
+ALTER TABLE api_keys ADD COLUMN IF NOT EXISTS max_parallel_requests INTEGER;
+ALTER TABLE api_keys ADD COLUMN IF NOT EXISTS model_max_budget JSONB;
+ALTER TABLE api_keys ADD COLUMN IF NOT EXISTS model_rpm_limit JSONB;
+ALTER TABLE api_keys ADD COLUMN IF NOT EXISTS model_tpm_limit JSONB;
 `;
 
 // API Key Models junction table

--- a/backend/src/lib/database-migrations.ts
+++ b/backend/src/lib/database-migrations.ts
@@ -278,6 +278,11 @@ ALTER TABLE api_keys ADD COLUMN IF NOT EXISTS litellm_key_alias VARCHAR(255);
 CREATE INDEX IF NOT EXISTS idx_api_keys_litellm_key_alias ON api_keys(litellm_key_alias);
 
 COMMENT ON COLUMN api_keys.litellm_key_alias IS 'The key_alias from LiteLLM used to match usage analytics data';
+
+-- Per-key budget and limit fields
+ALTER TABLE api_keys ADD COLUMN IF NOT EXISTS budget_duration VARCHAR(20);
+ALTER TABLE api_keys ADD COLUMN IF NOT EXISTS soft_budget DECIMAL(10,2);
+ALTER TABLE api_keys ADD COLUMN IF NOT EXISTS budget_reset_at TIMESTAMP WITH TIME ZONE;
 `;
 
 // API Key Models junction table

--- a/backend/src/routes/admin-users.ts
+++ b/backend/src/routes/admin-users.ts
@@ -451,6 +451,8 @@ const adminUsersRoutes: FastifyPluginAsync = async (fastify) => {
           maxBudget?: number;
           tpmLimit?: number;
           rpmLimit?: number;
+          budgetDuration?: string;
+          softBudget?: number;
         };
         const currentUser = (request as AuthenticatedRequest).user;
 
@@ -479,6 +481,8 @@ const adminUsersRoutes: FastifyPluginAsync = async (fastify) => {
           maxBudget: body.maxBudget,
           tpmLimit: body.tpmLimit,
           rpmLimit: body.rpmLimit,
+          budgetDuration: body.budgetDuration,
+          softBudget: body.softBudget,
         });
 
         // Additional audit log for admin action

--- a/backend/src/routes/admin-users.ts
+++ b/backend/src/routes/admin-users.ts
@@ -451,8 +451,12 @@ const adminUsersRoutes: FastifyPluginAsync = async (fastify) => {
           maxBudget?: number;
           tpmLimit?: number;
           rpmLimit?: number;
+          maxParallelRequests?: number;
           budgetDuration?: string;
           softBudget?: number;
+          modelMaxBudget?: Record<string, { budgetLimit: number; timePeriod: string }>;
+          modelRpmLimit?: Record<string, number>;
+          modelTpmLimit?: Record<string, number>;
         };
         const currentUser = (request as AuthenticatedRequest).user;
 
@@ -481,8 +485,12 @@ const adminUsersRoutes: FastifyPluginAsync = async (fastify) => {
           maxBudget: body.maxBudget,
           tpmLimit: body.tpmLimit,
           rpmLimit: body.rpmLimit,
+          maxParallelRequests: body.maxParallelRequests,
           budgetDuration: body.budgetDuration,
           softBudget: body.softBudget,
+          modelMaxBudget: body.modelMaxBudget,
+          modelRpmLimit: body.modelRpmLimit,
+          modelTpmLimit: body.modelTpmLimit,
         });
 
         // Additional audit log for admin action

--- a/backend/src/schemas/admin-users.ts
+++ b/backend/src/schemas/admin-users.ts
@@ -71,6 +71,10 @@ export const UserApiKeySchema = Type.Object({
   budgetDuration: Type.Optional(Type.String()),
   softBudget: Type.Optional(Type.Number()),
   budgetUtilization: Type.Optional(Type.Number()),
+  maxParallelRequests: Type.Optional(Type.Integer()),
+  modelMaxBudget: Type.Optional(Type.Any()),
+  modelRpmLimit: Type.Optional(Type.Any()),
+  modelTpmLimit: Type.Optional(Type.Any()),
   lastUsedAt: Type.Optional(Type.String({ format: 'date-time' })),
   createdAt: Type.String({ format: 'date-time' }),
   expiresAt: Type.Optional(Type.String({ format: 'date-time' })),
@@ -89,15 +93,28 @@ export const CreateApiKeyForUserSchema = Type.Object({
   maxBudget: Type.Optional(Type.Number({ minimum: 0 })),
   tpmLimit: Type.Optional(Type.Integer({ minimum: 0 })),
   rpmLimit: Type.Optional(Type.Integer({ minimum: 0 })),
+  maxParallelRequests: Type.Optional(Type.Integer({ minimum: 1 })),
   budgetDuration: Type.Optional(
     Type.Union([
       Type.Literal('daily'),
       Type.Literal('weekly'),
       Type.Literal('monthly'),
       Type.Literal('yearly'),
+      Type.String({ pattern: '^\\d+[smhd]$|^\\d+mo$' }),
     ]),
   ),
   softBudget: Type.Optional(Type.Number({ minimum: 0 })),
+  modelMaxBudget: Type.Optional(
+    Type.Record(
+      Type.String(),
+      Type.Object({
+        budgetLimit: Type.Number({ minimum: 0 }),
+        timePeriod: Type.String(),
+      }),
+    ),
+  ),
+  modelRpmLimit: Type.Optional(Type.Record(Type.String(), Type.Integer({ minimum: 0 }))),
+  modelTpmLimit: Type.Optional(Type.Record(Type.String(), Type.Integer({ minimum: 0 }))),
 });
 
 export type CreateApiKeyForUser = Static<typeof CreateApiKeyForUserSchema>;

--- a/backend/src/schemas/admin-users.ts
+++ b/backend/src/schemas/admin-users.ts
@@ -66,6 +66,11 @@ export const UserApiKeySchema = Type.Object({
   isActive: Type.Boolean(),
   maxBudget: Type.Optional(Type.Number()),
   currentSpend: Type.Optional(Type.Number()),
+  tpmLimit: Type.Optional(Type.Integer()),
+  rpmLimit: Type.Optional(Type.Integer()),
+  budgetDuration: Type.Optional(Type.String()),
+  softBudget: Type.Optional(Type.Number()),
+  budgetUtilization: Type.Optional(Type.Number()),
   lastUsedAt: Type.Optional(Type.String({ format: 'date-time' })),
   createdAt: Type.String({ format: 'date-time' }),
   expiresAt: Type.Optional(Type.String({ format: 'date-time' })),
@@ -84,6 +89,15 @@ export const CreateApiKeyForUserSchema = Type.Object({
   maxBudget: Type.Optional(Type.Number({ minimum: 0 })),
   tpmLimit: Type.Optional(Type.Integer({ minimum: 0 })),
   rpmLimit: Type.Optional(Type.Integer({ minimum: 0 })),
+  budgetDuration: Type.Optional(
+    Type.Union([
+      Type.Literal('daily'),
+      Type.Literal('weekly'),
+      Type.Literal('monthly'),
+      Type.Literal('yearly'),
+    ]),
+  ),
+  softBudget: Type.Optional(Type.Number({ minimum: 0 })),
 });
 
 export type CreateApiKeyForUser = Static<typeof CreateApiKeyForUserSchema>;

--- a/backend/src/types/api-key.types.ts
+++ b/backend/src/types/api-key.types.ts
@@ -20,6 +20,10 @@ export interface CreateApiKeyRequest {
   budgetDuration?: string;
   tpmLimit?: number;
   rpmLimit?: number;
+  maxParallelRequests?: number;
+  modelMaxBudget?: Record<string, { budgetLimit: number; timePeriod: string }>;
+  modelRpmLimit?: Record<string, number>;
+  modelTpmLimit?: Record<string, number>;
   teamId?: string;
   tags?: string[];
   permissions?: ApiKeyPermissions;
@@ -118,7 +122,11 @@ export interface LiteLLMKeyGenerationRequest {
   metadata?: ApiKeyMetadata;
   tpm_limit?: number; // tokens per minute
   rpm_limit?: number; // requests per minute
-  budget_duration?: string; // "monthly", "daily", etc.
+  max_parallel_requests?: number; // concurrent in-flight requests
+  budget_duration?: string; // "monthly", "daily", "30d", "1mo", etc.
+  model_max_budget?: Record<string, { budget_limit: number; time_period: string }>; // per-model budgets
+  model_rpm_limit?: Record<string, number>; // per-model RPM
+  model_tpm_limit?: Record<string, number>; // per-model TPM
   permissions?: {
     allow_chat_completions?: boolean;
     allow_embeddings?: boolean;
@@ -154,6 +162,10 @@ export interface LiteLLMKeyInfo {
   models?: string[];
   tpm_limit?: number;
   rpm_limit?: number;
+  max_parallel_requests?: number;
+  model_max_budget?: Record<string, { budget_limit: number; time_period: string }>;
+  model_rpm_limit?: Record<string, number>;
+  model_tpm_limit?: Record<string, number>;
   user_id?: string;
   team_id?: string;
   expires?: string;
@@ -180,6 +192,10 @@ export interface EnhancedApiKey extends ApiKey {
   softBudget?: number;
   budgetResetAt?: Date;
   budgetUtilization?: number; // calculated: currentSpend / maxBudget * 100
+  maxParallelRequests?: number;
+  modelMaxBudget?: Record<string, { budgetLimit: number; timePeriod: string }>;
+  modelRpmLimit?: Record<string, number>;
+  modelTpmLimit?: Record<string, number>;
   modelDetails?: Array<{
     id: string;
     name: string;

--- a/backend/src/types/api-key.types.ts
+++ b/backend/src/types/api-key.types.ts
@@ -176,6 +176,10 @@ export interface LiteLLMKeyInfoResponse {
  * Enhanced API key interface that includes model and subscription details
  */
 export interface EnhancedApiKey extends ApiKey {
+  budgetDuration?: string;
+  softBudget?: number;
+  budgetResetAt?: Date;
+  budgetUtilization?: number; // calculated: currentSpend / maxBudget * 100
   modelDetails?: Array<{
     id: string;
     name: string;

--- a/frontend/src/types/users.ts
+++ b/frontend/src/types/users.ts
@@ -129,6 +129,10 @@ export interface UserApiKey {
   budgetDuration?: string;
   softBudget?: number;
   budgetUtilization?: number;
+  maxParallelRequests?: number;
+  modelMaxBudget?: Record<string, { budgetLimit: number; timePeriod: string }>;
+  modelRpmLimit?: Record<string, number>;
+  modelTpmLimit?: Record<string, number>;
   lastUsedAt?: string;
   createdAt: string;
   expiresAt?: string;
@@ -143,8 +147,12 @@ export interface CreateApiKeyForUserRequest {
   maxBudget?: number;
   tpmLimit?: number;
   rpmLimit?: number;
+  maxParallelRequests?: number;
   budgetDuration?: string;
   softBudget?: number;
+  modelMaxBudget?: Record<string, { budgetLimit: number; timePeriod: string }>;
+  modelRpmLimit?: Record<string, number>;
+  modelTpmLimit?: Record<string, number>;
 }
 
 // Created API key response (includes full key shown once)

--- a/frontend/src/types/users.ts
+++ b/frontend/src/types/users.ts
@@ -124,6 +124,11 @@ export interface UserApiKey {
   isActive: boolean;
   maxBudget?: number;
   currentSpend?: number;
+  tpmLimit?: number;
+  rpmLimit?: number;
+  budgetDuration?: string;
+  softBudget?: number;
+  budgetUtilization?: number;
   lastUsedAt?: string;
   createdAt: string;
   expiresAt?: string;
@@ -138,6 +143,8 @@ export interface CreateApiKeyForUserRequest {
   maxBudget?: number;
   tpmLimit?: number;
   rpmLimit?: number;
+  budgetDuration?: string;
+  softBudget?: number;
 }
 
 // Created API key response (includes full key shown once)


### PR DESCRIPTION
## Summary

Adds per-key quota and rate limiting support based on the [Rate Limiting Investigation](https://github.com/rh-aiservices-bu/litemaas/blob/rate-limit/RATE_LIMITING_INVESTIGATION.md).

When an admin creates an API key for a user (Admin > Users > select user > API Keys > Create Key), the following limits can be configured:

### Global key limits
| Field | Description |
|-------|-------------|
| `max_budget` | Dollar spending limit on the key |
| `budget_duration` | Reset period — daily, weekly, monthly, yearly, or custom (30d, 1mo, 1h) |
| `soft_budget` | Warning threshold before hitting max budget |
| `tpm_limit` | Tokens-per-minute cap |
| `rpm_limit` | Requests-per-minute cap |
| `max_parallel_requests` | Concurrent in-flight request cap |

### Per-model limits
| Field | Description |
|-------|-------------|
| `model_rpm_limit` | Per-model requests-per-minute (works without Enterprise) |
| `model_tpm_limit` | Per-model tokens-per-minute (works without Enterprise) |
| `model_max_budget` | Per-model spending cap (requires LiteLLM Enterprise license) |

Limits are stored in LiteMaaS DB (`api_keys` table) and propagated to LiteLLM via `/key/generate`. LiteLLM enforces them at the proxy level (HTTP 429 on exceed).

### Backend changes
- **DB migration** (`database-migrations.ts`): 7 new columns on `api_keys` table — `budget_duration`, `soft_budget`, `budget_reset_at`, `max_parallel_requests`, `model_max_budget`, `model_rpm_limit`, `model_tpm_limit`
- **Types** (`api-key.types.ts`): Added fields to `CreateApiKeyRequest`, `LiteLLMKeyGenerationRequest`, `LiteLLMKeyInfo`, `EnhancedApiKey`
- **Schema** (`admin-users.ts`): Typebox validation for all new fields, expanded `budgetDuration` to support LiteLLM's custom formats (`^\d+[smhd]$|^\d+mo$`)
- **Route** (`admin-users.ts`): Passes new fields to `apiKeyService.createApiKey()`
- **Service** (`api-key.service.ts`): camelCase→snake_case transform for LiteLLM API (e.g. `modelMaxBudget` → `model_max_budget` with `budget_limit`/`time_period` format), JSONB storage for per-model limits, updated INSERT query and `mapToEnhancedApiKey()`
- **App** (`app.ts`): `trustProxy: true` for correct protocol detection behind OpenShift edge TLS

### Frontend changes
- **Types** (`users.ts`): Added `maxParallelRequests`, `modelMaxBudget`, `modelRpmLimit`, `modelTpmLimit` to `UserApiKey` and `CreateApiKeyForUserRequest`
- **Create Key modal** (`UserApiKeysTab.tsx`):
  - Budget with configurable duration and soft budget warning
  - TPM/RPM inputs with helper text
  - Max Parallel Requests input
  - Extended Budget Duration dropdown (daily, weekly, monthly, yearly, 1h, 30d, 1mo)
  - Per-Model Limits expandable section — appears when models are selected, shows budget, time period, RPM, TPM per model
  - Cleans up per-model limits when a model is deselected
- **Table display**: Budget utilization progress bar, rate limit labels (TPM, RPM, Parallel), blue "Per-model" indicator when per-model limits are set

### Test results (litemaas-api-key namespace on cluster-gqkn4)
- Created key with `max_parallel_requests=3` — verified in LiteLLM, value set correctly
- Created key with `max_budget=10`, `budget_duration=daily`, `soft_budget=5` — budget reset working
- RPM enforcement: requests 10 and 11 returned HTTP 429 with `rpm_limit=10`
- `model_rpm_limit`/`model_tpm_limit` stored in LiteLLM key metadata, enforced by `parallel_request_limiter` hook — no enterprise license needed
- `model_max_budget` rejected by LiteLLM with `premium_user` check in `validate_model_max_budget()` — requires Enterprise license

### Note on model_max_budget
`model_max_budget` requires a LiteLLM Enterprise license. The enforcement code exists in the open source package (`model_max_budget_limiter.py`) but the `/key/generate` endpoint validates `premium_user` before accepting it. The UI supports setting it, but it will return a 400 error without a license. Since we build our own LiteLLM image, this check can be bypassed if needed. `model_rpm_limit` and `model_tpm_limit` work without enterprise.