### PR TITLE
Cosmetic UI and documentation naming improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Admin Navigation Cosmetic Renames**: Improved menu and page naming for consistency across the admin section
+  - Renamed "Users" menu to "Users Management"
+  - Renamed "Tools" menu and page title to "Settings and Tools"
+  - Renamed "Models Management" tab to "Models Sync" (moved to last position)
+  - Simplified "Limits Management" tab to "Limits" and "Banner Management" to "Banners"
+  - Moved "Usage Analytics" to first position in admin navigation
 - **Login Page Default Logo**: Replaced `LogoTitle` with new `Octobean` SVG as the default login page brand image
 - **Fastify `trustProxy` Enabled**: Added `trustProxy: true` to Fastify configuration for correct protocol detection behind edge TLS termination proxies
 - **React Query Global staleTime**: Set to `0` (always refetch on mount) to ensure fresh data on every page navigation; individual queries can still override with their own staleTime

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Configurable Currency Settings**: Admin-controlled currency configuration for all monetary value displays across the platform
-  - New **Currency** tab in Admin Tools page (`/admin/tools`) with dropdown selector from 25 supported currencies
+  - New **Currency** tab in Settings and Tools page (`/admin/tools`) with dropdown selector from 25 supported currencies
   - 25 supported currencies: USD, EUR, GBP, JPY, CNY, CAD, AUD, CHF, INR, KRW, BRL, MXN, SGD, HKD, NZD, SEK, NOK, DKK, PLN, ZAR, TRY, THB, AED, SAR, ILS
   - Backend `SettingsService` extended with `getCurrencySettings()` and `updateCurrencySettings()` methods using `system_settings` table (`currency` key)
   - Three new admin API endpoints: `GET/PUT /api/v1/admin/settings/currency` and `GET /api/v1/admin/settings/currency/supported`
@@ -34,7 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - New `BrandingService` extending `BaseService` with image validation (2 MB max, JPEG/PNG/SVG/GIF/WebP)
   - Five API endpoints under `/api/v1/branding` (public GET for settings/images, admin PATCH/PUT/DELETE for modifications)
   - New `BrandingContext` with React Query (5-min stale time, graceful fallback to defaults)
-  - New `BrandingTab` component with card-based layout in Admin Tools page
+  - New `BrandingTab` component with card-based layout in Settings and Tools page
   - Image storage as base64 in database with binary serving via proper Content-Type headers
   - Cache-busting via `updatedAt` query parameter on image URLs
   - RBAC: public read access for login page, `admin:banners:write` for modifications, adminReadonly for viewing admin UI
@@ -52,7 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Full LiteLLM bidirectional synchronization: fields passed on key create/update, spend and reset dates synced back on read
   - i18n support across all 9 locales
 
-- **Admin Limits Management** (Admin Tools → Limits tab): Three-section admin interface for system-wide quota configuration
+- **Admin Limits** (Settings and Tools → Limits tab): Three-section admin interface for system-wide quota configuration
   - **New User Defaults**: Default TPM, RPM, and max budget applied to newly registered users; stored in `system_settings` table (`user_defaults` key)
   - **API Key Quota Defaults**: Side-by-side grid layout for configuring default and maximum values (max budget, budget duration, soft budget, TPM, RPM) for user self-service key creation; stored in `system_settings` table (`api_key_defaults` key); public endpoint `GET /api/v1/config/api-key-defaults` for frontend pre-fill
   - **Bulk User Limits**: Apply TPM, RPM, and max budget to all existing users at once with confirmation and result summary
@@ -129,7 +129,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated: `docs/api/rest-api.md` — Branding, model test, admin settings, and config endpoints
 - Updated: `docs/architecture/database-schema.md` — New branding_settings, api_keys columns, and system_settings table
 - Updated: `docs/architecture/litellm-integration.md` — Actual `/key/info` response structure and null value gotchas
-- Updated: `docs/features/admin-tools.md` — Limits Management section with all three sub-sections
+- Updated: `docs/features/admin-tools.md` — Limits section with all three sub-sections
 
 ### Infrastructure
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ See [`docs/architecture/project-structure.md`](docs/architecture/project-structu
 - **BrandingContext**: React Context with React Query (5-min stale time, fallback defaults)
 - **RBAC**: `admin:banners:write` for modifications, public for reading
 
-**Configurable Currency**: Admin-controlled currency settings (25 supported currencies) for all monetary displays across the platform. Configured via Admin Tools → Currency tab, stored in `system_settings` table, exposed via public config endpoint. Default: USD ($).
+**Configurable Currency**: Admin-controlled currency settings (25 supported currencies) for all monetary displays across the platform. Configured via Settings and Tools → Currency tab, stored in `system_settings` table, exposed via public config endpoint. Default: USD ($).
 
 **State Management**: React Context for auth/notifications/config/branding, React Query for server state with dynamic cache TTL from backend configuration.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -62,7 +62,7 @@ Welcome to the LiteMaaS documentation! This guide will help you understand, depl
 
 - **[User Roles & Administration](features/user-roles-administration.md)** - RBAC with three-tier role hierarchy
 - **[Users Management](features/users-management.md)** - Admin user management (profile, budget, API keys, subscriptions)
-- **[Admin Tools](features/admin-tools.md)** - Administrative tools and model sync
+- **[Settings and Tools](features/admin-tools.md)** - Administrative settings and tools
 - **[Branding Customization](features/branding-customization.md)** - Custom login page and header branding
 - **[Currency Settings](features/admin-tools.md#currency-settings)** - Configurable currency for monetary displays
 - **[Admin Usage API Key Filter](features/admin-usage-api-key-filter.md)** - API key filtering for usage analytics

--- a/docs/api/model-sync-api.md
+++ b/docs/api/model-sync-api.md
@@ -184,9 +184,9 @@ Administrators can trigger manual synchronization at any time using the sync API
 
 ## Frontend Integration
 
-### Admin Tools Page
+### Settings and Tools Page
 
-The model sync API is integrated with the frontend through the Admin Tools page (`/admin/tools`), providing a user-friendly interface for triggering manual synchronization.
+The model sync API is integrated with the frontend through the Settings and Tools page (`/admin/tools`), providing a user-friendly interface for triggering manual synchronization.
 
 #### JavaScript Service Integration
 
@@ -279,7 +279,7 @@ catch (error) {
 4. **Accessibility**: WCAG 2.1 AA compliant with screen reader support
 5. **Internationalization**: Translated to 9 languages
 
-For complete frontend implementation details, see [Admin Tools Documentation](../features/admin-tools.md).
+For complete frontend implementation details, see [Settings and Tools Documentation](../features/admin-tools.md).
 
 ## Data Mapping
 

--- a/docs/archive/implementation-plans/test-coverage-improvement-plan.md
+++ b/docs/archive/implementation-plans/test-coverage-improvement-plan.md
@@ -162,10 +162,10 @@ describe('ToolsPage - Models Sync', () => {
 });
 ```
 
-##### B. Limits Management Tab
+##### B. Limits Tab
 
 ```typescript
-describe('ToolsPage - Limits Management', () => {
+describe('ToolsPage - Limits', () => {
   it('should render limits tab for admin and admin-readonly users');
   it('should not render limits tab for regular users');
   it('should display form with maxBudget, tpmLimit, rpmLimit fields');
@@ -184,10 +184,10 @@ describe('ToolsPage - Limits Management', () => {
 });
 ```
 
-##### C. Banner Management Tab
+##### C. Banners Tab
 
 ```typescript
-describe('ToolsPage - Banner Management', () => {
+describe('ToolsPage - Banners', () => {
   it('should render banner tab for admin and admin-readonly users');
   it('should load all banners on mount using React Query');
   it('should display create banner button for admin users');

--- a/docs/development/model-sync.md
+++ b/docs/development/model-sync.md
@@ -323,15 +323,15 @@ const MOCK_MODELS = [
 
 ## Frontend Integration
 
-### Admin Tools Page
+### Settings and Tools Page
 
-The model sync functionality is exposed to administrators through the Tools page at `/admin/tools`.
+The model sync functionality is exposed to administrators through the Settings and Tools page at `/admin/tools`.
 
 **Location**: `frontend/src/pages/ToolsPage.tsx`
 
 #### Implementation Overview
 
-The Tools page provides a **Models Management** panel that allows administrators to trigger manual model synchronization:
+The Settings and Tools page provides a **Models Sync** tab that allows administrators to trigger manual model synchronization:
 
 ```typescript
 // Role-based access control
@@ -412,7 +412,7 @@ All UI text is internationalized with keys under `pages.tools`:
 {
   "pages": {
     "tools": {
-      "models": "Models Management",
+      "models": "Models Sync",
       "refreshModels": "Refresh Models from LiteLLM",
       "syncInProgress": "Synchronizing models...",
       "syncSuccess": "Models synchronized successfully",

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -5,13 +5,13 @@ This directory contains documentation for key features and functionality in Lite
 ## Core Features
 
 - **[User Roles & Administration](user-roles-administration.md)** - RBAC system with three-tier role hierarchy (admin > adminReadonly > user)
-- **[Admin Tools](admin-tools.md)** - Administrative tools and model synchronization
+- **[Settings and Tools](admin-tools.md)** - Administrative settings and tools
 - **[Branding Customization](branding-customization.md)** - Custom login page and header branding for administrators
 - **[Authentication Flow](authentication-flow.md)** - OAuth2 integration and authentication details
 - **[Restricted Model Subscription Approval](subscription-approval-workflow.md)** - Admin approval workflow for restricted model access with audit trail
 - **[Admin Usage API Key Filter](admin-usage-api-key-filter.md)** - Filtering usage data by API keys
 - **[Model Configuration Testing](model-configuration-testing.md)** - Configuration validation and testing features
-- **[Admin Tools — API Key Quota Defaults](admin-tools.md#api-key-quota-defaults)** - Admin-configurable defaults and maximums for user self-service API key quotas
+- **[Settings and Tools — API Key Quota Defaults](admin-tools.md#api-key-quota-defaults)** - Admin-configurable defaults and maximums for user self-service API key quotas
 - **[Test Chatbot](test-chatbot.md)** - Chatbot testing guide and features
 
 ## Feature Categories

--- a/docs/features/admin-tools.md
+++ b/docs/features/admin-tools.md
@@ -1,20 +1,20 @@
-# Admin Tools Page
+# Settings and Tools Page
 
 ## Overview
 
-The Admin Tools page (`/admin/tools`) provides administrative tools for managing LiteMaaS system configurations. Currently, it focuses on **Models Management**, allowing administrators to manually synchronize AI models from LiteLLM.
+The Settings and Tools page (`/admin/tools`) provides administrative tools for managing LiteMaaS system configurations. It includes tabs for Limits, Banners, Branding, Currency, and Models Sync.
 
 ### Access Requirements
 
-The Tools page is restricted to users with administrative privileges:
+The Settings and Tools page is restricted to users with administrative privileges:
 
 - **Admin users**: Full access with ability to trigger synchronization
 - **Admin-readonly users**: View-only access to sync information and statistics
 - **Regular users**: No access (redirected or receive 403 error)
 
-## Models Management Panel
+## Models Sync
 
-The Models Management panel is the primary feature of the Tools page, providing control over model synchronization between LiteLLM and the LiteMaaS database. It also includes model configuration testing capabilities for validating new model setups.
+The Models Sync tab provides control over model synchronization between LiteLLM and the LiteMaaS database. It also includes model configuration testing capabilities for validating new model setups.
 
 ### Purpose
 
@@ -91,7 +91,7 @@ For complete technical documentation, see [Model Configuration Testing](model-co
 #### How to Trigger Sync
 
 1. Navigate to `/admin/tools` in the LiteMaaS interface
-2. Locate the **Models Management** panel
+2. Select the **Models Sync** tab
 3. Click the **"Refresh Models from LiteLLM"** button
 4. Wait for the synchronization to complete
 5. Review the sync results displayed
@@ -287,7 +287,7 @@ For more technical details about the sync process, see:
 
 ## Branding Customization
 
-The Branding Customization feature allows administrators to personalize the login page and application header with custom logos, titles, and subtitles. It is accessible from the **Branding** tab on the Admin Tools page (`/admin/tools`).
+The Branding Customization feature allows administrators to personalize the login page and application header with custom logos, titles, and subtitles. It is accessible from the **Branding** tab on the Settings and Tools page (`/admin/tools`).
 
 ### Access Requirements
 
@@ -309,7 +309,7 @@ The Branding Customization feature allows administrators to personalize the logi
 
 ### How to Customize Branding
 
-1. Navigate to **Admin → Tools** and select the **Branding** tab
+1. Navigate to **Admin → Settings and Tools** and select the **Branding** tab
 2. Toggle the elements you want to customize (Login Logo, Login Title, Login Subtitle, Header Brand)
 3. For images: click **Upload Image** and select a file (takes effect immediately)
 4. For text: enter the desired title or subtitle
@@ -317,9 +317,9 @@ The Branding Customization feature allows administrators to personalize the logi
 
 For complete details, see the [Branding Customization](branding-customization.md) feature documentation.
 
-## Limits Management
+## Limits
 
-The Limits Management feature is accessible from the **Limits** tab on the Admin Tools page (`/admin/tools`). It provides three sections for managing resource limits across the system.
+The Limits feature is accessible from the **Limits** tab on the Settings and Tools page (`/admin/tools`). It provides three sections for managing resource limits across the system.
 
 ### New User Defaults
 
@@ -417,7 +417,7 @@ Allows administrators to update max budget, TPM limit, and RPM limit for **all a
 
 ## Currency Settings
 
-The Currency Settings feature is accessible from the **Currency** tab on the Admin Tools page (`/admin/tools`). It allows administrators to configure the currency used for all monetary value displays across the platform.
+The Currency Settings feature is accessible from the **Currency** tab on the Settings and Tools page (`/admin/tools`). It allows administrators to configure the currency used for all monetary value displays across the platform.
 
 ### Purpose
 
@@ -437,7 +437,7 @@ LiteMaaS supports 25 currencies: USD, EUR, GBP, JPY, CNY, CAD, AUD, CHF, INR, KR
 
 ### How to Change Currency
 
-1. Navigate to **Admin → Tools** and select the **Currency** tab
+1. Navigate to **Admin → Settings and Tools** and select the **Currency** tab
 2. Select the desired currency from the dropdown
 3. Click **Save** to apply the change
 

--- a/docs/features/branding-customization.md
+++ b/docs/features/branding-customization.md
@@ -18,7 +18,7 @@ Branding Customization allows administrators to personalize the LiteMaaS login p
 | Action | Required Role | Description |
 |--------|--------------|-------------|
 | View branding settings | Public | Login page branding is visible to all users (unauthenticated) |
-| View branding admin UI | admin, adminReadonly | Access the Branding tab in Admin Tools |
+| View branding admin UI | admin, adminReadonly | Access the Branding tab in Settings and Tools |
 | Modify branding settings | admin | Update toggles, text, upload/delete images |
 
 ## Customizable Elements
@@ -35,7 +35,7 @@ Branding Customization allows administrators to personalize the LiteMaaS login p
 
 ### BrandingTab
 
-The `BrandingTab` component (`frontend/src/components/branding/BrandingTab.tsx`) is rendered within the Admin Tools page (`/admin/tools`). It provides a card-based layout with four sections:
+The `BrandingTab` component (`frontend/src/components/branding/BrandingTab.tsx`) is rendered within the Settings and Tools page (`/admin/tools`). It provides a card-based layout with four sections:
 
 1. **Login Logo Card** — Toggle switch + image upload/preview/delete
 2. **Login Title Card** — Toggle switch + text input (max 200 characters)
@@ -80,6 +80,6 @@ Images are stored as base64 text in the database. When served via the `GET /imag
 
 ## Related Documentation
 
-- [Admin Tools](admin-tools.md#branding-customization) — Branding section in admin tools guide
+- [Settings and Tools](admin-tools.md#branding-customization) — Branding section in Settings and Tools guide
 - [REST API Reference](../api/rest-api.md#branding-apiv1branding) — Branding API endpoints
 - [Database Schema](../architecture/database-schema.md#branding_settings) — Table definition

--- a/docs/features/model-configuration-testing.md
+++ b/docs/features/model-configuration-testing.md
@@ -183,7 +183,7 @@ The feature supports all 9 LiteMaaS languages with appropriate translations:
 
 ## Related Documentation
 
-- [Admin Tools Guide](admin-tools.md) - Overview of administrative features
+- [Settings and Tools Guide](admin-tools.md) - Overview of administrative settings and tools
 - [User Roles Administration](user-roles-administration.md) - Role-based access control
 - [API Reference](../api/rest-api.md) - Backend API documentation
 - [Frontend Development](../development/pf6-guide/) - PatternFly 6 component usage

--- a/docs/features/user-roles-administration.md
+++ b/docs/features/user-roles-administration.md
@@ -137,43 +137,43 @@ CREATE TABLE users (
 | Admin endpoints       | ✅    | Limited       | ❌   |
 | User endpoints        | ✅    | ✅            | ✅   |
 | System endpoints      | ✅    | ❌            | ❌   |
-| **Admin Tools Page**  |
-| Access Tools page     | ✅    | ✅            | ❌   |
+| **Settings and Tools Page**  |
+| Access Settings and Tools page | ✅    | ✅            | ❌   |
 | Trigger model sync    | ✅    | ❌            | ❌   |
 | View sync results     | ✅    | ✅            | ❌   |
 
-## Admin Tools Page Access
+## Settings and Tools Page Access
 
-The Admin Tools page (`/admin/tools`) provides role-based access to system management tools, with different capabilities for each admin role type.
+The Settings and Tools page (`/admin/tools`) provides role-based access to system management tools, with different capabilities for each admin role type.
 
 ### Access Control
 
 #### Admin Users (`admin` role)
 
-- **Full access** to the Tools page at `/admin/tools`
+- **Full access** to the Settings and Tools page at `/admin/tools`
 - **Can trigger manual model sync**: Refresh button is enabled
 - **View detailed sync results**: Access to all sync statistics and error details
 - **Real-time sync monitoring**: Can monitor sync progress and receive notifications
 
 #### Admin-Readonly Users (`adminReadonly` role)
 
-- **View-only access** to the Tools page at `/admin/tools`
+- **View-only access** to the Settings and Tools page at `/admin/tools`
 - **Cannot trigger sync**: Refresh button is disabled with tooltip explanation
 - **View sync results**: Can see sync statistics and error details from previous syncs
 - **Monitor sync history**: Track when syncs were last performed by admin users
 
 #### Standard Users (`user` role)
 
-- **No access** to the Tools page
+- **No access** to the Settings and Tools page
 - Attempts to navigate to `/admin/tools` result in redirect or 403 error
 - Cannot view or interact with any admin settings functionality
 
-### Tools Page Features by Role
+### Settings and Tools Page Features by Role
 
 | Feature                         | admin | adminReadonly | user |
 | ------------------------------- | ----- | ------------- | ---- |
 | Access `/admin/tools` page      | ✅    | ✅            | ❌   |
-| View Models Management panel    | ✅    | ✅            | ❌   |
+| View Models Sync tab            | ✅    | ✅            | ❌   |
 | Click "Refresh Models" button   | ✅    | ❌ (disabled) | ❌   |
 | See sync progress/loading state | ✅    | ❌            | ❌   |
 | View sync statistics            | ✅    | ✅            | ❌   |
@@ -182,7 +182,7 @@ The Admin Tools page (`/admin/tools`) provides role-based access to system manag
 
 ### UI Implementation Details
 
-The Tools page implements role-based functionality through conditional rendering:
+The Settings and Tools page implements role-based functionality through conditional rendering:
 
 ```typescript
 // Check if user has admin permission (not admin-readonly)
@@ -204,7 +204,7 @@ const canSync = user?.roles?.includes('admin') ?? false;
 )}
 ```
 
-For complete Tools page documentation, see [Admin Tools Guide](./admin-tools.md).
+For complete Settings and Tools page documentation, see [Settings and Tools Guide](./admin-tools.md).
 
 ## API Role Requirements
 

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -159,27 +159,27 @@ See [`docs/architecture/project-structure.md`](../docs/architecture/project-stru
 
 **Admin Routes** (admin/adminReadonly roles required):
 
-- `/admin/users` - **Admin user management (UsersPage.tsx)** - Consolidated modal-based interface:
-  - Tabbed management: Profile, Budget & Limits, API Keys, Subscriptions
-  - Role management with admin/adminReadonly/user toggles
-  - Budget and rate limit configuration with progress indicators
-  - API key creation with auto-subscription and revocation
-  - RBAC: admin (full access) vs adminReadonly (view only)
-- `/admin/models` - Model configuration testing (AdminModelsPage.tsx)
-- `/admin/tools` - Administrative tools with Limits, Branding, and Banners tabs (ToolsPage.tsx)
-  - Limits tab: Bulk User Limits (max budget, TPM, RPM for all users) and API Key Quota Defaults (admin-configurable defaults and maximums)
-- `/admin/subscriptions` - **Subscription approval management (AdminSubscriptionsPage.tsx)** - Approve/deny restricted model access:
-  - Multi-dimensional filtering (status, model, user, date range)
-  - Bulk approve/deny operations with result modals
-  - Granular RBAC (admin vs adminReadonly)
-  - Manual refresh only (no polling)
-  - Full audit trail display
-- `/admin/usage` - **Admin usage analytics (AdminUsagePage.tsx)** - Major feature with comprehensive system-wide analytics:
+- `/admin/usage` - **Usage Analytics (AdminUsagePage.tsx)** - Major feature with comprehensive system-wide analytics:
   - Global metrics with trend analysis
   - Multi-dimensional filtering (users, models, providers, API keys)
   - Day-by-day incremental caching (5-min TTL for current day)
   - Data export (CSV/JSON)
   - ConfigContext integration for dynamic cache TTL
+- `/admin/models` - **Model Management (AdminModelsPage.tsx)** - Model configuration testing
+- `/admin/subscriptions` - **Subscription Management (AdminSubscriptionsPage.tsx)** - Approve/deny restricted model access:
+  - Multi-dimensional filtering (status, model, user, date range)
+  - Bulk approve/deny operations with result modals
+  - Granular RBAC (admin vs adminReadonly)
+  - Manual refresh only (no polling)
+  - Full audit trail display
+- `/admin/users` - **Users Management (UsersPage.tsx)** - Consolidated modal-based interface:
+  - Tabbed management: Profile, Budget & Limits, API Keys, Subscriptions
+  - Role management with admin/adminReadonly/user toggles
+  - Budget and rate limit configuration with progress indicators
+  - API key creation with auto-subscription and revocation
+  - RBAC: admin (full access) vs adminReadonly (view only)
+- `/admin/tools` - **Settings and Tools (ToolsPage.tsx)** - Tabs: Limits, Banners, Branding, Currency, Models Sync
+  - Limits tab: Bulk User Limits (max budget, TPM, RPM for all users) and API Key Quota Defaults (admin-configurable defaults and maximums)
 
 **Protection**: `ProtectedRoute` for auth, `RoleProtectedRoute` for admin routes with required roles
 

--- a/frontend/src/config/navigation.tsx
+++ b/frontend/src/config/navigation.tsx
@@ -82,19 +82,19 @@ export const appConfig: AppConfig = {
       label: 'Admin',
       routes: [
         {
-          id: 'admin-models',
-          path: '/admin/models',
-          element: AdminModelsPage,
-          label: 'nav.admin.models',
-          icon: CubesIcon,
-          requiredRoles: ['admin', 'admin-readonly'],
-        },
-        {
           id: 'admin-usage',
           path: '/admin/usage',
           element: AdminUsagePage,
           label: 'nav.admin.usage',
           icon: ChartBarIcon,
+          requiredRoles: ['admin', 'admin-readonly'],
+        },
+        {
+          id: 'admin-models',
+          path: '/admin/models',
+          element: AdminModelsPage,
+          label: 'nav.admin.models',
+          icon: CubesIcon,
           requiredRoles: ['admin', 'admin-readonly'],
         },
         {
@@ -169,17 +169,17 @@ export const appConfig: AppConfig = {
       requiredRoles: ['admin', 'admin-readonly'],
     },
     {
-      id: 'admin-models',
-      label: 'nav.admin.models',
-      path: '/admin/models',
-      icon: CubesIcon,
-      requiredRoles: ['admin', 'admin-readonly'],
-    },
-    {
       id: 'admin-usage',
       label: 'nav.admin.usage',
       path: '/admin/usage',
       icon: ChartBarIcon,
+      requiredRoles: ['admin', 'admin-readonly'],
+    },
+    {
+      id: 'admin-models',
+      label: 'nav.admin.models',
+      path: '/admin/models',
+      icon: CubesIcon,
       requiredRoles: ['admin', 'admin-readonly'],
     },
     {

--- a/frontend/src/i18n/locales/de/translation.json
+++ b/frontend/src/i18n/locales/de/translation.json
@@ -469,9 +469,9 @@
     "admin": {
       "models": "Modellverwaltung",
       "subscriptions": "Abonnementverwaltung",
-      "tools": "Werkzeuge",
+      "tools": "Einstellungen und Werkzeuge",
       "usage": "Nutzungsanalyse",
-      "users": "Benutzer"
+      "users": "Benutzerverwaltung"
     },
     "apiKeys": "API-Schlüssel",
     "chatbot": "Chatbot-Spielplatz",
@@ -1144,7 +1144,7 @@
       "bannerDeleteErrorGeneric": "Ein Fehler ist beim Löschen des Banners aufgetreten. Bitte versuchen Sie es erneut.",
       "bannerDescription": "Erstellen und verwalten Sie Ankündigungen, die oben in der Anwendung für alle Benutzer erscheinen.",
       "bannerEnglishRequired": "Englischer Inhalt ist erforderlich (andere Sprachen sind optional)",
-      "bannerManagement": "Banner-Verwaltung",
+      "bannerManagement": "Banner",
       "bannerName": "Banner-Name",
       "bannerNamePlaceholder": "Geben Sie einen beschreibenden Namen für dieses Banner ein",
       "bannerNameRequired": "Banner-Name ist erforderlich",
@@ -1191,14 +1191,14 @@
       "lastUpdated": "Zuletzt aktualisiert",
       "leaveEmptyToKeep": "Leer lassen, um aktuellen Wert zu behalten",
       "limitsDescription": "Ressourcenlimits für alle Benutzer im System festlegen. Änderungen werden auf alle aktiven Benutzer angewendet. Standards für neue Benutzer ändern sich nicht.",
-      "limitsManagement": "Limits-Management",
+      "limitsManagement": "Limits",
       "bulkUpdate": {
         "title": "Bulk Update All Users",
         "description": "Override resource limits for every active user at once. This does not change defaults for future users."
       },
       "maxBudgetHelper": "Maximales Ausgabenlimit pro Benutzer in {{currencyCode}}",
       "maxBudgetLabel": "Maximales Budget ({{currencyCode}})",
-      "models": "Modell-Management",
+      "models": "Modell-Synchronisation",
       "modelsDescription": "KI-Modelle von LiteLLM synchronisieren, um sicherzustellen, dass Sie Zugriff auf die neuesten verfügbaren Modelle haben.",
       "newModels": "Neue Modelle",
       "noBannersFound": "Keine Banner gefunden. Erstellen Sie Ihr erstes Banner, um zu beginnen.",
@@ -1221,7 +1221,7 @@
       "syncSuccess": "Modelle erfolgreich synchronisiert",
       "syncSuccessDetails": "{{total}} Modelle insgesamt ({{new}} neue, {{updated}} aktualisierte)",
       "syncTime": "Zeit",
-      "title": "Werkzeuge",
+      "title": "Einstellungen und Werkzeuge",
       "toggleVisibility": "Sichtbarkeit für {{name}} umschalten",
       "totalModels": "Modelle insgesamt",
       "totalUsersUpdated": "Benutzer insgesamt",

--- a/frontend/src/i18n/locales/elv/translation.json
+++ b/frontend/src/i18n/locales/elv/translation.json
@@ -469,9 +469,9 @@
     "admin": {
       "models": "Vegil Vellyn",
       "subscriptions": "Glaemscath Govannen",
-      "tools": "Echad",
+      "tools": "Estel ah Echad",
       "usage": "Aerlinn-Minithith",
-      "users": "Aduiain"
+      "users": "Tirith Aduiain"
     },
     "apiKeys": "Anguirel-API",
     "chatbot": "Glingad-Celeb",
@@ -1144,7 +1144,7 @@
       "bannerDeleteErrorGeneric": "Gweith orthant pen neledh i faer. Prestanno.",
       "bannerDescription": "Orthor ar thûr i feer i thilin vi baran in aear na hain elei dúnedain.",
       "bannerEnglishRequired": "Rochon Adûnaig (aenyn hain eglain sui thillen)",
-      "bannerManagement": "Tawar Orthad Faer",
+      "bannerManagement": "Tawar",
       "bannerName": "Eneth Faer",
       "bannerNamePlaceholder": "Teithado eneth dannen han faer",
       "bannerNameRequired": "Rochon eneth faer",
@@ -1191,14 +1191,14 @@
       "lastUpdated": "Orthanc Duin",
       "leaveEmptyToKeep": "Awartha lim na mí vaethen fair",
       "limitsDescription": "Orthatha limmad-gelair na îl aduiain mi rond. Ceird thuiar na îl aduiain orthad. Anann aduiain vuin ú-ceird.",
-      "limitsManagement": "Limmad Vellyn",
+      "limitsManagement": "Limmad",
       "bulkUpdate": {
         "title": "Bulk Update All Users",
         "description": "Override resource limits for every active user at once. This does not change defaults for future users."
       },
       "maxBudgetHelper": "Vahamal cost-lim na aduiadan hen {{currencyCode}}",
       "maxBudgetLabel": "Vahamal Linn ({{currencyCode}})",
-      "models": "Echuin Vellyn",
+      "models": "Echuin Sinhronath",
       "modelsDescription": "Sinhronatha isui echuin o LiteLLM na thirad în dalitha na echuin sui vuin.",
       "newModels": "Echuin Vuin",
       "noBannersFound": "Ú-faer trened. Ortho pen faer na thûl.",
@@ -1221,7 +1221,7 @@
       "syncSuccess": "Echuin sinhron sui prestannen",
       "syncSuccessDetails": "{{total}} echuin îl ({{new}} vuin, {{updated}} edraith)",
       "syncTime": "Lû",
-      "title": "Echad",
+      "title": "Estel ah Echad",
       "toggleVisibility": "Prestanno tiruith {{name}}",
       "totalModels": "Echuin îl",
       "totalUsersUpdated": "Aduiain îl",

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -469,9 +469,9 @@
     "admin": {
       "models": "Model Management",
       "subscriptions": "Subscription Management",
-      "tools": "Tools",
+      "tools": "Settings and Tools",
       "usage": "Usage Analytics",
-      "users": "Users"
+      "users": "Users Management"
     },
     "apiKeys": "API Keys",
     "chatbot": "Chatbot Playground",
@@ -1146,7 +1146,7 @@
       "bannerDeleteErrorGeneric": "An error occurred while deleting the banner. Please try again.",
       "bannerDescription": "Create and manage announcements that appear at the top of the application for all users.",
       "bannerEnglishRequired": "English content is required (other languages are optional)",
-      "bannerManagement": "Banner Management",
+      "bannerManagement": "Banners",
       "bannerName": "Banner Name",
       "bannerNamePlaceholder": "Enter a descriptive name for this banner",
       "bannerNameRequired": "Banner name is required",
@@ -1193,14 +1193,14 @@
       "lastUpdated": "Last Updated",
       "leaveEmptyToKeep": "Leave empty to keep current value",
       "limitsDescription": "Set resource limits for all users in the system. Changes will apply to all active users. Defaults for new users won't change.",
-      "limitsManagement": "Limits Management",
+      "limitsManagement": "Limits",
       "bulkUpdate": {
         "title": "Bulk Update All Users",
         "description": "Override resource limits for every active user at once. This does not change defaults for future users."
       },
       "maxBudgetHelper": "Maximum spending limit per user in {{currencyCode}}",
       "maxBudgetLabel": "Maximum Budget ({{currencyCode}})",
-      "models": "Models Management",
+      "models": "Models Sync",
       "modelsDescription": "Synchronize AI models from LiteLLM to ensure you have access to the latest available models.",
       "newModels": "New Models",
       "noBannersFound": "No banners found. Create your first banner to get started.",
@@ -1223,7 +1223,7 @@
       "syncSuccess": "Models synchronized successfully",
       "syncSuccessDetails": "{{total}} total models ({{new}} new, {{updated}} updated)",
       "syncTime": "Time",
-      "title": "Tools",
+      "title": "Settings and Tools",
       "toggleVisibility": "Toggle visibility for {{name}}",
       "totalModels": "Total Models",
       "totalUsersUpdated": "Total Users",

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -469,9 +469,9 @@
     "admin": {
       "models": "Gestión de Modelos",
       "subscriptions": "Gestión de Suscripciones",
-      "tools": "Herramientas",
+      "tools": "Configuración y Herramientas",
       "usage": "Analíticas de uso",
-      "users": "Usuarios"
+      "users": "Gestión de Usuarios"
     },
     "apiKeys": "Claves API",
     "chatbot": "Área de Juegos del Chatbot",
@@ -1144,7 +1144,7 @@
       "bannerDeleteErrorGeneric": "Ocurrió un error mientras se eliminaba el banner. Por favor, inténtalo de nuevo.",
       "bannerDescription": "Crear y gestionar anuncios que aparecen en la parte superior de la aplicación para todos los usuarios.",
       "bannerEnglishRequired": "El contenido en inglés es obligatorio (otros idiomas son opcionales)",
-      "bannerManagement": "Gestión de Banners",
+      "bannerManagement": "Banners",
       "bannerName": "Nombre del Banner",
       "bannerNamePlaceholder": "Ingresa un nombre descriptivo para este banner",
       "bannerNameRequired": "El nombre del banner es obligatorio",
@@ -1191,14 +1191,14 @@
       "lastUpdated": "Última Actualización",
       "leaveEmptyToKeep": "Dejar vacío para mantener el valor actual",
       "limitsDescription": "Establecer límites de recursos predeterminados para todos los usuarios del sistema. Los cambios se aplicarán a todos los usuarios activos.",
-      "limitsManagement": "Gestión de Límites",
+      "limitsManagement": "Límites",
       "bulkUpdate": {
         "title": "Bulk Update All Users",
         "description": "Override resource limits for every active user at once. This does not change defaults for future users."
       },
       "maxBudgetHelper": "Límite máximo de gasto por usuario en {{currencyCode}}",
       "maxBudgetLabel": "Presupuesto Máximo ({{currencyCode}})",
-      "models": "Gestión de Modelos",
+      "models": "Sincronización de Modelos",
       "modelsDescription": "Sincronizar modelos de IA desde LiteLLM para asegurar que tengas acceso a los últimos modelos disponibles.",
       "newModels": "Modelos Nuevos",
       "noBannersFound": "No se encontraron banners. Crea tu primer banner para comenzar.",
@@ -1221,7 +1221,7 @@
       "syncSuccess": "Modelos sincronizados exitosamente",
       "syncSuccessDetails": "{{total}} modelos totales ({{new}} nuevos, {{updated}} actualizados)",
       "syncTime": "Hora",
-      "title": "Herramientas",
+      "title": "Configuración y Herramientas",
       "toggleVisibility": "Alternar visibilidad para {{name}}",
       "totalModels": "Modelos Totales",
       "totalUsersUpdated": "Usuarios Totales",

--- a/frontend/src/i18n/locales/fr/translation.json
+++ b/frontend/src/i18n/locales/fr/translation.json
@@ -469,9 +469,9 @@
     "admin": {
       "models": "Gestion des Modèles",
       "subscriptions": "Gestion des Abonnements",
-      "tools": "Outils",
+      "tools": "Paramètres et Outils",
       "usage": "Analyses d'utilisation",
-      "users": "Utilisateurs"
+      "users": "Gestion des Utilisateurs"
     },
     "apiKeys": "Clés API",
     "chatbot": "Terrain de Jeu du Chatbot",
@@ -1144,7 +1144,7 @@
       "bannerDeleteErrorGeneric": "Une erreur s'est produite lors de la suppression de la bannière. Veuillez réessayer.",
       "bannerDescription": "Créer et gérer des annonces qui apparaissent en haut de l'application pour tous les utilisateurs.",
       "bannerEnglishRequired": "Le contenu en anglais est obligatoire (les autres langues sont optionnelles)",
-      "bannerManagement": "Gestion des Bannières",
+      "bannerManagement": "Bannières",
       "bannerName": "Nom de la Bannière",
       "bannerNamePlaceholder": "Saisissez un nom descriptif pour cette bannière",
       "bannerNameRequired": "Le nom de la bannière est obligatoire",
@@ -1191,14 +1191,14 @@
       "lastUpdated": "Dernière Mise à Jour",
       "leaveEmptyToKeep": "Laisser vide pour conserver la valeur actuelle",
       "limitsDescription": "Définir les limites de ressources pour tous les utilisateurs du système. Les modifications s'appliqueront à tous les utilisateurs actifs. Les valeurs par défaut pour les nouveaux utilisateurs ne changeront pas.",
-      "limitsManagement": "Gestion des Limites",
+      "limitsManagement": "Limites",
       "bulkUpdate": {
         "title": "Bulk Update All Users",
         "description": "Override resource limits for every active user at once. This does not change defaults for future users."
       },
       "maxBudgetHelper": "Limite de dépenses maximale par utilisateur en {{currencyCode}}",
       "maxBudgetLabel": "Budget Maximum ({{currencyCode}})",
-      "models": "Gestion des Modèles",
+      "models": "Synchronisation des Modèles",
       "modelsDescription": "Synchroniser les modèles d'IA depuis LiteLLM pour s'assurer d'avoir accès aux derniers modèles disponibles.",
       "newModels": "Nouveaux Modèles",
       "noBannersFound": "Aucune bannière trouvée. Créez votre première bannière pour commencer.",
@@ -1221,7 +1221,7 @@
       "syncSuccess": "Modèles synchronisés avec succès",
       "syncSuccessDetails": "{{total}} modèles au total ({{new}} nouveaux, {{updated}} mis à jour)",
       "syncTime": "Heure",
-      "title": "Outils",
+      "title": "Paramètres et Outils",
       "toggleVisibility": "Basculer la visibilité pour {{name}}",
       "totalModels": "Modèles Totaux",
       "totalUsersUpdated": "Utilisateurs Totaux",

--- a/frontend/src/i18n/locales/it/translation.json
+++ b/frontend/src/i18n/locales/it/translation.json
@@ -469,9 +469,9 @@
     "admin": {
       "models": "Gestione Modelli",
       "subscriptions": "Gestione degli Abbonamenti",
-      "tools": "Strumenti",
+      "tools": "Impostazioni e Strumenti",
       "usage": "Analitiche di Utilizzo",
-      "users": "Utenti"
+      "users": "Gestione Utenti"
     },
     "apiKeys": "Chiavi API",
     "chatbot": "Area Giochi del Chatbot",
@@ -1144,7 +1144,7 @@
       "bannerDeleteErrorGeneric": "Si è verificato un errore durante l'eliminazione del banner. Riprova.",
       "bannerDescription": "Crea e gestisci annunci che appaiono nella parte superiore dell'applicazione per tutti gli utenti.",
       "bannerEnglishRequired": "Il contenuto in inglese è obbligatorio (altre lingue sono opzionali)",
-      "bannerManagement": "Gestione Banner",
+      "bannerManagement": "Banner",
       "bannerName": "Nome del Banner",
       "bannerNamePlaceholder": "Inserisci un nome descrittivo per questo banner",
       "bannerNameRequired": "Il nome del banner è obbligatorio",
@@ -1191,14 +1191,14 @@
       "lastUpdated": "Ultimo Aggiornamento",
       "leaveEmptyToKeep": "Lascia vuoto per mantenere il valore corrente",
       "limitsDescription": "Imposta limiti di risorse per tutti gli utenti nel sistema. Le modifiche si applicheranno a tutti gli utenti attivi. I valori predefiniti per i nuovi utenti non cambieranno.",
-      "limitsManagement": "Gestione Limiti",
+      "limitsManagement": "Limiti",
       "bulkUpdate": {
         "title": "Bulk Update All Users",
         "description": "Override resource limits for every active user at once. This does not change defaults for future users."
       },
       "maxBudgetHelper": "Limite massimo di spesa per utente in {{currencyCode}}",
       "maxBudgetLabel": "Budget Massimo ({{currencyCode}})",
-      "models": "Gestione Modelli",
+      "models": "Sincronizzazione Modelli",
       "modelsDescription": "Sincronizza i modelli AI da LiteLLM per assicurarti di avere accesso agli ultimi modelli disponibili.",
       "newModels": "Nuovi Modelli",
       "noBannersFound": "Nessun banner trovato. Crea il tuo primo banner per iniziare.",
@@ -1221,7 +1221,7 @@
       "syncSuccess": "Modelli sincronizzati con successo",
       "syncSuccessDetails": "{{total}} modelli totali ({{new}} nuovi, {{updated}} aggiornati)",
       "syncTime": "Ora",
-      "title": "Strumenti",
+      "title": "Impostazioni e Strumenti",
       "toggleVisibility": "Attiva/disattiva visibilità per {{name}}",
       "totalModels": "Modelli Totali",
       "totalUsersUpdated": "Utenti Totali",

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -469,9 +469,9 @@
     "admin": {
       "models": "モデル管理",
       "subscriptions": "サブスクリプション管理",
-      "tools": "ツール",
+      "tools": "設定とツール",
       "usage": "使用分析",
-      "users": "ユーザー"
+      "users": "ユーザー管理"
     },
     "apiKeys": "APIキー",
     "chatbot": "チャットボットプレイグラウンド",
@@ -1144,7 +1144,7 @@
       "bannerDeleteErrorGeneric": "バナーの削除中にエラーが発生しました。再度お試しください。",
       "bannerDescription": "全ユーザーに表示されるアプリケーション上部のお知らせを作成・管理します。",
       "bannerEnglishRequired": "英語の内容は必須です（他の言語はオプション）",
-      "bannerManagement": "バナー管理",
+      "bannerManagement": "バナー",
       "bannerName": "バナー名",
       "bannerNamePlaceholder": "このバナーの説明的な名前を入力してください",
       "bannerNameRequired": "バナー名は必須です",
@@ -1191,14 +1191,14 @@
       "lastUpdated": "最終更新",
       "leaveEmptyToKeep": "現在の値を保持するには空欄にしておいてください",
       "limitsDescription": "システム内のすべてのユーザーにリソース制限を設定します。変更はすべてのアクティブユーザーに適用されます。新しいユーザーのデフォルト値は変更されません。",
-      "limitsManagement": "制限管理",
+      "limitsManagement": "制限",
       "bulkUpdate": {
         "title": "Bulk Update All Users",
         "description": "Override resource limits for every active user at once. This does not change defaults for future users."
       },
       "maxBudgetHelper": "ユーザーあたりの最大支出制限（{{currencyCode}}）",
       "maxBudgetLabel": "最大予算 ({{currencyCode}})",
-      "models": "モデル管理",
+      "models": "モデル同期",
       "modelsDescription": "最新の利用可能モデルにアクセスできるようにLiteLLMからAIモデルを同期します。",
       "newModels": "新しいモデル",
       "noBannersFound": "バナーが見つかりません。最初のバナーを作成して開始してください。",
@@ -1221,7 +1221,7 @@
       "syncSuccess": "モデルの同期が成功しました",
       "syncSuccessDetails": "合計{{total}}モデル（{{new}}個新規、{{updated}}個更新）",
       "syncTime": "時刻",
-      "title": "ツール",
+      "title": "設定とツール",
       "toggleVisibility": "{{name}}の表示を切り替え",
       "totalModels": "総モデル数",
       "totalUsersUpdated": "総ユーザー数",

--- a/frontend/src/i18n/locales/ko/translation.json
+++ b/frontend/src/i18n/locales/ko/translation.json
@@ -469,9 +469,9 @@
     "admin": {
       "models": "모델 관리",
       "subscriptions": "구독 관리",
-      "tools": "도구",
+      "tools": "설정 및 도구",
       "usage": "사용량 분석",
-      "users": "사용자"
+      "users": "사용자 관리"
     },
     "apiKeys": "API 키",
     "chatbot": "챗봇 플레이그라운드",
@@ -1144,7 +1144,7 @@
       "bannerDeleteErrorGeneric": "배너 삭제 중 오류가 발생했습니다. 다시 시도해 주세요.",
       "bannerDescription": "모든 사용자에게 표시되는 애플리케이션 상단의 공지사항을 생성하고 관리합니다.",
       "bannerEnglishRequired": "영어 내용은 필수입니다 (다른 언어는 선택사항)",
-      "bannerManagement": "배너 관리",
+      "bannerManagement": "배너",
       "bannerName": "배너 이름",
       "bannerNamePlaceholder": "이 배너의 설명적인 이름을 입력하세요",
       "bannerNameRequired": "배너 이름은 필수입니다",
@@ -1191,14 +1191,14 @@
       "lastUpdated": "마지막 업데이트",
       "leaveEmptyToKeep": "현재 값을 유지하려면 비워두세요",
       "limitsDescription": "시스템의 모든 사용자에게 리소스 제한을 설정합니다. 변경 사항은 모든 활성 사용자에게 적용됩니다. 새 사용자의 기본값은 변경되지 않습니다.",
-      "limitsManagement": "제한 관리",
+      "limitsManagement": "제한",
       "bulkUpdate": {
         "title": "Bulk Update All Users",
         "description": "Override resource limits for every active user at once. This does not change defaults for future users."
       },
       "maxBudgetHelper": "사용자별 최대 지출 제한({{currencyCode}})",
       "maxBudgetLabel": "최대 예산 ({{currencyCode}})",
-      "models": "모델 관리",
+      "models": "모델 동기화",
       "modelsDescription": "최신 사용 가능한 모델에 액세스할 수 있도록 LiteLLM에서 AI 모델을 동기화합니다.",
       "newModels": "새로운 모델",
       "noBannersFound": "배너를 찾을 수 없습니다. 첫 번째 배너를 만들어 시작하세요.",
@@ -1221,7 +1221,7 @@
       "syncSuccess": "모델이 성공적으로 동기화되었습니다",
       "syncSuccessDetails": "총 {{total}}개 모델 ({{new}}개 신규, {{updated}}개 업데이트)",
       "syncTime": "시간",
-      "title": "도구",
+      "title": "설정 및 도구",
       "toggleVisibility": "{{name}}의 표시 전환",
       "totalModels": "총 모델 수",
       "totalUsersUpdated": "총 사용자 수",

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -469,9 +469,9 @@
     "admin": {
       "models": "模型管理",
       "subscriptions": "订阅管理",
-      "tools": "工具",
+      "tools": "设置与工具",
       "usage": "使用分析",
-      "users": "用户"
+      "users": "用户管理"
     },
     "apiKeys": "API密钥",
     "chatbot": "聊天机器人游乐场",
@@ -1144,7 +1144,7 @@
       "bannerDeleteErrorGeneric": "删除横幅时发生错误。请重试。",
       "bannerDescription": "创建和管理显示在应用程序顶部的公告，面向所有用户。",
       "bannerEnglishRequired": "英文内容是必需的（其他语言是可选的）",
-      "bannerManagement": "横幅管理",
+      "bannerManagement": "横幅",
       "bannerName": "横幅名称",
       "bannerNamePlaceholder": "为此横幅输入描述性名称",
       "bannerNameRequired": "横幅名称是必需的",
@@ -1191,14 +1191,14 @@
       "lastUpdated": "最后更新",
       "leaveEmptyToKeep": "留空以保持当前值",
       "limitsDescription": "为系统中的所有用户设置资源限制。更改将应用于所有活跃用户。新用户的默认值不会更改。",
-      "limitsManagement": "限制管理",
+      "limitsManagement": "限制",
       "bulkUpdate": {
         "title": "Bulk Update All Users",
         "description": "Override resource limits for every active user at once. This does not change defaults for future users."
       },
       "maxBudgetHelper": "每个用户的最大支出限制（{{currencyCode}}）",
       "maxBudgetLabel": "最大预算 ({{currencyCode}})",
-      "models": "模型管理",
+      "models": "模型同步",
       "modelsDescription": "同步LiteLLM的AI模型，以确保您可以访问最新的可用模型。",
       "newModels": "新模型",
       "noBannersFound": "未找到横幅。创建您的第一个横幅以开始。",
@@ -1221,7 +1221,7 @@
       "syncSuccess": "模型同步成功",
       "syncSuccessDetails": "总计{{total}}个模型（{{new}}个新增，{{updated}}个更新）",
       "syncTime": "时间",
-      "title": "工具",
+      "title": "设置与工具",
       "toggleVisibility": "切换{{name}}的可见性",
       "totalModels": "模型总数",
       "totalUsersUpdated": "用户总数",

--- a/frontend/src/pages/ToolsPage.tsx
+++ b/frontend/src/pages/ToolsPage.tsx
@@ -69,7 +69,9 @@ const ToolsPage: React.FC = () => {
   const { currencySymbol, currencyCode } = useCurrency();
   const [isLoading, setIsLoading] = useState(false);
   const [lastSyncResult, setLastSyncResult] = useState<SyncResult | null>(null);
-  const [activeTabKey, setActiveTabKey] = useState<string | number>('models');
+  const isAdmin =
+    (user?.roles?.includes('admin') || user?.roles?.includes('admin-readonly')) ?? false;
+  const [activeTabKey, setActiveTabKey] = useState<string | number>(isAdmin ? 'limits' : 'models');
 
   // Limits Management state
   const [isLimitsLoading, setIsLimitsLoading] = useState(false);
@@ -413,78 +415,6 @@ const ToolsPage: React.FC = () => {
       </PageSection>
       <PageSection>
         <Tabs activeKey={activeTabKey} onSelect={handleTabClick}>
-          {/* Models Management Tab */}
-          <Tab eventKey="models" title={<TabTitleText>{t('pages.tools.models')}</TabTitleText>}>
-            <TabContent id="models-tab-content" style={{ paddingTop: '10px' }}>
-              <TabContentBody>
-                <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsMd' }}>
-                  <FlexItem>
-                    <p>{t('pages.tools.modelsDescription')}</p>
-                  </FlexItem>
-
-                  {lastSyncResult && (
-                    <FlexItem>
-                      <Alert
-                        variant={lastSyncResult.success ? 'success' : 'warning'}
-                        title={t('pages.tools.lastSync')}
-                        isInline
-                      >
-                        <DescriptionList isHorizontal>
-                          <DescriptionListGroup>
-                            <DescriptionListTerm>{t('pages.tools.syncTime')}</DescriptionListTerm>
-                            <DescriptionListDescription>
-                              {formatSyncTime(lastSyncResult.syncedAt)}
-                            </DescriptionListDescription>
-                          </DescriptionListGroup>
-                          <DescriptionListGroup>
-                            <DescriptionListTerm>
-                              {t('pages.tools.totalModels')}
-                            </DescriptionListTerm>
-                            <DescriptionListDescription>
-                              {lastSyncResult.totalModels}
-                            </DescriptionListDescription>
-                          </DescriptionListGroup>
-                          <DescriptionListGroup>
-                            <DescriptionListTerm>{t('pages.tools.newModels')}</DescriptionListTerm>
-                            <DescriptionListDescription>
-                              {lastSyncResult.newModels}
-                            </DescriptionListDescription>
-                          </DescriptionListGroup>
-                          <DescriptionListGroup>
-                            <DescriptionListTerm>
-                              {t('pages.tools.updatedModels')}
-                            </DescriptionListTerm>
-                            <DescriptionListDescription>
-                              {lastSyncResult.updatedModels}
-                            </DescriptionListDescription>
-                          </DescriptionListGroup>
-                        </DescriptionList>
-                        {lastSyncResult.errors.length > 0 && (
-                          <div style={{ marginTop: '1rem' }}>
-                            <strong>{t('pages.tools.syncErrors')}:</strong>
-                            <ul style={{ marginTop: '0.5rem' }}>
-                              {lastSyncResult.errors.map((error, index) => (
-                                <li key={index}>{error}</li>
-                              ))}
-                            </ul>
-                          </div>
-                        )}
-                      </Alert>
-                    </FlexItem>
-                  )}
-
-                  <FlexItem>
-                    {canSync ? (
-                      syncButton
-                    ) : (
-                      <Tooltip content={t('pages.tools.adminRequired')}>{syncButton}</Tooltip>
-                    )}
-                  </FlexItem>
-                </Flex>
-              </TabContentBody>
-            </TabContent>
-          </Tab>
-
           {/* Limits Management Tab */}
           {canViewLimits && (
             <Tab
@@ -733,6 +663,77 @@ const ToolsPage: React.FC = () => {
               </TabContent>
             </Tab>
           )}
+          {/* Models Sync Tab */}
+          <Tab eventKey="models" title={<TabTitleText>{t('pages.tools.models')}</TabTitleText>}>
+            <TabContent id="models-tab-content" style={{ paddingTop: '10px' }}>
+              <TabContentBody>
+                <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsMd' }}>
+                  <FlexItem>
+                    <p>{t('pages.tools.modelsDescription')}</p>
+                  </FlexItem>
+
+                  {lastSyncResult && (
+                    <FlexItem>
+                      <Alert
+                        variant={lastSyncResult.success ? 'success' : 'warning'}
+                        title={t('pages.tools.lastSync')}
+                        isInline
+                      >
+                        <DescriptionList isHorizontal>
+                          <DescriptionListGroup>
+                            <DescriptionListTerm>{t('pages.tools.syncTime')}</DescriptionListTerm>
+                            <DescriptionListDescription>
+                              {formatSyncTime(lastSyncResult.syncedAt)}
+                            </DescriptionListDescription>
+                          </DescriptionListGroup>
+                          <DescriptionListGroup>
+                            <DescriptionListTerm>
+                              {t('pages.tools.totalModels')}
+                            </DescriptionListTerm>
+                            <DescriptionListDescription>
+                              {lastSyncResult.totalModels}
+                            </DescriptionListDescription>
+                          </DescriptionListGroup>
+                          <DescriptionListGroup>
+                            <DescriptionListTerm>{t('pages.tools.newModels')}</DescriptionListTerm>
+                            <DescriptionListDescription>
+                              {lastSyncResult.newModels}
+                            </DescriptionListDescription>
+                          </DescriptionListGroup>
+                          <DescriptionListGroup>
+                            <DescriptionListTerm>
+                              {t('pages.tools.updatedModels')}
+                            </DescriptionListTerm>
+                            <DescriptionListDescription>
+                              {lastSyncResult.updatedModels}
+                            </DescriptionListDescription>
+                          </DescriptionListGroup>
+                        </DescriptionList>
+                        {lastSyncResult.errors.length > 0 && (
+                          <div style={{ marginTop: '1rem' }}>
+                            <strong>{t('pages.tools.syncErrors')}:</strong>
+                            <ul style={{ marginTop: '0.5rem' }}>
+                              {lastSyncResult.errors.map((error, index) => (
+                                <li key={index}>{error}</li>
+                              ))}
+                            </ul>
+                          </div>
+                        )}
+                      </Alert>
+                    </FlexItem>
+                  )}
+
+                  <FlexItem>
+                    {canSync ? (
+                      syncButton
+                    ) : (
+                      <Tooltip content={t('pages.tools.adminRequired')}>{syncButton}</Tooltip>
+                    )}
+                  </FlexItem>
+                </Flex>
+              </TabContentBody>
+            </TabContent>
+          </Tab>
         </Tabs>
 
         {/* Confirmation Modal */}

--- a/frontend/src/test/components/ToolsPage.test.tsx
+++ b/frontend/src/test/components/ToolsPage.test.tsx
@@ -193,25 +193,25 @@ describe('ToolsPage', () => {
       expect(screen.getByRole('heading', { level: 1, name: /tools/i })).toBeInTheDocument();
     });
 
-    it('should render models tab as default active tab', () => {
+    it('should render limits tab as default active tab', () => {
       renderWithAuth(<ToolsPage />, { user: mockAdminUser });
 
-      const modelsTab = screen.getByRole('tab', { name: /models/i });
-      expect(modelsTab).toHaveAttribute('aria-selected', 'true');
+      const limitsTab = screen.getByRole('tab', { name: /limits/i });
+      expect(limitsTab).toHaveAttribute('aria-selected', 'true');
     });
 
     it('should switch between tabs correctly', async () => {
       const user = userEvent.setup();
       renderWithAuth(<ToolsPage />, { user: mockAdminUser });
 
-      // Initially on models tab
-      expect(screen.getByRole('tab', { name: /models/i })).toHaveAttribute('aria-selected', 'true');
+      // Initially on limits tab
+      expect(screen.getByRole('tab', { name: /limits/i })).toHaveAttribute('aria-selected', 'true');
 
-      // Click limits tab
-      const limitsTab = screen.getByRole('tab', { name: /limits/i });
-      await user.click(limitsTab);
+      // Click models tab
+      const modelsTab = screen.getByRole('tab', { name: /models/i });
+      await user.click(modelsTab);
 
-      expect(limitsTab).toHaveAttribute('aria-selected', 'true');
+      expect(modelsTab).toHaveAttribute('aria-selected', 'true');
     });
 
     it('should only show models tab for regular users', () => {
@@ -240,14 +240,22 @@ describe('ToolsPage', () => {
   });
 
   describe('Models Sync Tab', () => {
-    it('should render models sync section', () => {
+    async function switchToModelsTab() {
+      const usr = userEvent.setup();
+      const modelsTab = screen.getByRole('tab', { name: /models/i });
+      await usr.click(modelsTab);
+    }
+
+    it('should render models sync section', async () => {
       renderWithAuth(<ToolsPage />, { user: mockAdminUser });
+      await switchToModelsTab();
 
       expect(screen.getByText(/browse and manage ai models/i)).toBeInTheDocument();
     });
 
-    it('should display sync button for admin users', () => {
+    it('should display sync button for admin users', async () => {
       renderWithAuth(<ToolsPage />, { user: mockAdminUser });
+      await switchToModelsTab();
 
       const syncButton = screen.getByRole('button', { name: /refresh models/i });
       expect(syncButton).toBeInTheDocument();
@@ -283,6 +291,7 @@ describe('ToolsPage', () => {
       vi.mocked(modelsService.refreshModels).mockResolvedValue(mockRefreshResult);
 
       renderWithAuth(<ToolsPage />, { user: mockAdminUser });
+      await switchToModelsTab();
 
       const syncButton = screen.getByRole('button', { name: /refresh models/i });
       await user.click(syncButton);
@@ -304,6 +313,7 @@ describe('ToolsPage', () => {
       vi.mocked(modelsService.refreshModels).mockResolvedValue(mockRefreshResult);
 
       renderWithAuth(<ToolsPage />, { user: mockAdminUser });
+      await switchToModelsTab();
 
       const syncButton = screen.getByRole('button', { name: /refresh models/i });
       await user.click(syncButton);
@@ -330,6 +340,7 @@ describe('ToolsPage', () => {
       vi.mocked(modelsService.refreshModels).mockResolvedValue(mockRefreshResult);
 
       renderWithAuth(<ToolsPage />, { user: mockAdminUser });
+      await switchToModelsTab();
 
       const syncButton = screen.getByRole('button', { name: /refresh models/i });
       await user.click(syncButton);
@@ -362,6 +373,7 @@ describe('ToolsPage', () => {
       );
 
       renderWithAuth(<ToolsPage />, { user: mockAdminUser });
+      await switchToModelsTab();
 
       const syncButton = screen.getByRole('button', { name: /refresh models/i });
       await user.click(syncButton);
@@ -377,6 +389,7 @@ describe('ToolsPage', () => {
       vi.mocked(modelsService.refreshModels).mockRejectedValue(new Error('Sync failed'));
 
       renderWithAuth(<ToolsPage />, { user: mockAdminUser });
+      await switchToModelsTab();
 
       const syncButton = screen.getByRole('button', { name: /refresh models/i });
       await user.click(syncButton);

--- a/frontend/src/test/i18n-test-setup.ts
+++ b/frontend/src/test/i18n-test-setup.ts
@@ -17,7 +17,7 @@ const testTranslations = {
   'nav.apiKeys': 'API Keys',
   'nav.usage': 'Usage',
   'nav.admin.settings': 'Settings',
-  'nav.admin.users': 'Users',
+  'nav.admin.users': 'Users Management',
   'nav.home': 'Home',
 
   // Common UI elements
@@ -258,7 +258,7 @@ const testTranslations = {
   'pages.settings.syncTime': 'Sync Time',
 
   // Settings - Limits Management
-  'pages.settings.limitsManagement': 'Limits Management',
+  'pages.settings.limitsManagement': 'Limits',
   'pages.settings.limitsDescription': 'Apply user limits to all active users in the system.',
   'pages.settings.maxBudgetLabel': 'Maximum Budget ($)',
   'pages.settings.tpmLimitLabel': 'Tokens per Minute Limit',
@@ -289,8 +289,8 @@ const testTranslations = {
   'pages.settings.updateErrors': 'Update Errors',
 
   // Tools Page
-  'pages.tools.title': 'Tools',
-  'pages.tools.models': 'Models',
+  'pages.tools.title': 'Settings and Tools',
+  'pages.tools.models': 'Models Sync',
   'pages.tools.modelsDescription': 'Browse and manage AI models from LiteLLM',
   'pages.tools.refreshModels': 'Refresh Models',
   'pages.tools.syncInProgress': 'Sync in progress...',
@@ -305,7 +305,7 @@ const testTranslations = {
   'pages.tools.newModels': 'New Models',
   'pages.tools.updatedModels': 'Updated Models',
   'pages.tools.syncErrors': 'Errors',
-  'pages.tools.limitsManagement': 'Limits Management',
+  'pages.tools.limitsManagement': 'Limits',
   'pages.tools.limitsDescription': 'Bulk update user limits for all users',
   'pages.tools.bulkUpdate.title': 'Bulk Update All Users',
   'pages.tools.bulkUpdate.description':
@@ -335,7 +335,7 @@ const testTranslations = {
   'pages.tools.bulkUpdatePartial': '{{success}} succeeded, {{failed}} failed',
   'pages.tools.bulkUpdateError': 'Failed to update users',
   'pages.tools.bulkUpdateErrorGeneric': 'Update failed',
-  'pages.tools.bannerManagement': 'Banner Management',
+  'pages.tools.bannerManagement': 'Banners',
   'pages.tools.bannerDescription': 'Manage system-wide banners',
   'pages.tools.createNewBanner': 'Create New Banner',
   'pages.tools.applying': 'Applying...',


### PR DESCRIPTION
## Summary
- Rename admin menu items for consistency: "Users" → "Users Management", "Tools" → "Settings and Tools"
- Reorder admin navigation: move "Usage Analytics" to first position
- Rename Settings and Tools page tabs: "Models Management" → "Models Sync" (moved to last), "Limits Management" → "Limits", "Banner Management" → "Banners"
- Update all 9 locale translation files, test setup, and ToolsPage tests
- Update 12 documentation files to reflect all naming changes

## Test plan
- [x] All 41 ToolsPage tests pass (updated default tab and Models Sync tab tests)
- [x] All 30 UsersPage tests pass
- [x] No regressions from cosmetic changes (3 pre-existing failures unrelated)
- [x] Verify menu labels display correctly in the browser
- [x] Verify page titles match the updated menu names
- [x] Verify tab order on Settings and Tools page: Limits, Banners, Branding, Currency, Models Sync