### PR TITLE
feat: server-side model config testing with encrypted API key storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Encrypted API Key Storage & Edit-Mode Testing**: Provider API keys are now stored encrypted (AES-256-GCM) in the LiteMaaS database, enabling admins to test model configuration during editing without re-entering the API key
+  - New `encrypted_api_key` column on `models` table stores keys encrypted with `LITELLM_MASTER_KEY` (falls back to `LITELLM_API_KEY`)
+  - New `LITELLM_MASTER_KEY` environment variable for encryption key derivation (optional, recommended for production)
+  - Test Configuration button is now enabled in edit mode without an API key; create mode still requires one
+  - Graceful fallback for models created before this feature: warns the admin to enter an API key manually
+  - New `encryption.ts` utility with `encryptApiKey` / `decryptApiKey` using AES-256-GCM (random IV, auth tag, base64-encoded)
+  - New `missing_stored_key` result type for the test configuration endpoint
+
+### Fixed
+
+- **Model Configuration Testing Security**: Moved model endpoint connectivity testing from browser-side to backend
+  - New `POST /api/v1/admin/models/test` endpoint with authentication and RBAC (`admin:models` permission)
+  - API keys are no longer exposed in browser network requests during configuration tests
+  - Backend-side 10-second timeout with AbortController for reliable connection handling
+  - Structured result types: `model_found`, `model_not_found`, `auth_error`, `connection_error`, `timeout`
+
 ---
 
 ## [0.2.0] - 2026-02-13

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,7 @@
 > - **Backend Context**: [`backend/CLAUDE.md`](backend/CLAUDE.md) - Fastify API implementation details
 > - **Frontend Context**: [`frontend/CLAUDE.md`](frontend/CLAUDE.md) - React/PatternFly 6 implementation details
 > - **Project Structure**: [`docs/architecture/project-structure.md`](docs/architecture/project-structure.md) - Complete directory structure
+> - **Changelog**: [`CHANGELOG.md`](CHANGELOG.md) - All notable changes per release (Keep a Changelog format)
 > - **Documentation**: See `docs/` for comprehensive guides
 
 ## 🚀 Project Overview

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -59,6 +59,7 @@ JWT_EXPIRES_IN=24h
 # LiteLLM Configuration
 LITELLM_API_URL=http://your-litellm-instance:8000
 LITELLM_API_KEY=your-litellm-api-key
+LITELLM_MASTER_KEY=your-encryption-key  # For encrypting stored model API keys (falls back to LITELLM_API_KEY)
 
 # LiteLLM Sync
 LITELLM_AUTO_SYNC=true

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -76,6 +76,8 @@ Fastify plugins are registered in specific order:
 
 **Subscription Approval Workflow**: `subscription_status_history` table tracks all status changes with full audit trail. Models table includes `restricted_access` boolean. Subscriptions enhanced with `status_reason`, `status_changed_at`, `status_changed_by` fields and unique constraint `(user_id, model_id)`.
 
+**Encrypted API Key Storage**: Models table includes `encrypted_api_key` (TEXT) column storing provider API keys encrypted with AES-256-GCM. Used to enable configuration testing during model editing without re-entering the key. Encryption key derived from `LITELLM_MASTER_KEY` (falls back to `LITELLM_API_KEY`). See `src/utils/encryption.ts`.
+
 **System User**: Fixed UUID `00000000-0000-0000-0000-000000000001` for audit trail of automated actions (e.g., model restriction cascades).
 
 **Admin User Management Audit**: All admin-initiated user management actions (API key creation/revocation, budget updates) are logged to `audit_logs` with action type, admin user ID, target user ID, and operation metadata.

--- a/backend/src/lib/database-migrations.ts
+++ b/backend/src/lib/database-migrations.ts
@@ -160,6 +160,9 @@ ALTER TABLE models ADD COLUMN IF NOT EXISTS backend_model_name VARCHAR(255);
 -- Add restricted_access column for subscription approval workflow
 ALTER TABLE models ADD COLUMN IF NOT EXISTS restricted_access BOOLEAN DEFAULT false;
 
+-- Add encrypted_api_key column for storing encrypted provider API keys
+ALTER TABLE models ADD COLUMN IF NOT EXISTS encrypted_api_key TEXT;
+
 CREATE INDEX IF NOT EXISTS idx_models_provider ON models(provider);
 CREATE INDEX IF NOT EXISTS idx_models_category ON models(category);
 CREATE INDEX IF NOT EXISTS idx_models_availability ON models(availability);

--- a/backend/src/plugins/env.ts
+++ b/backend/src/plugins/env.ts
@@ -33,6 +33,7 @@ const envSchema = Type.Object({
   // LiteLLM
   LITELLM_API_URL: Type.String({ default: 'http://localhost:4000' }),
   LITELLM_API_KEY: Type.Optional(Type.String()),
+  LITELLM_MASTER_KEY: Type.Optional(Type.String()),
   LITELLM_TIMEOUT: Type.String({ default: '30000' }),
   LITELLM_RETRIES: Type.String({ default: '3' }),
   LITELLM_RETRY_DELAY: Type.String({ default: '1000' }),

--- a/backend/src/schemas/admin-models.ts
+++ b/backend/src/schemas/admin-models.ts
@@ -90,3 +90,25 @@ export const AdminModelErrorResponseSchema = Type.Object({
   message: Type.String(),
   statusCode: Type.Integer(),
 });
+
+// Test model configuration schemas
+export const AdminTestModelConfigSchema = Type.Object({
+  api_base: Type.String(),
+  api_key: Type.Optional(Type.String()),
+  backend_model_name: Type.String(),
+  model_id: Type.Optional(Type.String()),
+});
+
+export const AdminTestModelConfigResponseSchema = Type.Object({
+  success: Type.Boolean(),
+  result: Type.Union([
+    Type.Literal('model_found'),
+    Type.Literal('model_not_found'),
+    Type.Literal('auth_error'),
+    Type.Literal('connection_error'),
+    Type.Literal('timeout'),
+    Type.Literal('missing_stored_key'),
+  ]),
+  message: Type.String(),
+  availableModels: Type.Optional(Type.Array(Type.String())),
+});

--- a/backend/src/services/litellm.service.ts
+++ b/backend/src/services/litellm.service.ts
@@ -812,10 +812,7 @@ export class LiteLLMService extends BaseService {
     } catch (error) {
       // LiteLLM v1.81.0+ returns 404 for non-existent users
       if (this.isLiteLLM404Error(error)) {
-        this.fastify.log.info(
-          { userId },
-          'User does not exist in LiteLLM (404 response)',
-        );
+        this.fastify.log.info({ userId }, 'User does not exist in LiteLLM (404 response)');
         return null;
       }
 
@@ -960,10 +957,7 @@ export class LiteLLMService extends BaseService {
     } catch (error) {
       // LiteLLM v1.81.0+ returns 404 for non-existent users
       if (this.isLiteLLM404Error(error)) {
-        this.fastify.log.info(
-          { userId },
-          'User does not exist in LiteLLM (404 response)',
-        );
+        this.fastify.log.info({ userId }, 'User does not exist in LiteLLM (404 response)');
         return null;
       }
 

--- a/backend/src/types/fastify.ts
+++ b/backend/src/types/fastify.ts
@@ -32,6 +32,7 @@ declare module 'fastify' {
       // LiteLLM
       LITELLM_API_URL: string;
       LITELLM_API_KEY?: string;
+      LITELLM_MASTER_KEY?: string;
       LITELLM_TIMEOUT: string;
       LITELLM_RETRIES: string;
       LITELLM_RETRY_DELAY: string;

--- a/backend/src/utils/encryption.ts
+++ b/backend/src/utils/encryption.ts
@@ -1,0 +1,45 @@
+import crypto from 'crypto';
+
+const IV_LENGTH = 12;
+const AUTH_TAG_LENGTH = 16;
+const ALGORITHM = 'aes-256-gcm';
+
+/**
+ * Derive a 256-bit AES key from an encryption key string using SHA-256.
+ */
+function deriveKey(encryptionKey: string): Buffer {
+  return crypto.createHash('sha256').update(encryptionKey).digest();
+}
+
+/**
+ * Encrypt a plaintext string using AES-256-GCM.
+ * Returns a base64-encoded string containing: IV (12 bytes) + ciphertext + auth tag (16 bytes).
+ */
+export function encryptApiKey(plaintext: string, encryptionKey: string): string {
+  const key = deriveKey(encryptionKey);
+  const iv = crypto.randomBytes(IV_LENGTH);
+  const cipher = crypto.createCipheriv(ALGORITHM, key, iv);
+
+  const encrypted = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+
+  return Buffer.concat([iv, encrypted, authTag]).toString('base64');
+}
+
+/**
+ * Decrypt a base64-encoded AES-256-GCM ciphertext.
+ * Expects format: IV (12 bytes) + ciphertext + auth tag (16 bytes).
+ */
+export function decryptApiKey(ciphertext: string, encryptionKey: string): string {
+  const key = deriveKey(encryptionKey);
+  const data = Buffer.from(ciphertext, 'base64');
+
+  const iv = data.subarray(0, IV_LENGTH);
+  const authTag = data.subarray(data.length - AUTH_TAG_LENGTH);
+  const encrypted = data.subarray(IV_LENGTH, data.length - AUTH_TAG_LENGTH);
+
+  const decipher = crypto.createDecipheriv(ALGORITHM, key, iv);
+  decipher.setAuthTag(authTag);
+
+  return decipher.update(encrypted) + decipher.final('utf8');
+}

--- a/deployment/helm/litemaas/templates/backend-deployment.yaml
+++ b/deployment/helm/litemaas/templates/backend-deployment.yaml
@@ -88,6 +88,11 @@ spec:
                 secretKeyRef:
                   name: {{ include "litemaas.backend.secretName" . }}
                   key: litellm-api-key
+            - name: LITELLM_MASTER_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "litemaas.backend.secretName" . }}
+                  key: litellm-master-key
           resources:
             {{- toYaml .Values.backend.resources | nindent 12 }}
           livenessProbe:

--- a/deployment/helm/litemaas/templates/backend-secret.yaml
+++ b/deployment/helm/litemaas/templates/backend-secret.yaml
@@ -16,4 +16,5 @@ stringData:
   oauth-callback-url: {{ include "litemaas.backend.oauthCallbackUrl" . | quote }}
   admin-api-keys: {{ .Values.backend.auth.adminApiKeys | quote }}
   litellm-api-key: {{ .Values.backend.auth.litellmApiKey | quote }}
+  litellm-master-key: {{ .Values.backend.auth.litellmMasterKey | default .Values.backend.auth.litellmApiKey | quote }}
 {{- end }}

--- a/deployment/helm/litemaas/values.yaml
+++ b/deployment/helm/litemaas/values.yaml
@@ -177,9 +177,12 @@ backend:
     initialAdminUsers: ""
     # -- LiteLLM API key (must match litellm.auth.masterKey)
     litellmApiKey: changeme
+    # -- Encryption key for stored model API keys (AES-256-GCM).
+    # Falls back to litellmApiKey if empty. Recommended to set explicitly in production.
+    litellmMasterKey: ""
     # -- Use an existing Secret instead of creating one.
     # Must contain keys: database-url, cors-origin, jwt-secret, oauth-client-id,
-    # oauth-client-secret, oauth-issuer, oauth-callback-url, admin-api-keys, litellm-api-key
+    # oauth-client-secret, oauth-issuer, oauth-callback-url, admin-api-keys, litellm-api-key, litellm-master-key
     existingSecret: ""
 
   # -- Rate limiting for backend API (NOT for LLM requests)

--- a/deployment/kustomize/README.md
+++ b/deployment/kustomize/README.md
@@ -50,6 +50,7 @@ The deployment uses a **template-based configuration system**:
    - `OAUTH_CLIENT_SECRET` - OAuth client secret from OpenShift
    - `ADMIN_API_KEY` - Admin API key for backend management operations (generate with `openssl rand -base64 32`)
    - `LITELLM_API_KEY` - LiteLLM master API key (generate with `openssl rand -base64 32`, must start with `sk-`)
+   - `LITELLM_MASTER_KEY` - *(Optional)* Encryption key for stored model API keys (defaults to `LITELLM_API_KEY` if not set)
    - `LITELLM_UI_USERNAME` - LiteLLM admin UI username
    - `LITELLM_UI_PASSWORD` - LiteLLM admin UI password
 
@@ -133,6 +134,7 @@ oc apply -k .
   - OAuth client credentials
   - Admin API key (for backend management API, NOT for LLM requests)
   - LiteLLM API key
+  - LiteLLM master key (encryption key for stored model API keys)
 - `litellm-secret.yaml` - LiteLLM configuration including:
   - LiteLLM database connection string
   - Master API key

--- a/deployment/kustomize/backend-deployment.yaml.template
+++ b/deployment/kustomize/backend-deployment.yaml.template
@@ -111,6 +111,11 @@ spec:
                 secretKeyRef:
                   name: backend-secret
                   key: litellm-api-key
+            - name: LITELLM_MASTER_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: backend-secret
+                  key: litellm-master-key
 
             # Backend API Rate Limiting (NOT for LLM requests)
             - name: RATE_LIMIT_MAX

--- a/deployment/kustomize/backend-secret.yaml.template
+++ b/deployment/kustomize/backend-secret.yaml.template
@@ -22,3 +22,5 @@ stringData:
   admin-api-keys: ${ADMIN_API_KEY}
   # LiteLLM Integration
   litellm-api-key: ${LITELLM_API_KEY}
+  # Encryption key for stored model API keys (falls back to LITELLM_API_KEY at runtime if empty)
+  litellm-master-key: ${LITELLM_MASTER_KEY}

--- a/deployment/kustomize/preparation.sh
+++ b/deployment/kustomize/preparation.sh
@@ -3,6 +3,11 @@ set -a  # automatically export all variables
 source user-values.env
 set +a
 
+# Default LITELLM_MASTER_KEY to LITELLM_API_KEY if not set
+if [ -z "${LITELLM_MASTER_KEY}" ]; then
+    export LITELLM_MASTER_KEY="${LITELLM_API_KEY}"
+fi
+
 # Conditionally set NODE_TLS_ENV_BLOCK if NODE_TLS_REJECT_UNAUTHORIZED is "0"
 if [ "${NODE_TLS_REJECT_UNAUTHORIZED}" = "0" ]; then
     export NODE_TLS_ENV_BLOCK="- name: NODE_TLS_REJECT_UNAUTHORIZED

--- a/deployment/kustomize/user-values.env.example
+++ b/deployment/kustomize/user-values.env.example
@@ -7,5 +7,6 @@ OAUTH_CLIENT_ID=litemaas-oauth-client
 OAUTH_CLIENT_SECRET=change-me-oauth-secret
 ADMIN_API_KEY=change-me-admin-key
 LITELLM_API_KEY=sk-change-me-litellm-admin-key
+LITELLM_MASTER_KEY=  # Optional: encryption key for stored model API keys (defaults to LITELLM_API_KEY)
 LITELLM_UI_USERNAME=admin
 LITELLM_UI_PASSWORD=change-me-ui-password

--- a/docs/architecture/database-schema.md
+++ b/docs/architecture/database-schema.md
@@ -66,6 +66,9 @@ CREATE TABLE models (
     -- Subscription Approval Workflow
     restricted_access BOOLEAN DEFAULT false,
 
+    -- Encrypted Provider API Key (AES-256-GCM)
+    encrypted_api_key TEXT,
+
     metadata JSONB DEFAULT '{}',
     is_active BOOLEAN DEFAULT true,
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -189,6 +189,7 @@ JWT_EXPIRES_IN=7d
 | ----------------------------- | ---------------------------------------------- | ----------------------- | -------- |
 | `LITELLM_API_URL`             | LiteLLM API URL                                | `http://localhost:4000` | No       |
 | `LITELLM_API_KEY`             | LiteLLM API key (if required)                  | -                       | No       |
+| `LITELLM_MASTER_KEY`          | Encryption key for stored model API keys (falls back to `LITELLM_API_KEY`) | -       | No       |
 | `LITELLM_AUTO_SYNC`           | Enable automatic model sync on startup         | `true`                  | No       |
 | `LITELLM_SYNC_INTERVAL`       | Auto-sync interval (seconds)                   | `60`                    | No       |
 | `LITELLM_CONFLICT_RESOLUTION` | Sync conflict resolution strategy              | `litellm_wins`          | No       |
@@ -202,6 +203,7 @@ JWT_EXPIRES_IN=7d
 ```bash
 LITELLM_API_URL=http://litellm-service:4000
 LITELLM_API_KEY=your-litellm-api-key
+LITELLM_MASTER_KEY=your-encryption-key  # For encrypting stored model API keys (falls back to LITELLM_API_KEY)
 LITELLM_AUTO_SYNC=true
 LITELLM_SYNC_INTERVAL=300
 LITELLM_CONFLICT_RESOLUTION=database_wins
@@ -541,6 +543,7 @@ JWT_EXPIRES_IN=7d
 # LiteLLM
 LITELLM_API_URL=http://litellm-service.internal:4000
 LITELLM_API_KEY=${LITELLM_PROD_KEY}
+LITELLM_MASTER_KEY=${LITELLM_MASTER_KEY}  # Encryption key for stored model API keys
 LITELLM_AUTO_SYNC=true
 LITELLM_SYNC_INTERVAL=300
 LITELLM_TIMEOUT=60000

--- a/docs/deployment/helm-deployment.md
+++ b/docs/deployment/helm-deployment.md
@@ -41,6 +41,7 @@ backend:
     jwtSecret: "<secure-random-key>"        # openssl rand -base64 32
     adminApiKeys: "<secure-random-key>"     # openssl rand -base64 32
     litellmApiKey: "sk-<same-as-masterKey>" # Must match litellm.auth.masterKey
+    litellmMasterKey: "<encryption-key>"   # Optional: for encrypting stored model API keys (defaults to litellmApiKey)
 ```
 
 > **Note**: OAuth client ID, secret, and issuer are auto-configured when using the default ServiceAccount OAuth mode on OpenShift. See [OAuth Configuration](#oauth-configuration) for details.
@@ -146,7 +147,8 @@ helm test litemaas -n litemaas
 | `backend.auth.adminApiKeys` | Admin API keys (comma-separated) | `changeme` |
 | `backend.auth.initialAdminUsers` | Initial admin users (comma-separated usernames; auto-detected on OpenShift if empty) | `""` |
 | `backend.auth.litellmApiKey` | LiteLLM API key (must match `litellm.auth.masterKey`) | `changeme` |
-| `backend.auth.existingSecret` | Use an existing Secret (keys: `database-url`, `cors-origin`, `jwt-secret`, `oauth-client-id`, `oauth-client-secret`, `oauth-issuer`, `oauth-callback-url`, `admin-api-keys`, `litellm-api-key`) | `""` |
+| `backend.auth.litellmMasterKey` | Encryption key for stored model API keys (falls back to `litellmApiKey`) | `""` |
+| `backend.auth.existingSecret` | Use an existing Secret (keys: `database-url`, `cors-origin`, `jwt-secret`, `oauth-client-id`, `oauth-client-secret`, `oauth-issuer`, `oauth-callback-url`, `admin-api-keys`, `litellm-api-key`, `litellm-master-key`) | `""` |
 | `backend.rateLimit.max` | Rate limit max requests | `1000` |
 | `backend.rateLimit.timeWindow` | Rate limit time window | `5m` |
 | `backend.defaultUser.maxBudget` | Default user max budget | `100` |

--- a/docs/deployment/kustomize-deployment.md
+++ b/docs/deployment/kustomize-deployment.md
@@ -305,6 +305,7 @@ OAUTH_CLIENT_ID=litemaas-oauth-client
 OAUTH_CLIENT_SECRET=your-oauth-client-secret-from-step-4
 ADMIN_API_KEY=ltm_admin_your-admin-key
 LITELLM_API_KEY=sk-your-litellm-master-key
+LITELLM_MASTER_KEY=  # Optional: encryption key for stored model API keys (defaults to LITELLM_API_KEY)
 LITELLM_UI_USERNAME=admin
 LITELLM_UI_PASSWORD=your-litellm-ui-password
 ```

--- a/frontend/src/i18n/locales/de/translation.json
+++ b/frontend/src/i18n/locales/de/translation.json
@@ -362,6 +362,7 @@
       "backendModelName": "Backend-Modellname",
       "backendModelNameIsRequired": "Backend-Modellname ist erforderlich",
       "cannotContactEndpoint": "Endpunkt kann nicht kontaktiert werden",
+      "noStoredApiKey": "Dieses Modell wurde erstellt, bevor die API-Schlüsselspeicherung aktiviert wurde. Bitte geben Sie einen API-Schlüssel ein, um die Konfiguration zu testen.",
       "connectionSuccessful": "Verbindung erfolgreich! Sie können das Modell erstellen.",
       "createModel": "Modell Erstellen",
       "createModelFailed": "Modell-Erstellung fehlgeschlagen",

--- a/frontend/src/i18n/locales/elv/translation.json
+++ b/frontend/src/i18n/locales/elv/translation.json
@@ -362,6 +362,7 @@
       "backendModelName": "Dâd-vegil Estel",
       "backendModelNameIsRequired": "Dâd-vegil estel prestanneth",
       "cannotContactEndpoint": "Ú-eston fael i fuin",
+      "noStoredApiKey": "I vegil cared nuin lû erin i acharn-lhaw prestanneth. Anno i acharn-lhaw celeg i prestiad.",
       "connectionSuccessful": "Yrch prestinn! Eryd carned i vegil.",
       "createModel": "Caro Vegil",
       "createModelFailed": "Caro Vegil Vuin",

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -362,6 +362,7 @@
       "backendModelName": "Backend Model Name",
       "backendModelNameIsRequired": "Backend model name is required",
       "cannotContactEndpoint": "Cannot contact the endpoint",
+      "noStoredApiKey": "This model was created before API key storage was enabled. Please enter an API key to test the configuration.",
       "connectionSuccessful": "Connection successful! You can create the model.",
       "createModel": "Create Model",
       "createModelFailed": "Create Model Failed",

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -362,6 +362,7 @@
       "backendModelName": "Nombre del Modelo Backend",
       "backendModelNameIsRequired": "El nombre del modelo backend es requerido",
       "cannotContactEndpoint": "No se puede contactar el endpoint",
+      "noStoredApiKey": "Este modelo fue creado antes de que se habilitara el almacenamiento de claves API. Ingrese una clave API para probar la configuración.",
       "connectionSuccessful": "¡Conexión exitosa! Puedes crear el modelo.",
       "createModel": "Crear Modelo",
       "createModelFailed": "Error al Crear Modelo",

--- a/frontend/src/i18n/locales/fr/translation.json
+++ b/frontend/src/i18n/locales/fr/translation.json
@@ -362,6 +362,7 @@
       "backendModelName": "Nom du Modèle Backend",
       "backendModelNameIsRequired": "Le nom du modèle backend est requis",
       "cannotContactEndpoint": "Impossible de contacter le point de terminaison",
+      "noStoredApiKey": "Ce modèle a été créé avant l'activation du stockage des clés API. Veuillez saisir une clé API pour tester la configuration.",
       "connectionSuccessful": "Connexion réussie ! Vous pouvez créer le modèle.",
       "createModel": "Créer un Modèle",
       "createModelFailed": "Échec de la Création du Modèle",

--- a/frontend/src/i18n/locales/it/translation.json
+++ b/frontend/src/i18n/locales/it/translation.json
@@ -362,6 +362,7 @@
       "backendModelName": "Nome Modello Backend",
       "backendModelNameIsRequired": "Il nome del modello backend è obbligatorio",
       "cannotContactEndpoint": "Impossibile contattare l'endpoint",
+      "noStoredApiKey": "Questo modello è stato creato prima dell'abilitazione dell'archiviazione delle chiavi API. Inserisci una chiave API per testare la configurazione.",
       "connectionSuccessful": "Connessione riuscita! Puoi creare il modello.",
       "createModel": "Crea Modello",
       "createModelFailed": "Creazione Modello Fallita",

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -362,6 +362,7 @@
       "backendModelName": "バックエンドモデル名",
       "backendModelNameIsRequired": "バックエンドモデル名は必須です",
       "cannotContactEndpoint": "エンドポイントに接続できません",
+      "noStoredApiKey": "このモデルはAPIキーの保存機能が有効になる前に作成されました。設定をテストするにはAPIキーを入力してください。",
       "connectionSuccessful": "接続成功！モデルを作成できます。",
       "createModel": "モデル作成",
       "createModelFailed": "モデル作成に失敗しました",

--- a/frontend/src/i18n/locales/ko/translation.json
+++ b/frontend/src/i18n/locales/ko/translation.json
@@ -362,6 +362,7 @@
       "backendModelName": "백엔드 모델 이름",
       "backendModelNameIsRequired": "백엔드 모델 이름이 필수입니다",
       "cannotContactEndpoint": "엔드포인트에 연결할 수 없습니다",
+      "noStoredApiKey": "이 모델은 API 키 저장 기능이 활성화되기 전에 생성되었습니다. 구성을 테스트하려면 API 키를 입력하세요.",
       "connectionSuccessful": "연결 성공! 모델을 생성할 수 있습니다.",
       "createModel": "모델 생성",
       "createModelFailed": "모델 생성 실패",

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -362,6 +362,7 @@
       "backendModelName": "后端模型名称",
       "backendModelNameIsRequired": "后端模型名称是必需的",
       "cannotContactEndpoint": "无法联系端点",
+      "noStoredApiKey": "此模型在启用API密钥存储之前创建。请输入API密钥以测试配置。",
       "connectionSuccessful": "连接成功！您可以创建模型。",
       "createModel": "创建模型",
       "createModelFailed": "创建模型失败",

--- a/frontend/src/services/adminModels.service.ts
+++ b/frontend/src/services/adminModels.service.ts
@@ -4,6 +4,8 @@ import type {
   LiteLLMModelUpdate,
   AdminModelResponse,
   AdminModelError,
+  TestModelConfigRequest,
+  TestModelConfigResponse,
 } from '../types/admin';
 
 export class AdminModelsService {
@@ -39,6 +41,22 @@ export class AdminModelsService {
       throw {
         error: 'NETWORK_ERROR',
         message: 'Failed to update model. Please check your connection and try again.',
+        statusCode: error.response?.status || 500,
+      } as AdminModelError;
+    }
+  }
+
+  async testConfiguration(data: TestModelConfigRequest): Promise<TestModelConfigResponse> {
+    try {
+      const response = await apiClient.post<TestModelConfigResponse>(`${this.basePath}/test`, data);
+      return response;
+    } catch (error: any) {
+      if (error.response?.data) {
+        throw error.response.data as AdminModelError;
+      }
+      throw {
+        error: 'NETWORK_ERROR',
+        message: 'Failed to test configuration. Please check your connection and try again.',
         statusCode: error.response?.status || 500,
       } as AdminModelError;
     }

--- a/frontend/src/types/admin.ts
+++ b/frontend/src/types/admin.ts
@@ -86,6 +86,27 @@ export interface AdminModelFormErrors {
   max_tokens?: string;
 }
 
+// Test model configuration types
+export interface TestModelConfigRequest {
+  api_base: string;
+  api_key?: string;
+  backend_model_name: string;
+  model_id?: string;
+}
+
+export interface TestModelConfigResponse {
+  success: boolean;
+  result:
+    | 'model_found'
+    | 'model_not_found'
+    | 'auth_error'
+    | 'connection_error'
+    | 'timeout'
+    | 'missing_stored_key';
+  message: string;
+  availableModels?: string[];
+}
+
 // Subscription Approval Workflow Types
 
 export type SubscriptionStatus =

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "litemaas",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "litemaas",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "workspaces": [
         "backend",
         "frontend"


### PR DESCRIPTION
## Summary

- Move model configuration testing from browser-side to a dedicated backend endpoint (`POST /api/v1/admin/models/test`) with RBAC protection
- Store provider API keys encrypted (AES-256-GCM) in the LiteMaaS database so admins can test model configuration during editing without re-entering the key
- Add `LITELLM_MASTER_KEY` env var to Helm and Kustomize deployment manifests

## Details

**Backend:**
- AES-256-GCM encryption utility (`encryption.ts`) for API key storage
- Encrypted keys stored on model create/update, decrypted for test endpoint
- Database migration: `encrypted_api_key` column on `models` table
- Structured result types: `model_found`, `model_not_found`, `auth_error`, `connection_error`, `timeout`, `missing_stored_key`

**Frontend:**
- Test Configuration button enabled in edit mode without API key (sends `model_id` for stored key lookup)
- Create mode still requires explicit API key (unchanged)
- Graceful `missing_stored_key` warning for models created before this feature
- i18n translations added for all 9 locales

**Deployment:**
- Helm: `litellmMasterKey` in values, backend secret, and deployment
- Kustomize: `LITELLM_MASTER_KEY` in user-values, secret, deployment, and `preparation.sh` with fallback to `LITELLM_API_KEY`

## Test plan

- [x] Create model with API key — verify `encrypted_api_key` is populated in DB (not plaintext)
- [x] Edit mode — verify Test Configuration button is enabled without entering API key
- [x] Edit mode test without API key — verify test uses stored encrypted key
- [x] Edit mode test with new API key — verify test uses the newly entered key
- [x] Create mode — verify button stays disabled without API key (unchanged behavior)
- [x] Backend lint/typecheck: `cd backend && npm run lint && npm run build`
- [x] Frontend lint/typecheck: `cd frontend && npm run lint && npx tsc --noEmit`
- [x] Backend unit tests: `cd backend && npm run test:unit` (927/927 passed)
- [x] Frontend unit tests: `cd frontend && npm run test:unit` (810 passed, 68 skipped)