### PR TITLE
Fix LiteLLM user creation defaulting to no-default-models

### DIFF
--- a/backend/src/services/oauth.service.ts
+++ b/backend/src/services/oauth.service.ts
@@ -455,6 +455,7 @@ export class OAuthService extends BaseService {
         rpm_limit: Number(this.fastify.config.DEFAULT_USER_RPM_LIMIT), // Configurable via DEFAULT_USER_RPM_LIMIT env var
         auto_create_key: false, // Don't auto-create key during user creation
         teams: [DefaultTeamService.DEFAULT_TEAM_ID], // CRITICAL: Always assign user to default team
+        models: [], // Empty array = no user-level model restriction; access controlled at key level
       });
 
       this.fastify.log.info(

--- a/backend/src/utils/litellm-sync.utils.ts
+++ b/backend/src/utils/litellm-sync.utils.ts
@@ -90,6 +90,7 @@ export class LiteLLMSyncUtils {
         rpm_limit: Number(user.rpm_limit) || Number(process.env.DEFAULT_USER_RPM_LIMIT) || 60,
         auto_create_key: false,
         teams: [userTeam], // CRITICAL: Always assign user to a team
+        models: [], // Empty array = no user-level model restriction; access controlled at key level
       };
 
       fastify.log.info(


### PR DESCRIPTION
## Summary

- Pass `models: []` explicitly when creating users in LiteLLM via `/user/new`
- Without this, LiteLLM defaults to `models: ['no-default-models']` which blocks API key access to all models at the user level
- Fix applied in both `oauth.service.ts` (OAuth login flow) and `litellm-sync.utils.ts` (sync utility)

## Impact

- **New users only** — existing users are not affected
- **Strictly less restrictive** — removes the user-level model block; model access continues to be controlled at the key level (each key specifies its models)
- **Safe for prod** — current prod works because team-level `models: []` on the default team overrides, but this fix prevents the issue from surfacing when keys are used without team context

## Test plan

- [x] Backend compiles clean (`tsc --noEmit`)
- [ ] Deploy to dev cluster, create new user via OAuth login
- [ ] Verify new user's LiteLLM record has `models: []` not `['no-default-models']`
- [ ] Create API key and verify model access works without manual DB fix