### PR TITLE
feat: database backup & restore for LiteMaaS and LiteLLM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Database Backup & Restore**: Full backup and restore for both LiteMaaS and LiteLLM databases from the Settings and Tools → Backup tab
+  - **Create backups**: Compressed `.sql.gz` files (pure SQL, compatible with `psql` for manual restore via `gunzip -c backup.sql.gz | psql`)
+  - **Test restore**: Non-destructive restore to a temporary schema for validation, with editable schema name and human-readable timestamps
+  - **Full restore**: Destructive restore with type-to-confirm safety modal
+  - **Download/delete**: Manage backup files from the UI
+  - **Type-aware SQL serialization**: Correct handling of PostgreSQL array columns (`TEXT[]`) vs JSON/JSONB arrays, quoted identifiers for mixed-case table names (LiteLLM), and timestamp precision preservation via `::text` casting
+  - **LiteLLM direct database access**: New optional `LITELLM_DATABASE_URL` env var for direct PostgreSQL connection to LiteLLM's database
+  - **Configurable storage**: `BACKUP_STORAGE_PATH` env var (default: `./data/backups`)
+  - **CLI restore script**: `backend/src/scripts/restore-backup.ts` for catastrophic recovery when the web UI is unavailable
+  - **RBAC**: New `admin:backup` permission (admin role only); tab visible to adminReadonly but actions disabled
+  - **Audit logging**: All backup operations logged to `audit_logs` table
+  - **i18n**: Full translations across all 9 locales including test restore confirmation modal
+
 - **Configurable Currency Settings**: Admin-controlled currency configuration for all monetary value displays across the platform
   - New **Currency** tab in Settings and Tools page (`/admin/tools`) with dropdown selector from 25 supported currencies
   - 25 supported currencies: USD, EUR, GBP, JPY, CNY, CAD, AUD, CHF, INR, KRW, BRL, MXN, SGD, HKD, NZD, SEK, NOK, DKK, PLN, ZAR, TRY, THB, AED, SAR, ILS

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,15 @@ See [`docs/architecture/project-structure.md`](docs/architecture/project-structu
 - **BrandingContext**: React Context with React Query (5-min stale time, fallback defaults)
 - **RBAC**: `admin:banners:write` for modifications, public for reading
 
+**Database Backup & Restore**: Full backup and restore for both LiteMaaS and LiteLLM databases from Settings and Tools → Backup tab:
+
+- **Backup format**: Compressed `.sql.gz` (pure SQL, compatible with `psql` for manual restore)
+- **Test restore**: Non-destructive restore to temporary schema with data integrity validation
+- **Type-aware serialization**: Correct handling of PG arrays vs JSON arrays, mixed-case identifiers, timestamp precision
+- **CLI restore**: Standalone script for catastrophic recovery (`backend/src/scripts/restore-backup.ts`)
+- **RBAC**: `admin:backup` permission (admin only), tab visible to adminReadonly (read-only)
+- **Configuration**: `LITELLM_DATABASE_URL` for LiteLLM database access, `BACKUP_STORAGE_PATH` for storage location
+
 **Configurable Currency**: Admin-controlled currency settings (25 supported currencies) for all monetary displays across the platform. Configured via Settings and Tools → Currency tab, stored in `system_settings` table, exposed via public config endpoint. Default: USD ($).
 
 **State Management**: React Context for auth/notifications/config/branding, React Query for server state with dynamic cache TTL from backend configuration.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -61,6 +61,20 @@ LITELLM_API_URL=http://your-litellm-instance:8000
 LITELLM_API_KEY=your-litellm-api-key
 LITELLM_MASTER_KEY=your-encryption-key  # For encrypting stored model API keys (falls back to LITELLM_API_KEY)
 
+
+# LiteLLM Database Direct Connection (optional, for Backup & Restore only)
+# Full PostgreSQL connection string to LiteLLM's own database.
+# Required only if you want to backup/restore the LiteLLM database from the Backup tab.
+# This is NOT the same as LITELLM_API_URL — it connects directly to LiteLLM's PostgreSQL database.
+# Format: postgresql://user:password@host:port/dbname
+# Example with default LiteLLM Docker setup:
+# LITELLM_DATABASE_URL=postgresql://llmproxy:dbpassword9090@localhost:5432/litellm
+
+# Backup & Restore Configuration
+# Directory where backup files (.tar.gz) are stored
+# Default: ./data/backups
+# BACKUP_STORAGE_PATH=./data/backups
+
 # LiteLLM Sync
 LITELLM_AUTO_SYNC=true
 LITELLM_SYNC_INTERVAL=60

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -106,6 +106,8 @@ For complete schema and caching details, see [`docs/architecture/database-schema
 
 **User Management Permissions**: `users:read` (admin, adminReadonly — view user details, API keys, subscriptions), `users:write` (admin only — update budget/limits, create/revoke API keys)
 
+**Backup Permissions**: `admin:backup` (admin only — create, download, delete, restore, test-restore backups)
+
 **API Keys**: `Authorization: Bearer sk-litellm-{key}`
 
 **Development**: `MOCK_AUTH=true` for auto-login.
@@ -128,6 +130,7 @@ For details, see [`docs/features/user-roles-administration.md`](../docs/features
 - **Admin**: AdminService, admin-users route (user details, budget/limits, API keys, subscriptions)
 - **Settings**: SettingsService (API key quota defaults and maximums via `system_settings` table)
 - **Branding**: BrandingService (login page and header customization)
+- **Backup**: BackupService (database backup/restore for LiteMaaS and LiteLLM with type-aware SQL serialization)
 
 **Admin Analytics Architecture**: Uses specialized service architecture with orchestrator pattern:
 
@@ -285,7 +288,7 @@ All admin analytics business logic constants are centralized in `src/config/admi
 
 ## 🔗 Environment Variables
 
-Key configuration: DATABASE_URL, JWT_SECRET, OAUTH_CLIENT_ID, LITELLM_API_URL, MOCK_AUTH, plus 15+ admin analytics settings.
+Key configuration: DATABASE_URL, JWT_SECRET, OAUTH_CLIENT_ID, LITELLM_API_URL, MOCK_AUTH, LITELLM_DATABASE_URL (backup/restore), BACKUP_STORAGE_PATH, plus 15+ admin analytics settings.
 
 See [`docs/deployment/configuration.md`](../docs/deployment/configuration.md) and `.env.example` for complete list.
 

--- a/backend/src/plugins/env.ts
+++ b/backend/src/plugins/env.ts
@@ -52,6 +52,10 @@ const envSchema = Type.Object({
   DEFAULT_USER_MAX_BUDGET: Type.String({ default: '100' }),
   DEFAULT_USER_TPM_LIMIT: Type.String({ default: '100000' }),
   DEFAULT_USER_RPM_LIMIT: Type.String({ default: '120' }),
+
+  // Backup Configuration
+  LITELLM_DATABASE_URL: Type.Optional(Type.String()),
+  BACKUP_STORAGE_PATH: Type.Optional(Type.String()),
 });
 
 const envPlugin: FastifyPluginAsync = async (fastify) => {

--- a/backend/src/routes/admin-backup.ts
+++ b/backend/src/routes/admin-backup.ts
@@ -1,0 +1,465 @@
+import { FastifyPluginAsync } from 'fastify';
+import { createReadStream } from 'fs';
+import { ApplicationError } from '../utils/errors';
+import { BackupService } from '../services/backup.service';
+import { BackupDatabaseType } from '../types/backup.types';
+import { AuthenticatedRequest } from '../types';
+
+const adminBackupRoutes: FastifyPluginAsync = async (fastify) => {
+  const backupService = new BackupService(fastify);
+
+  /**
+   * Helper to log audit trail for backup operations
+   */
+  const logAudit = async (
+    userId: string,
+    action: string,
+    resourceId: string,
+    success: boolean,
+    metadata?: any,
+    errorMessage?: string,
+  ) => {
+    try {
+      await fastify.pg.query(
+        `INSERT INTO audit_logs (user_id, action, resource_type, resource_id, success, error_message, metadata, created_at)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, NOW())`,
+        [userId, action, 'backup', resourceId, success, errorMessage || null, metadata || null],
+      );
+    } catch (error) {
+      fastify.log.error({ error }, 'Failed to log audit trail');
+    }
+  };
+
+  // Get backup capabilities
+  fastify.get(
+    '/capabilities',
+    {
+      schema: {
+        tags: ['Admin - Backup'],
+        summary: 'Get backup capabilities',
+        description: 'Check which databases are available for backup and restore operations',
+        security: [{ bearerAuth: [] }],
+      },
+      preHandler: [fastify.authenticate, fastify.requirePermission('admin:backup')],
+    },
+    async (_request, _reply) => {
+      try {
+        const capabilities = await backupService.getCapabilities();
+        return { data: capabilities };
+      } catch (error) {
+        fastify.log.error({ error }, 'Failed to get backup capabilities');
+
+        if (error instanceof ApplicationError) {
+          throw error;
+        }
+
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        throw fastify.createError(500, `Failed to get backup capabilities: ${errorMessage}`);
+      }
+    },
+  );
+
+  // Create a new backup
+  fastify.post<{
+    Body: { database: BackupDatabaseType };
+  }>(
+    '/create',
+    {
+      schema: {
+        tags: ['Admin - Backup'],
+        summary: 'Create a database backup',
+        description: 'Create a compressed backup of the specified database',
+        security: [{ bearerAuth: [] }],
+        body: {
+          type: 'object',
+          required: ['database'],
+          properties: {
+            database: {
+              type: 'string',
+              enum: ['litemaas', 'litellm'],
+              description: 'Database to backup',
+            },
+          },
+        },
+      },
+      preHandler: [fastify.authenticate, fastify.requirePermission('admin:backup')],
+    },
+    async (request, _reply) => {
+      const user = (request as AuthenticatedRequest).user;
+      const { database } = request.body as { database: BackupDatabaseType };
+
+      try {
+        const backupInfo = await backupService.createBackup(database);
+
+        await logAudit(user.userId, 'backup:create', backupInfo.id, true, {
+          database,
+          filename: backupInfo.filename,
+          size: backupInfo.size,
+          tableCount: backupInfo.metadata.tableCount,
+        });
+
+        return { data: backupInfo };
+      } catch (error) {
+        await logAudit(
+          user.userId,
+          'backup:create',
+          database,
+          false,
+          { database },
+          error instanceof Error ? error.message : String(error),
+        );
+
+        fastify.log.error({ error, database }, 'Failed to create backup');
+
+        if (error instanceof ApplicationError) {
+          throw error;
+        }
+
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        throw fastify.createError(500, `Failed to create backup: ${errorMessage}`);
+      }
+    },
+  );
+
+  // List all backups
+  fastify.get(
+    '/',
+    {
+      schema: {
+        tags: ['Admin - Backup'],
+        summary: 'List all backups',
+        description: 'Retrieve a list of all available database backups',
+        security: [{ bearerAuth: [] }],
+      },
+      preHandler: [fastify.authenticate, fastify.requirePermission('admin:backup')],
+    },
+    async (_request, _reply) => {
+      try {
+        const backups = await backupService.listBackups();
+        return { data: backups };
+      } catch (error) {
+        fastify.log.error({ error }, 'Failed to list backups');
+
+        if (error instanceof ApplicationError) {
+          throw error;
+        }
+
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        throw fastify.createError(500, `Failed to list backups: ${errorMessage}`);
+      }
+    },
+  );
+
+  // Get backup info by ID
+  fastify.get<{
+    Params: { id: string };
+  }>(
+    '/:id',
+    {
+      schema: {
+        tags: ['Admin - Backup'],
+        summary: 'Get backup information',
+        description: 'Retrieve detailed information about a specific backup',
+        security: [{ bearerAuth: [] }],
+        params: {
+          type: 'object',
+          required: ['id'],
+          properties: {
+            id: { type: 'string', description: 'Backup ID (filename)' },
+          },
+        },
+      },
+      preHandler: [fastify.authenticate, fastify.requirePermission('admin:backup')],
+    },
+    async (request, _reply) => {
+      const { id } = request.params;
+
+      try {
+        const backups = await backupService.listBackups();
+        const backup = backups.find((b) => b.id === id);
+
+        if (!backup) {
+          throw fastify.createError(404, 'Backup not found');
+        }
+
+        return { data: backup };
+      } catch (error) {
+        fastify.log.error({ error, id }, 'Failed to get backup info');
+
+        if (error instanceof ApplicationError) {
+          throw error;
+        }
+
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        throw fastify.createError(500, `Failed to get backup info: ${errorMessage}`);
+      }
+    },
+  );
+
+  // Download a backup
+  fastify.get<{
+    Params: { id: string };
+  }>(
+    '/:id/download',
+    {
+      schema: {
+        tags: ['Admin - Backup'],
+        summary: 'Download a backup file',
+        description: 'Download the compressed backup file',
+        security: [{ bearerAuth: [] }],
+        params: {
+          type: 'object',
+          required: ['id'],
+          properties: {
+            id: { type: 'string', description: 'Backup ID (filename)' },
+          },
+        },
+      },
+      preHandler: [fastify.authenticate, fastify.requirePermission('admin:backup')],
+    },
+    async (request, reply) => {
+      const user = (request as AuthenticatedRequest).user;
+      const { id } = request.params as { id: string };
+
+      try {
+        const backupPath = backupService.getBackupPath(id);
+
+        // Set headers for download
+        reply.header('Content-Disposition', `attachment; filename="${id}"`);
+        reply.type('application/gzip');
+
+        await logAudit(user.userId, 'backup:download', id, true, { filename: id });
+
+        // Stream the file
+        return reply.send(createReadStream(backupPath));
+      } catch (error) {
+        await logAudit(
+          user.userId,
+          'backup:download',
+          id,
+          false,
+          { filename: id },
+          error instanceof Error ? error.message : String(error),
+        );
+
+        fastify.log.error({ error, id }, 'Failed to download backup');
+
+        if (error instanceof ApplicationError) {
+          throw error;
+        }
+
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        throw fastify.createError(500, `Failed to download backup: ${errorMessage}`);
+      }
+    },
+  );
+
+  // Delete a backup
+  fastify.delete<{
+    Params: { id: string };
+  }>(
+    '/:id',
+    {
+      schema: {
+        tags: ['Admin - Backup'],
+        summary: 'Delete a backup',
+        description: 'Permanently delete a backup file and its metadata',
+        security: [{ bearerAuth: [] }],
+        params: {
+          type: 'object',
+          required: ['id'],
+          properties: {
+            id: { type: 'string', description: 'Backup ID (filename)' },
+          },
+        },
+      },
+      preHandler: [fastify.authenticate, fastify.requirePermission('admin:backup')],
+    },
+    async (request, _reply) => {
+      const user = (request as AuthenticatedRequest).user;
+      const { id } = request.params as { id: string };
+
+      try {
+        await backupService.deleteBackup(id);
+
+        await logAudit(user.userId, 'backup:delete', id, true, { filename: id });
+
+        return { success: true, message: 'Backup deleted successfully' };
+      } catch (error) {
+        await logAudit(
+          user.userId,
+          'backup:delete',
+          id,
+          false,
+          { filename: id },
+          error instanceof Error ? error.message : String(error),
+        );
+
+        fastify.log.error({ error, id }, 'Failed to delete backup');
+
+        if (error instanceof ApplicationError) {
+          throw error;
+        }
+
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        throw fastify.createError(500, `Failed to delete backup: ${errorMessage}`);
+      }
+    },
+  );
+
+  // Restore a backup
+  fastify.post<{
+    Params: { id: string };
+    Body: { database: BackupDatabaseType };
+  }>(
+    '/:id/restore',
+    {
+      schema: {
+        tags: ['Admin - Backup'],
+        summary: 'Restore a backup',
+        description: 'Restore a backup to the specified database (DESTRUCTIVE OPERATION)',
+        security: [{ bearerAuth: [] }],
+        params: {
+          type: 'object',
+          required: ['id'],
+          properties: {
+            id: { type: 'string', description: 'Backup ID (filename)' },
+          },
+        },
+        body: {
+          type: 'object',
+          required: ['database'],
+          properties: {
+            database: {
+              type: 'string',
+              enum: ['litemaas', 'litellm'],
+              description: 'Target database for restore',
+            },
+          },
+        },
+      },
+      preHandler: [fastify.authenticate, fastify.requirePermission('admin:backup')],
+    },
+    async (request, _reply) => {
+      const user = (request as AuthenticatedRequest).user;
+      const { id } = request.params as { id: string };
+      const { database } = request.body as { database: BackupDatabaseType };
+
+      try {
+        const result = await backupService.restoreBackup(id, database);
+
+        await logAudit(user.userId, 'backup:restore', id, true, {
+          filename: id,
+          database,
+          tablesRestored: result.tablesRestored,
+          rowsRestored: result.rowsRestored,
+          duration: result.duration,
+          warnings: result.warnings,
+        });
+
+        return { data: result };
+      } catch (error) {
+        await logAudit(
+          user.userId,
+          'backup:restore',
+          id,
+          false,
+          { filename: id, database },
+          error instanceof Error ? error.message : String(error),
+        );
+
+        fastify.log.error({ error, id, database }, 'Failed to restore backup');
+
+        if (error instanceof ApplicationError) {
+          throw error;
+        }
+
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        throw fastify.createError(500, `Failed to restore backup: ${errorMessage}`);
+      }
+    },
+  );
+
+  // Test restore a backup
+  fastify.post<{
+    Params: { id: string };
+    Body: { database: BackupDatabaseType; testSchemaName?: string };
+  }>(
+    '/:id/test-restore',
+    {
+      schema: {
+        tags: ['Admin - Backup'],
+        summary: 'Test restore a backup',
+        description: 'Test restore a backup to a temporary schema for validation',
+        security: [{ bearerAuth: [] }],
+        params: {
+          type: 'object',
+          required: ['id'],
+          properties: {
+            id: { type: 'string', description: 'Backup ID (filename)' },
+          },
+        },
+        body: {
+          type: 'object',
+          required: ['database'],
+          properties: {
+            database: {
+              type: 'string',
+              enum: ['litemaas', 'litellm'],
+              description: 'Target database for test restore',
+            },
+            testSchemaName: {
+              type: 'string',
+              description: 'Optional custom name for the test schema',
+            },
+          },
+        },
+      },
+      preHandler: [fastify.authenticate, fastify.requirePermission('admin:backup')],
+    },
+    async (request, _reply) => {
+      const user = (request as AuthenticatedRequest).user;
+      const { id } = request.params as { id: string };
+      const { database, testSchemaName } = request.body as {
+        database: BackupDatabaseType;
+        testSchemaName?: string;
+      };
+
+      try {
+        const result = await backupService.testRestore(id, database, testSchemaName);
+
+        await logAudit(user.userId, 'backup:test-restore', id, true, {
+          filename: id,
+          database,
+          testSchema: result.testSchema,
+          tablesRestored: result.tablesRestored,
+          rowsRestored: result.rowsRestored,
+          duration: result.duration,
+          warnings: result.warnings,
+        });
+
+        return { data: result };
+      } catch (error) {
+        await logAudit(
+          user.userId,
+          'backup:test-restore',
+          id,
+          false,
+          { filename: id, database },
+          error instanceof Error ? error.message : String(error),
+        );
+
+        fastify.log.error({ error, id, database }, 'Failed to test restore backup');
+
+        if (error instanceof ApplicationError) {
+          throw error;
+        }
+
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        throw fastify.createError(500, `Failed to test restore backup: ${errorMessage}`);
+      }
+    },
+  );
+};
+
+export default adminBackupRoutes;

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -15,6 +15,7 @@ import adminUsageRoutes from './admin-usage';
 import adminUsersRoutes from './admin-users';
 import adminSettingsRoutes from './admin-settings';
 import adminAuditRoutes from './admin-audit';
+import adminBackupRoutes from './admin-backup';
 import bannerRoutes from './banners';
 import brandingRoutes from './branding';
 
@@ -42,6 +43,7 @@ const routes: FastifyPluginAsync = async (fastify) => {
   await fastify.register(adminUsersRoutes, { prefix: '/admin/users' });
   await fastify.register(adminSettingsRoutes, { prefix: '/admin/settings' });
   await fastify.register(adminAuditRoutes, { prefix: '/admin/audit' });
+  await fastify.register(adminBackupRoutes, { prefix: '/admin/backup' });
 
   // Banner endpoints
   await fastify.register(bannerRoutes, { prefix: '/banners' });

--- a/backend/src/scripts/restore-backup.ts
+++ b/backend/src/scripts/restore-backup.ts
@@ -1,0 +1,241 @@
+#!/usr/bin/env node
+
+/**
+ * CLI Backup Restore Script
+ *
+ * Usage: npx tsx src/scripts/restore-backup.ts --file path/to/backup.sql.gz --database litemaas|litellm
+ *
+ * This script is designed for catastrophic recovery scenarios where the normal
+ * application is unavailable. It directly reads a backup file and restores it
+ * to the specified database.
+ *
+ * IMPORTANT: This is a DESTRUCTIVE operation that will TRUNCATE all tables
+ * and restore from the backup. Always test restore in a non-production environment first.
+ */
+
+import { config } from 'dotenv';
+import { Pool } from 'pg';
+import { promises as fs } from 'fs';
+import * as zlib from 'zlib';
+
+// Load environment variables
+config();
+
+interface RestoreOptions {
+  file: string;
+  database: 'litemaas' | 'litellm';
+}
+
+async function parseArgs(): Promise<RestoreOptions> {
+  const args = process.argv.slice(2);
+  let file: string | undefined;
+  let database: 'litemaas' | 'litellm' | undefined;
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--file' && args[i + 1]) {
+      file = args[i + 1];
+      i++;
+    } else if (args[i] === '--database' && args[i + 1]) {
+      const db = args[i + 1];
+      if (db !== 'litemaas' && db !== 'litellm') {
+        throw new Error('Database must be either "litemaas" or "litellm"');
+      }
+      database = db;
+      i++;
+    }
+  }
+
+  if (!file || !database) {
+    console.error(
+      'Usage: npx tsx src/scripts/restore-backup.ts --file <path> --database <litemaas|litellm>',
+    );
+    console.error('');
+    console.error('Options:');
+    console.error('  --file <path>              Path to the backup file (.sql.gz)');
+    console.error('  --database <litemaas|litellm>  Target database to restore');
+    console.error('');
+    console.error('Example:');
+    console.error(
+      '  npx tsx src/scripts/restore-backup.ts --file ./backups/litemaas-backup-2024-01-01.sql.gz --database litemaas',
+    );
+    process.exit(1);
+  }
+
+  return { file, database };
+}
+
+async function getDatabaseUrl(database: 'litemaas' | 'litellm'): Promise<string> {
+  if (database === 'litemaas') {
+    const url = process.env.DATABASE_URL;
+    if (!url) {
+      throw new Error('DATABASE_URL environment variable is not set');
+    }
+    return url;
+  } else {
+    const url = process.env.LITELLM_DATABASE_URL;
+    if (!url) {
+      throw new Error('LITELLM_DATABASE_URL environment variable is not set');
+    }
+    return url;
+  }
+}
+
+async function readBackup(filePath: string): Promise<{ sqlContent: string; metadata: any }> {
+  console.log(`Reading backup file: ${filePath}`);
+
+  // Read metadata if available
+  const metaPath = `${filePath}.meta.json`;
+  let metadata: any = null;
+
+  try {
+    const metaContent = await fs.readFile(metaPath, 'utf-8');
+    metadata = JSON.parse(metaContent);
+    console.log('Backup metadata:');
+    console.log(`  Database: ${metadata.database}`);
+    console.log(`  Timestamp: ${metadata.timestamp}`);
+    console.log(`  Tables: ${metadata.tableCount}`);
+    console.log(`  Format Version: ${metadata.formatVersion}`);
+  } catch (error) {
+    console.warn('Warning: Could not read metadata file, continuing anyway...');
+  }
+
+  // Read and decompress backup file
+  console.log('Decompressing backup...');
+  const compressedData = await fs.readFile(filePath);
+  const sqlContent = zlib.gunzipSync(compressedData).toString('utf-8');
+
+  console.log(`Backup decompressed successfully (${sqlContent.length} bytes)`);
+
+  return { sqlContent, metadata };
+}
+
+async function restoreBackup(
+  databaseUrl: string,
+  sqlContent: string,
+  metadata: any,
+): Promise<void> {
+  const pool = new Pool({ connectionString: databaseUrl });
+
+  try {
+    console.log('Connecting to database...');
+    const client = await pool.connect();
+
+    try {
+      console.log('Starting transaction...');
+      await client.query('BEGIN');
+
+      console.log('Executing restore SQL...');
+      console.log('⚠️  WARNING: This will TRUNCATE all tables and restore from backup!');
+
+      // Execute the SQL content
+      await client.query(sqlContent);
+
+      console.log('Committing transaction...');
+      await client.query('COMMIT');
+
+      console.log('✅ Restore completed successfully!');
+
+      // Verify restore if metadata is available
+      if (metadata && metadata.rowCounts) {
+        console.log('');
+        console.log('Verifying restore:');
+        for (const [table, expectedCount] of Object.entries(metadata.rowCounts)) {
+          try {
+            const result = await client.query(`SELECT COUNT(*) as count FROM ${table}`);
+            const actualCount = parseInt(result.rows[0].count, 10);
+
+            if (actualCount === expectedCount) {
+              console.log(`  ✓ ${table}: ${actualCount} rows`);
+            } else {
+              console.log(`  ⚠ ${table}: ${actualCount} rows (expected ${expectedCount})`);
+            }
+          } catch (error) {
+            console.log(`  ✗ ${table}: verification failed`);
+          }
+        }
+      }
+    } catch (error) {
+      console.error('Restore failed, rolling back...');
+      await client.query('ROLLBACK');
+      throw error;
+    } finally {
+      client.release();
+    }
+  } finally {
+    await pool.end();
+  }
+}
+
+async function main() {
+  try {
+    console.log('========================================');
+    console.log('LiteMaaS Backup Restore Script');
+    console.log('========================================');
+    console.log('');
+
+    // Parse command line arguments
+    const options = await parseArgs();
+
+    console.log('Configuration:');
+    console.log(`  Backup file: ${options.file}`);
+    console.log(`  Target database: ${options.database}`);
+    console.log('');
+
+    // Verify file exists
+    try {
+      await fs.access(options.file);
+    } catch (error) {
+      throw new Error(`Backup file not found: ${options.file}`);
+    }
+
+    // Get database URL
+    const databaseUrl = await getDatabaseUrl(options.database);
+    console.log(`  Database URL: ${databaseUrl.replace(/:[^:@]+@/, ':****@')}`);
+    console.log('');
+
+    // Confirm with user
+    console.log('⚠️  WARNING: This operation will TRUNCATE all tables and restore from backup!');
+    console.log('⚠️  Make sure you have a backup of your current data before proceeding!');
+    console.log('');
+    console.log('Press Ctrl+C to cancel, or wait 5 seconds to continue...');
+
+    await new Promise((resolve) => setTimeout(resolve, 5000));
+
+    console.log('');
+
+    // Read backup
+    const { sqlContent, metadata } = await readBackup(options.file);
+
+    // Restore backup
+    await restoreBackup(databaseUrl, sqlContent, metadata);
+
+    console.log('');
+    console.log('========================================');
+    console.log('Restore completed successfully!');
+    console.log('========================================');
+
+    process.exit(0);
+  } catch (error) {
+    console.error('');
+    console.error('========================================');
+    console.error('Restore failed!');
+    console.error('========================================');
+    console.error('');
+
+    if (error instanceof Error) {
+      console.error(`Error: ${error.message}`);
+      if (error.stack) {
+        console.error('');
+        console.error('Stack trace:');
+        console.error(error.stack);
+      }
+    } else {
+      console.error(`Error: ${String(error)}`);
+    }
+
+    console.error('');
+    process.exit(1);
+  }
+}
+
+main();

--- a/backend/src/services/backup.service.ts
+++ b/backend/src/services/backup.service.ts
@@ -1,0 +1,684 @@
+import { FastifyInstance } from 'fastify';
+import { BaseService } from './base.service';
+import { Pool } from 'pg';
+import { promises as fs } from 'fs';
+import * as path from 'path';
+import * as zlib from 'zlib';
+import {
+  BackupCapabilities,
+  BackupDatabaseType,
+  BackupInfo,
+  BackupMetadata,
+  RestoreResult,
+  TestRestoreResult,
+} from '../types/backup.types';
+import { ApplicationError } from '../utils/errors';
+
+/**
+ * BackupService - Handles database backup and restore operations
+ *
+ * Extends BaseService for consistent error handling and database operations.
+ * Supports backup/restore for both LiteMaaS and LiteLLM databases.
+ */
+export class BackupService extends BaseService {
+  private readonly BACKUP_FORMAT_VERSION = '1.0.0';
+  private readonly APP_VERSION = '1.0.0';
+  private readonly DEFAULT_STORAGE_PATH = './data/backups';
+
+  // LiteMaaS table order (respects FK dependencies)
+  private readonly LITEMAAS_TABLES = [
+    'users',
+    'teams',
+    'team_members',
+    'models',
+    'subscriptions',
+    'api_keys',
+    'api_key_models',
+    'audit_logs',
+    'refresh_tokens',
+    'oauth_sessions',
+    'banner_announcements',
+    'user_banner_dismissals',
+    'banner_audit_log',
+    'subscription_status_history',
+    'daily_usage_cache',
+    'branding_settings',
+    'system_settings',
+  ];
+
+  constructor(fastify: FastifyInstance) {
+    super(fastify);
+  }
+
+  /**
+   * Get backup capabilities - checks database availability and storage path
+   */
+  async getCapabilities(): Promise<BackupCapabilities> {
+    const litemaasAvailable = !!this.fastify.pg;
+    const litellmConfigured = !!process.env.LITELLM_DATABASE_URL;
+    let litellmAvailable = false;
+
+    if (litellmConfigured) {
+      try {
+        const pool = new Pool({ connectionString: process.env.LITELLM_DATABASE_URL });
+        await pool.query('SELECT 1');
+        litellmAvailable = true;
+        await pool.end();
+      } catch (error) {
+        this.fastify.log.warn({ error }, 'LiteLLM database not available');
+      }
+    }
+
+    const storagePath = process.env.BACKUP_STORAGE_PATH || this.DEFAULT_STORAGE_PATH;
+
+    // Ensure storage directory exists
+    try {
+      await fs.mkdir(storagePath, { recursive: true });
+    } catch (error) {
+      this.fastify.log.error({ error, storagePath }, 'Failed to create backup storage directory');
+    }
+
+    return {
+      litemaasAvailable,
+      litellmAvailable,
+      litellmConfigured,
+      storagePath,
+    };
+  }
+
+  /**
+   * Create a backup of the specified database
+   */
+  async createBackup(dbType: BackupDatabaseType): Promise<BackupInfo> {
+    const capabilities = await this.getCapabilities();
+
+    if (dbType === 'litemaas' && !capabilities.litemaasAvailable) {
+      throw this.createValidationError('LiteMaaS database is not available', 'database');
+    }
+
+    if (dbType === 'litellm' && !capabilities.litellmAvailable) {
+      throw this.createValidationError('LiteLLM database is not available', 'database');
+    }
+
+    const timestamp = new Date().toISOString();
+    const filename = `${dbType}-backup-${timestamp.replace(/:/g, '-')}.sql.gz`;
+    const storagePath = capabilities.storagePath;
+    const backupPath = path.join(storagePath, filename);
+    const metaPath = path.join(storagePath, `${filename}.meta.json`);
+
+    try {
+      // Get database pool
+      let pool: Pool | undefined;
+      let shouldClosePool = false;
+
+      if (dbType === 'litemaas') {
+        pool = this.fastify.pg.pool;
+      } else {
+        pool = new Pool({ connectionString: process.env.LITELLM_DATABASE_URL });
+        shouldClosePool = true;
+      }
+
+      if (!pool) {
+        throw this.createValidationError('Database pool not available', 'database');
+      }
+
+      // Get tables to backup
+      const tables = await this.getTableList(pool, dbType);
+
+      // Generate SQL content
+      const sqlContent = await this.generateBackupSQL(pool, tables, dbType);
+
+      // Compress and save
+      const compressedData = zlib.gzipSync(sqlContent);
+      await fs.writeFile(backupPath, compressedData);
+
+      // Calculate row counts
+      const rowCounts: Record<string, number> = {};
+      for (const table of tables) {
+        const result = await pool.query(
+          `SELECT COUNT(*) as count FROM ${this.quoteIdentifier(table)}`,
+        );
+        rowCounts[table] = parseInt(result.rows[0].count, 10);
+      }
+
+      // Create metadata
+      const metadata: BackupMetadata = {
+        formatVersion: this.BACKUP_FORMAT_VERSION,
+        database: dbType,
+        timestamp,
+        appVersion: this.APP_VERSION,
+        tableCount: tables.length,
+        rowCounts,
+      };
+
+      // Save metadata
+      await fs.writeFile(metaPath, JSON.stringify(metadata, null, 2));
+
+      // Get file size
+      const stats = await fs.stat(backupPath);
+
+      // Close pool if we created it
+      if (shouldClosePool && pool) {
+        await pool.end();
+      }
+
+      const backupInfo: BackupInfo = {
+        id: filename,
+        filename,
+        database: dbType,
+        timestamp,
+        size: stats.size,
+        metadata,
+      };
+
+      this.fastify.log.info({ backupInfo }, 'Backup created successfully');
+
+      return backupInfo;
+    } catch (error) {
+      // Clean up partial files
+      try {
+        await fs.unlink(backupPath);
+      } catch {
+        // Ignore cleanup errors
+      }
+      try {
+        await fs.unlink(metaPath);
+      } catch {
+        // Ignore cleanup errors
+      }
+
+      this.fastify.log.error({ error, dbType }, 'Failed to create backup');
+      throw this.mapDatabaseError(error as Error, 'creating backup');
+    }
+  }
+
+  /**
+   * List all available backups
+   */
+  async listBackups(): Promise<BackupInfo[]> {
+    const capabilities = await this.getCapabilities();
+    const storagePath = capabilities.storagePath;
+
+    try {
+      const files = await fs.readdir(storagePath);
+      const metaFiles = files.filter((f) => f.endsWith('.meta.json'));
+
+      const backups: BackupInfo[] = [];
+
+      for (const metaFile of metaFiles) {
+        const metaPath = path.join(storagePath, metaFile);
+        const backupFile = metaFile.replace('.meta.json', '');
+        const backupPath = path.join(storagePath, backupFile);
+
+        try {
+          // Read metadata
+          const metaContent = await fs.readFile(metaPath, 'utf-8');
+          const metadata: BackupMetadata = JSON.parse(metaContent);
+
+          // Get file size
+          const stats = await fs.stat(backupPath);
+
+          backups.push({
+            id: backupFile,
+            filename: backupFile,
+            database: metadata.database,
+            timestamp: metadata.timestamp,
+            size: stats.size,
+            metadata,
+          });
+        } catch (error) {
+          this.fastify.log.warn({ error, metaFile }, 'Failed to read backup metadata');
+        }
+      }
+
+      // Sort by timestamp descending
+      backups.sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
+
+      return backups;
+    } catch (error) {
+      this.fastify.log.error({ error, storagePath }, 'Failed to list backups');
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      throw ApplicationError.internal('Failed to list backups', { error: errorMessage });
+    }
+  }
+
+  /**
+   * Get the full path for a backup file (with sanitization)
+   */
+  getBackupPath(id: string): string {
+    // Sanitize the ID to prevent path traversal
+    const sanitized = id.replace(/\.\./g, '').replace(/\//g, '').replace(/\\/g, '');
+
+    if (sanitized !== id) {
+      throw this.createValidationError('Invalid backup ID', 'id', id);
+    }
+
+    const capabilities = this.getCapabilitiesSync();
+    return path.join(capabilities.storagePath, sanitized);
+  }
+
+  /**
+   * Delete a backup
+   */
+  async deleteBackup(id: string): Promise<void> {
+    const backupPath = this.getBackupPath(id);
+    const metaPath = `${backupPath}.meta.json`;
+
+    try {
+      // Delete both files
+      await fs.unlink(backupPath);
+      await fs.unlink(metaPath);
+
+      this.fastify.log.info({ id }, 'Backup deleted successfully');
+    } catch (error) {
+      this.fastify.log.error({ error, id }, 'Failed to delete backup');
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      throw ApplicationError.internal('Failed to delete backup', { error: errorMessage });
+    }
+  }
+
+  /**
+   * Restore a backup to the specified database
+   */
+  async restoreBackup(id: string, dbType: BackupDatabaseType): Promise<RestoreResult> {
+    const backupPath = this.getBackupPath(id);
+    const metaPath = `${backupPath}.meta.json`;
+
+    const startTime = Date.now();
+    const warnings: string[] = [];
+
+    try {
+      // Read metadata
+      const metaContent = await fs.readFile(metaPath, 'utf-8');
+      const metadata: BackupMetadata = JSON.parse(metaContent);
+
+      // Validate database type matches
+      if (metadata.database !== dbType) {
+        warnings.push(`Backup was created for ${metadata.database} but restoring to ${dbType}`);
+      }
+
+      // Read and decompress backup
+      const compressedData = await fs.readFile(backupPath);
+      const sqlContent = zlib.gunzipSync(compressedData).toString('utf-8');
+
+      // Get database pool
+      let pool: Pool | undefined;
+      let shouldClosePool = false;
+
+      if (dbType === 'litemaas') {
+        pool = this.fastify.pg.pool;
+      } else {
+        const capabilities = await this.getCapabilities();
+        if (!capabilities.litellmAvailable) {
+          throw this.createValidationError('LiteLLM database is not available', 'database');
+        }
+        pool = new Pool({ connectionString: process.env.LITELLM_DATABASE_URL });
+        shouldClosePool = true;
+      }
+
+      if (!pool) {
+        throw this.createValidationError('Database pool not available', 'database');
+      }
+
+      // Execute restore in transaction
+      const client = await pool.connect();
+      try {
+        await client.query('BEGIN');
+
+        // Execute SQL content
+        await client.query(sqlContent);
+
+        await client.query('COMMIT');
+
+        // Count rows restored
+        let rowsRestored = 0;
+        for (const [_table, count] of Object.entries(metadata.rowCounts)) {
+          rowsRestored += count;
+        }
+
+        const duration = Date.now() - startTime;
+
+        this.fastify.log.info({ id, dbType, duration }, 'Backup restored successfully');
+
+        return {
+          success: true,
+          tablesRestored: metadata.tableCount,
+          rowsRestored,
+          duration,
+          warnings,
+        };
+      } catch (error) {
+        await client.query('ROLLBACK');
+        throw error;
+      } finally {
+        client.release();
+        if (shouldClosePool && pool) {
+          await pool.end();
+        }
+      }
+    } catch (error) {
+      this.fastify.log.error({ error, id, dbType }, 'Failed to restore backup');
+      throw this.mapDatabaseError(error as Error, 'restoring backup');
+    }
+  }
+
+  /**
+   * Test restore - restore to a temporary schema for validation
+   */
+  async testRestore(
+    id: string,
+    dbType: BackupDatabaseType,
+    testSchemaName?: string,
+  ): Promise<TestRestoreResult> {
+    const backupPath = this.getBackupPath(id);
+    const metaPath = `${backupPath}.meta.json`;
+
+    const startTime = Date.now();
+    const warnings: string[] = [];
+    const testSchema = this.sanitizeSchemaName(
+      testSchemaName ||
+        `backup_test_${new Date()
+          .toISOString()
+          .replace(/[-:]/g, '_')
+          .replace(/\.\d+Z$/, '')}`,
+    );
+
+    try {
+      // Read metadata
+      const metaContent = await fs.readFile(metaPath, 'utf-8');
+      const metadata: BackupMetadata = JSON.parse(metaContent);
+
+      // Read and decompress backup
+      const compressedData = await fs.readFile(backupPath);
+      const sqlContent = zlib.gunzipSync(compressedData).toString('utf-8');
+
+      // Get database pool
+      let pool: Pool | undefined;
+      let shouldClosePool = false;
+
+      if (dbType === 'litemaas') {
+        pool = this.fastify.pg.pool;
+      } else {
+        const capabilities = await this.getCapabilities();
+        if (!capabilities.litellmAvailable) {
+          throw this.createValidationError('LiteLLM database is not available', 'database');
+        }
+        pool = new Pool({ connectionString: process.env.LITELLM_DATABASE_URL });
+        shouldClosePool = true;
+      }
+
+      if (!pool) {
+        throw this.createValidationError('Database pool not available', 'database');
+      }
+
+      const client = await pool.connect();
+      try {
+        await client.query('BEGIN');
+
+        // Create test schema
+        await client.query(`CREATE SCHEMA ${testSchema}`);
+
+        // Get tables from metadata
+        const tables = Object.keys(metadata.rowCounts);
+
+        // Copy table structures to test schema (without FK constraints to avoid cross-schema references)
+        for (const table of tables) {
+          const quotedTable = this.quoteIdentifier(table);
+          await client.query(
+            `CREATE TABLE ${testSchema}.${quotedTable} (LIKE public.${quotedTable} INCLUDING DEFAULTS INCLUDING INDEXES)`,
+          );
+        }
+
+        // Modify SQL to use test schema
+        const testSqlContent = this.modifySQLForSchema(sqlContent, testSchema);
+
+        // Execute restore in test schema
+        await client.query(testSqlContent);
+
+        await client.query('COMMIT');
+
+        // Verify row counts
+        let rowsRestored = 0;
+        for (const [table, expectedCount] of Object.entries(metadata.rowCounts)) {
+          const result = await client.query(
+            `SELECT COUNT(*) as count FROM ${testSchema}.${this.quoteIdentifier(table)}`,
+          );
+          const actualCount = parseInt(result.rows[0].count, 10);
+          rowsRestored += actualCount;
+
+          if (actualCount !== expectedCount) {
+            warnings.push(
+              `Table ${table}: expected ${expectedCount} rows, got ${actualCount} rows`,
+            );
+          }
+        }
+
+        const duration = Date.now() - startTime;
+
+        this.fastify.log.info(
+          { id, dbType, testSchema, duration },
+          'Test restore completed successfully',
+        );
+
+        return {
+          success: true,
+          tablesRestored: metadata.tableCount,
+          rowsRestored,
+          duration,
+          warnings,
+          testSchema,
+        };
+      } catch (error) {
+        await client.query('ROLLBACK');
+        throw error;
+      } finally {
+        client.release();
+        if (shouldClosePool && pool) {
+          await pool.end();
+        }
+      }
+    } catch (error) {
+      this.fastify.log.error({ error, id, dbType }, 'Test restore failed');
+      throw this.mapDatabaseError(error as Error, 'testing restore');
+    }
+  }
+
+  /**
+   * Quote a SQL identifier (table or column name) to handle mixed-case names.
+   * PostgreSQL lowercases unquoted identifiers, so tables created with quotes
+   * (e.g., LiteLLM's "LiteLLM_AgentsTable") must always be quoted.
+   */
+  private quoteIdentifier(name: string): string {
+    return `"${name.replace(/"/g, '""')}"`;
+  }
+
+  /**
+   * Get table list for backup
+   */
+  private async getTableList(pool: Pool, dbType: BackupDatabaseType): Promise<string[]> {
+    if (dbType === 'litemaas') {
+      return this.LITEMAAS_TABLES;
+    } else {
+      // For LiteLLM, discover tables dynamically
+      const result = await pool.query(`
+        SELECT tablename
+        FROM pg_tables
+        WHERE schemaname = 'public'
+        ORDER BY tablename
+      `);
+      return result.rows.map((row) => row.tablename);
+    }
+  }
+
+  // PostgreSQL OIDs for type-aware serialization
+  private readonly PG_JSON_OID = 114;
+  private readonly PG_JSONB_OID = 3802;
+  private readonly PG_TIMESTAMP_OID = 1114;
+  private readonly PG_TIMESTAMPTZ_OID = 1184;
+
+  /**
+   * Generate SQL content for backup
+   */
+  private async generateBackupSQL(
+    pool: Pool,
+    tables: string[],
+    dbType: BackupDatabaseType,
+  ): Promise<string> {
+    let sql = `-- Database backup for ${dbType}\n`;
+    sql += `-- Generated at ${new Date().toISOString()}\n\n`;
+
+    for (const table of tables) {
+      const quotedTable = this.quoteIdentifier(table);
+      sql += `-- Table: ${table}\n`;
+      sql += `TRUNCATE TABLE ${quotedTable} CASCADE;\n`;
+
+      // First, get column metadata to identify types
+      const metaResult = await pool.query(`SELECT * FROM ${quotedTable} LIMIT 0`);
+      const fields = metaResult.fields;
+
+      if (fields.length > 0) {
+        const columns = fields.map((f) => f.name);
+        const quotedColumns = columns.map((c) => this.quoteIdentifier(c)).join(', ');
+
+        // Build sets of columns by type for proper serialization
+        const jsonColumns = new Set(
+          fields
+            .filter((f) => f.dataTypeID === this.PG_JSON_OID || f.dataTypeID === this.PG_JSONB_OID)
+            .map((f) => f.name),
+        );
+        const timestampColumns = new Set(
+          fields
+            .filter(
+              (f) =>
+                f.dataTypeID === this.PG_TIMESTAMP_OID ||
+                f.dataTypeID === this.PG_TIMESTAMPTZ_OID,
+            )
+            .map((f) => f.name),
+        );
+
+        // Cast timestamp columns to text in the query to preserve exact precision and timezone
+        const selectColumns = fields
+          .map((f) => {
+            if (
+              f.dataTypeID === this.PG_TIMESTAMP_OID ||
+              f.dataTypeID === this.PG_TIMESTAMPTZ_OID
+            ) {
+              return `${this.quoteIdentifier(f.name)}::text AS ${this.quoteIdentifier(f.name)}`;
+            }
+            return this.quoteIdentifier(f.name);
+          })
+          .join(', ');
+
+        // Get all rows with timestamps as text
+        const result = await pool.query(`SELECT ${selectColumns} FROM ${quotedTable}`);
+
+        // Generate INSERT statements
+        for (const row of result.rows) {
+          const values = columns.map((col) =>
+            this.escapeSQLValue(row[col], jsonColumns.has(col), timestampColumns.has(col)),
+          );
+          sql += `INSERT INTO ${quotedTable} (${quotedColumns}) VALUES (${values.join(', ')});\n`;
+        }
+      }
+
+      sql += '\n';
+    }
+
+    return sql;
+  }
+
+  /**
+   * Escape SQL value for safe insertion.
+   * @param isJsonColumn - true if the column is JSON/JSONB type (arrays should stay as JSON, not PG array syntax)
+   * @param isTimestamp - true if the column is a timestamp type (value arrives as pre-formatted text string)
+   */
+  private escapeSQLValue(value: any, isJsonColumn = false, isTimestamp = false): string {
+    if (value === null || value === undefined) {
+      return 'NULL';
+    }
+
+    // Timestamp columns are cast to text in the SELECT query, so they arrive as exact strings
+    if (isTimestamp && typeof value === 'string') {
+      return `'${value}'`;
+    }
+
+    if (typeof value === 'boolean') {
+      return value ? 'true' : 'false';
+    }
+
+    if (typeof value === 'number') {
+      return value.toString();
+    }
+
+    if (value instanceof Date) {
+      return `'${value.toISOString()}'`;
+    }
+
+    if (Array.isArray(value)) {
+      if (isJsonColumn) {
+        // JSON/JSONB column: serialize as JSON array
+        return `'${JSON.stringify(value).replace(/'/g, "''")}'`;
+      }
+      // PostgreSQL array column (TEXT[], etc.): use PG array literal syntax
+      const elements = value.map((v) => {
+        if (v === null || v === undefined) return 'NULL';
+        const escaped = String(v).replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+        return `"${escaped}"`;
+      });
+      return `'{${elements.join(',')}}'`;
+    }
+
+    if (typeof value === 'object') {
+      // Handle JSON/JSONB columns (objects are always serialized as JSON)
+      return `'${JSON.stringify(value).replace(/'/g, "''")}'`;
+    }
+
+    // String values - escape single quotes
+    return `'${String(value).replace(/'/g, "''")}'`;
+  }
+
+  /**
+   * Modify SQL to use a specific schema
+   */
+  private modifySQLForSchema(sql: string, schema: string): string {
+    // Replace table references with schema-qualified references
+    // Handles both quoted ("table") and unquoted (table) identifiers
+    const lines = sql.split('\n');
+    return lines
+      .map((line) => {
+        if (line.startsWith('TRUNCATE TABLE ')) {
+          return line.replace('TRUNCATE TABLE ', `TRUNCATE TABLE ${schema}.`);
+        }
+        if (line.startsWith('INSERT INTO ')) {
+          return line.replace('INSERT INTO ', `INSERT INTO ${schema}.`);
+        }
+        return line;
+      })
+      .join('\n');
+  }
+
+  /**
+   * Synchronous version of getCapabilities (for path operations)
+   */
+  private getCapabilitiesSync(): { storagePath: string } {
+    return {
+      storagePath: process.env.BACKUP_STORAGE_PATH || this.DEFAULT_STORAGE_PATH,
+    };
+  }
+
+  /**
+   * Sanitize schema name to prevent SQL injection
+   */
+  private sanitizeSchemaName(name: string): string {
+    // Only allow alphanumeric characters and underscores
+    const sanitized = name.replace(/[^a-zA-Z0-9_]/g, '_');
+    if (sanitized.length === 0 || sanitized.length > 63) {
+      throw this.createValidationError(
+        'Schema name must be 1-63 characters, alphanumeric and underscores only',
+        'testSchemaName',
+        name,
+      );
+    }
+    return sanitized;
+  }
+}

--- a/backend/src/services/rbac.service.ts
+++ b/backend/src/services/rbac.service.ts
@@ -194,6 +194,13 @@ export class RBACService {
       resource: 'admin',
       action: 'usage',
     },
+    {
+      id: 'admin:backup',
+      name: 'Database Backup',
+      description: 'Create, restore, and manage database backups',
+      resource: 'admin',
+      action: 'backup',
+    },
   ];
 
   // System roles
@@ -207,6 +214,7 @@ export class RBACService {
         'admin:users',
         'admin:audit',
         'admin:usage',
+        'admin:backup',
         'admin:banners:read',
         'admin:banners:write',
         'admin:subscriptions:read',

--- a/backend/src/types/backup.types.ts
+++ b/backend/src/types/backup.types.ts
@@ -1,0 +1,38 @@
+export type BackupDatabaseType = 'litemaas' | 'litellm';
+
+export interface BackupMetadata {
+  formatVersion: string;
+  database: BackupDatabaseType;
+  timestamp: string;
+  appVersion: string;
+  tableCount: number;
+  rowCounts: Record<string, number>;
+}
+
+export interface BackupCapabilities {
+  litemaasAvailable: boolean;
+  litellmAvailable: boolean;
+  litellmConfigured: boolean;
+  storagePath: string;
+}
+
+export interface BackupInfo {
+  id: string;
+  filename: string;
+  database: BackupDatabaseType;
+  timestamp: string;
+  size: number;
+  metadata: BackupMetadata;
+}
+
+export interface RestoreResult {
+  success: boolean;
+  tablesRestored: number;
+  rowsRestored: number;
+  duration: number;
+  warnings: string[];
+}
+
+export interface TestRestoreResult extends RestoreResult {
+  testSchema: string;
+}

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -152,6 +152,7 @@ See [`docs/architecture/project-structure.md`](../docs/architecture/project-stru
 - `chat.service.ts` - Chatbot integration
 - `config.service.ts` - Application configuration and API key quota defaults
 - `admin.service.ts` - Admin operations (API key quota defaults CRUD, bulk user limits, system stats)
+- `backup.service.ts` - **Database backup & restore** (capabilities, create, list, download, delete, restore, test-restore)
 
 ## 🌍 Routing Structure
 
@@ -178,8 +179,9 @@ See [`docs/architecture/project-structure.md`](../docs/architecture/project-stru
   - Budget and rate limit configuration with progress indicators
   - API key creation with auto-subscription and revocation
   - RBAC: admin (full access) vs adminReadonly (view only)
-- `/admin/tools` - **Settings and Tools (ToolsPage.tsx)** - Tabs: Limits, Banners, Branding, Currency, Models Sync
+- `/admin/tools` - **Settings and Tools (ToolsPage.tsx)** - Tabs: Limits, Banners, Branding, Currency, Models Sync, Backup
   - Limits tab: Bulk User Limits (max budget, TPM, RPM for all users) and API Key Quota Defaults (admin-configurable defaults and maximums)
+  - Backup tab: Create/restore/test-restore/download/delete database backups for LiteMaaS and LiteLLM (admin only, visible read-only for adminReadonly)
 
 **Protection**: `ProtectedRoute` for auth, `RoleProtectedRoute` for admin routes with required roles
 

--- a/frontend/src/components/backup/BackupTab.tsx
+++ b/frontend/src/components/backup/BackupTab.tsx
@@ -1,0 +1,665 @@
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useQuery, useMutation, useQueryClient } from 'react-query';
+import {
+  Card,
+  CardBody,
+  CardTitle,
+  Button,
+  Alert,
+  Modal,
+  ModalVariant,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  TextInput,
+  Split,
+  SplitItem,
+  Flex,
+  FlexItem,
+  Spinner,
+  EmptyState,
+  EmptyStateBody,
+  DescriptionList,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  DescriptionListDescription,
+  Tooltip,
+} from '@patternfly/react-core';
+import { Table, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
+import {
+  DownloadIcon,
+  UndoIcon,
+  TrashIcon,
+  CheckCircleIcon,
+  DatabaseIcon,
+} from '@patternfly/react-icons';
+import { useNotifications } from '../../contexts/NotificationContext';
+import {
+  backupService,
+  type BackupDatabaseType,
+  type BackupInfo,
+  type TestRestoreResult,
+} from '../../services/backup.service';
+import { extractErrorDetails } from '../../utils/error.utils';
+
+interface BackupTabProps {
+  canManage: boolean;
+}
+
+const BackupTab: React.FC<BackupTabProps> = ({ canManage }) => {
+  const { t } = useTranslation();
+  const { addNotification } = useNotifications();
+  const queryClient = useQueryClient();
+
+  // Modal states
+  const [restoreModalBackup, setRestoreModalBackup] = useState<BackupInfo | null>(null);
+  const [deleteModalBackup, setDeleteModalBackup] = useState<BackupInfo | null>(null);
+  const [testRestoreModalBackup, setTestRestoreModalBackup] = useState<BackupInfo | null>(null);
+  const [testRestoreSchemaName, setTestRestoreSchemaName] = useState('');
+  const [testRestoreResult, setTestRestoreResult] = useState<TestRestoreResult | null>(null);
+  const [confirmInput, setConfirmInput] = useState('');
+  // Queries
+  const { data: capabilities, isLoading: capabilitiesLoading } = useQuery(
+    ['backupCapabilities'],
+    () => backupService.getCapabilities(),
+  );
+
+  const { data: backups = [], isLoading: backupsLoading } = useQuery(['backupList'], () =>
+    backupService.listBackups(),
+  );
+
+  // Mutations
+  const createLitemaasBackup = useMutation(() => backupService.createBackup('litemaas'), {
+    onSuccess: () => {
+      queryClient.invalidateQueries(['backupList']);
+      addNotification({
+        variant: 'success',
+        title: t('pages.tools.backup.notifications.backupCreated'),
+      });
+    },
+    onError: (error: Error) => {
+      addNotification({
+        variant: 'danger',
+        title: t('pages.tools.backup.notifications.error'),
+        description: extractErrorDetails(error).message || undefined,
+      });
+    },
+  });
+
+  const createLitellmBackup = useMutation(() => backupService.createBackup('litellm'), {
+    onSuccess: () => {
+      queryClient.invalidateQueries(['backupList']);
+      addNotification({
+        variant: 'success',
+        title: t('pages.tools.backup.notifications.backupCreated'),
+      });
+    },
+    onError: (error: Error) => {
+      addNotification({
+        variant: 'danger',
+        title: t('pages.tools.backup.notifications.error'),
+        description: extractErrorDetails(error).message || undefined,
+      });
+    },
+  });
+
+  const deleteBackupMutation = useMutation((id: string) => backupService.deleteBackup(id), {
+    onSuccess: () => {
+      queryClient.invalidateQueries(['backupList']);
+      addNotification({
+        variant: 'success',
+        title: t('pages.tools.backup.notifications.backupDeleted'),
+      });
+      setDeleteModalBackup(null);
+    },
+    onError: (error: Error) => {
+      addNotification({
+        variant: 'danger',
+        title: t('pages.tools.backup.notifications.error'),
+        description: extractErrorDetails(error).message || undefined,
+      });
+    },
+  });
+
+  const restoreBackupMutation = useMutation(
+    ({ id, database }: { id: string; database: BackupDatabaseType }) =>
+      backupService.restoreBackup(id, database),
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries(['backupList']);
+        addNotification({
+          variant: 'success',
+          title: t('pages.tools.backup.notifications.restoreSuccess'),
+        });
+        setRestoreModalBackup(null);
+        setConfirmInput('');
+      },
+      onError: (error: Error) => {
+        addNotification({
+          variant: 'danger',
+          title: t('pages.tools.backup.notifications.error'),
+          description: extractErrorDetails(error).message || undefined,
+        });
+      },
+    },
+  );
+
+  const testRestoreMutation = useMutation(
+    ({
+      id,
+      database,
+      testSchemaName,
+    }: {
+      id: string;
+      database: BackupDatabaseType;
+      testSchemaName?: string;
+    }) => backupService.testRestoreBackup(id, database, testSchemaName),
+    {
+      onSuccess: (result: TestRestoreResult) => {
+        setTestRestoreResult(result);
+        setTestRestoreModalBackup(null);
+        addNotification({
+          variant: result.success ? 'success' : 'warning',
+          title: t('pages.tools.backup.notifications.testRestoreComplete'),
+        });
+      },
+      onError: (error: Error) => {
+        addNotification({
+          variant: 'danger',
+          title: t('pages.tools.backup.notifications.error'),
+          description: extractErrorDetails(error).message || undefined,
+        });
+      },
+    },
+  );
+
+  // Handlers
+
+  const handleDownload = async (backup: BackupInfo) => {
+    try {
+      await backupService.downloadBackup(backup.id);
+    } catch (error) {
+      addNotification({
+        variant: 'danger',
+        title: t('pages.tools.backup.notifications.error'),
+        description: extractErrorDetails(error).message || undefined,
+      });
+    }
+  };
+
+  const handleRestore = () => {
+    if (restoreModalBackup && confirmInput === restoreModalBackup.database) {
+      restoreBackupMutation.mutate({
+        id: restoreModalBackup.id,
+        database: restoreModalBackup.database,
+      });
+    }
+  };
+
+  const handleOpenTestRestore = (backup: BackupInfo) => {
+    setTestRestoreSchemaName(
+      `backup_test_${new Date()
+        .toISOString()
+        .replace(/[-:]/g, '_')
+        .replace(/\.\d+Z$/, '')}`,
+    );
+    setTestRestoreModalBackup(backup);
+  };
+
+  const handleConfirmTestRestore = () => {
+    if (testRestoreModalBackup) {
+      testRestoreMutation.mutate({
+        id: testRestoreModalBackup.id,
+        database: testRestoreModalBackup.database,
+        testSchemaName: testRestoreSchemaName || undefined,
+      });
+    }
+  };
+
+  const handleDelete = () => {
+    if (deleteModalBackup) {
+      deleteBackupMutation.mutate(deleteModalBackup.id);
+    }
+  };
+
+  // Format bytes to human-readable size
+  const formatSize = (bytes: number): string => {
+    if (bytes === 0) return '0 B';
+    const k = 1024;
+    const sizes = ['B', 'KB', 'MB', 'GB'];
+    const i = Math.floor(Math.log(bytes) / Math.log(k));
+    return `${(bytes / Math.pow(k, i)).toFixed(2)} ${sizes[i]}`;
+  };
+
+  // Format timestamp to locale string
+  const formatTimestamp = (timestamp: string): string => {
+    return new Date(timestamp).toLocaleString();
+  };
+
+  if (capabilitiesLoading) {
+    return (
+      <Flex justifyContent={{ default: 'justifyContentCenter' }} style={{ padding: '40px' }}>
+        <Spinner size="lg" />
+      </Flex>
+    );
+  }
+
+  return (
+    <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsMd' }}>
+      {/* Top Section: Database Cards */}
+      <FlexItem>
+        <Split hasGutter>
+          {/* LiteMaaS Card */}
+          <SplitItem isFilled>
+            <Card isCompact>
+              <CardTitle>{t('pages.tools.backup.litemaasCard.title')}</CardTitle>
+              <CardBody>
+                <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsSm' }}>
+                  <FlexItem>
+                    <p>{t('pages.tools.backup.litemaasCard.description')}</p>
+                  </FlexItem>
+                  <FlexItem>
+                    <Button
+                      variant="primary"
+                      onClick={() => createLitemaasBackup.mutate()}
+                      isDisabled={!canManage || createLitemaasBackup.isLoading}
+                      isLoading={createLitemaasBackup.isLoading}
+                      icon={<DatabaseIcon />}
+                    >
+                      {createLitemaasBackup.isLoading
+                        ? t('pages.tools.backup.creating')
+                        : t('pages.tools.backup.createBackup')}
+                    </Button>
+                  </FlexItem>
+                </Flex>
+              </CardBody>
+            </Card>
+          </SplitItem>
+
+          {/* LiteLLM Card */}
+          <SplitItem isFilled>
+            <Card isCompact>
+              <CardTitle>{t('pages.tools.backup.litellmCard.title')}</CardTitle>
+              <CardBody>
+                <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsSm' }}>
+                  <FlexItem>
+                    <p>{t('pages.tools.backup.litellmCard.description')}</p>
+                  </FlexItem>
+                  {capabilities?.litellmConfigured ? (
+                    <FlexItem>
+                      <Button
+                        variant="primary"
+                        onClick={() => createLitellmBackup.mutate()}
+                        isDisabled={!canManage || createLitellmBackup.isLoading}
+                        isLoading={createLitellmBackup.isLoading}
+                        icon={<DatabaseIcon />}
+                      >
+                        {createLitellmBackup.isLoading
+                          ? t('pages.tools.backup.creating')
+                          : t('pages.tools.backup.createBackup')}
+                      </Button>
+                    </FlexItem>
+                  ) : (
+                    <FlexItem>
+                      <Alert
+                        variant="info"
+                        isInline
+                        title={t('pages.tools.backup.litellmCard.notConfigured')}
+                      />
+                    </FlexItem>
+                  )}
+                </Flex>
+              </CardBody>
+            </Card>
+          </SplitItem>
+        </Split>
+      </FlexItem>
+
+      {/* Bottom Section: Backups Table */}
+      <FlexItem>
+        <Card>
+          <CardBody>
+            {backupsLoading ? (
+              <Flex
+                justifyContent={{ default: 'justifyContentCenter' }}
+                style={{ padding: '40px' }}
+              >
+                <Spinner size="lg" />
+              </Flex>
+            ) : backups.length === 0 ? (
+              <EmptyState
+                headingLevel="h4"
+                titleText={t('pages.tools.backup.table.empty')}
+                icon={DatabaseIcon}
+              >
+                <EmptyStateBody>{t('pages.tools.backup.table.emptyDescription')}</EmptyStateBody>
+              </EmptyState>
+            ) : (
+              <Table aria-label="Backups table" variant="compact">
+                <Thead>
+                  <Tr>
+                    <Th screenReaderText={t('pages.tools.backup.table.database')}>
+                      {t('pages.tools.backup.table.database')}
+                    </Th>
+                    <Th screenReaderText={t('pages.tools.backup.table.timestamp')}>
+                      {t('pages.tools.backup.table.timestamp')}
+                    </Th>
+                    <Th screenReaderText={t('pages.tools.backup.table.size')}>
+                      {t('pages.tools.backup.table.size')}
+                    </Th>
+                    <Th screenReaderText={t('pages.tools.backup.table.actions')}>
+                      {t('pages.tools.backup.table.actions')}
+                    </Th>
+                  </Tr>
+                </Thead>
+                <Tbody>
+                  {backups.map((backup: BackupInfo) => (
+                    <Tr key={backup.id}>
+                      <Td>{backup.database}</Td>
+                      <Td>{formatTimestamp(backup.timestamp)}</Td>
+                      <Td>{formatSize(backup.size)}</Td>
+                      <Td>
+                        <Flex spaceItems={{ default: 'spaceItemsNone' }}>
+                          <FlexItem>
+                            <Tooltip content={t('pages.tools.backup.download')}>
+                              <Button
+                                variant="plain"
+                                aria-label={t('pages.tools.backup.download')}
+                                onClick={() => handleDownload(backup)}
+                                icon={<DownloadIcon />}
+                              />
+                            </Tooltip>
+                          </FlexItem>
+                          <FlexItem>
+                            <Tooltip content={t('pages.tools.backup.testRestore')}>
+                              <Button
+                                variant="plain"
+                                aria-label={t('pages.tools.backup.testRestore')}
+                                onClick={() => handleOpenTestRestore(backup)}
+                                isDisabled={!canManage || testRestoreMutation.isLoading}
+                                icon={<CheckCircleIcon />}
+                              />
+                            </Tooltip>
+                          </FlexItem>
+                          <FlexItem>
+                            <Tooltip content={t('pages.tools.backup.restore')}>
+                              <Button
+                                variant="plain"
+                                aria-label={t('pages.tools.backup.restore')}
+                                onClick={() => setRestoreModalBackup(backup)}
+                                isDisabled={!canManage}
+                                icon={<UndoIcon />}
+                              />
+                            </Tooltip>
+                          </FlexItem>
+                          <FlexItem>
+                            <Tooltip content={t('pages.tools.backup.delete')}>
+                              <Button
+                                variant="plain"
+                                aria-label={t('pages.tools.backup.delete')}
+                                onClick={() => setDeleteModalBackup(backup)}
+                                isDisabled={!canManage}
+                                isDanger
+                                icon={<TrashIcon />}
+                              />
+                            </Tooltip>
+                          </FlexItem>
+                        </Flex>
+                      </Td>
+                    </Tr>
+                  ))}
+                </Tbody>
+              </Table>
+            )}
+          </CardBody>
+        </Card>
+      </FlexItem>
+
+      {/* Restore Confirmation Modal */}
+      {restoreModalBackup && (
+        <Modal
+          variant={ModalVariant.small}
+          isOpen={true}
+          onClose={() => {
+            setRestoreModalBackup(null);
+            setConfirmInput('');
+          }}
+          aria-labelledby="restore-modal-title"
+        >
+          <ModalHeader
+            title={t('pages.tools.backup.restoreModal.title')}
+            labelId="restore-modal-title"
+          />
+          <ModalBody>
+            <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsMd' }}>
+              <FlexItem>
+                <Alert
+                  variant="danger"
+                  isInline
+                  title={t('pages.tools.backup.restoreModal.warning', {
+                    database: restoreModalBackup.database,
+                    timestamp: formatTimestamp(restoreModalBackup.timestamp),
+                  })}
+                />
+              </FlexItem>
+              <FlexItem>
+                <TextInput
+                  id="confirm-restore-input"
+                  value={confirmInput}
+                  onChange={(_event, value) => setConfirmInput(value)}
+                  placeholder={t('pages.tools.backup.restoreModal.confirmPlaceholder')}
+                  aria-label={t('pages.tools.backup.restoreModal.typeToConfirm', {
+                    database: restoreModalBackup.database,
+                  })}
+                />
+                <p style={{ marginTop: '8px', fontSize: 'var(--pf-t--global--font--size--sm)' }}>
+                  {t('pages.tools.backup.restoreModal.typeToConfirm', {
+                    database: restoreModalBackup.database,
+                  })}
+                </p>
+              </FlexItem>
+            </Flex>
+          </ModalBody>
+          <ModalFooter>
+            <Button
+              variant="danger"
+              onClick={handleRestore}
+              isDisabled={
+                confirmInput !== restoreModalBackup.database || restoreBackupMutation.isLoading
+              }
+              isLoading={restoreBackupMutation.isLoading}
+            >
+              {t('pages.tools.backup.restore')}
+            </Button>
+            <Button
+              variant="link"
+              onClick={() => {
+                setRestoreModalBackup(null);
+                setConfirmInput('');
+              }}
+            >
+              {t('common.cancel')}
+            </Button>
+          </ModalFooter>
+        </Modal>
+      )}
+
+      {/* Delete Confirmation Modal */}
+      {deleteModalBackup && (
+        <Modal
+          variant={ModalVariant.small}
+          isOpen={true}
+          onClose={() => setDeleteModalBackup(null)}
+          aria-labelledby="delete-modal-title"
+        >
+          <ModalHeader
+            title={t('pages.tools.backup.deleteModal.title')}
+            labelId="delete-modal-title"
+          />
+          <ModalBody>
+            <p>
+              {t('pages.tools.backup.deleteModal.message', {
+                filename: deleteModalBackup.filename,
+              })}
+            </p>
+          </ModalBody>
+          <ModalFooter>
+            <Button
+              variant="danger"
+              onClick={handleDelete}
+              isDisabled={deleteBackupMutation.isLoading}
+              isLoading={deleteBackupMutation.isLoading}
+            >
+              {t('pages.tools.backup.delete')}
+            </Button>
+            <Button variant="link" onClick={() => setDeleteModalBackup(null)}>
+              {t('common.cancel')}
+            </Button>
+          </ModalFooter>
+        </Modal>
+      )}
+
+      {/* Test Restore Confirmation Modal */}
+      {testRestoreModalBackup && (
+        <Modal
+          variant={ModalVariant.small}
+          isOpen={true}
+          onClose={() => setTestRestoreModalBackup(null)}
+          aria-labelledby="test-restore-confirm-modal-title"
+        >
+          <ModalHeader
+            title={t('pages.tools.backup.testRestoreConfirmModal.title')}
+            labelId="test-restore-confirm-modal-title"
+          />
+          <ModalBody>
+            <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsMd' }}>
+              <FlexItem>
+                <Alert
+                  variant="info"
+                  isInline
+                  title={t('pages.tools.backup.testRestoreConfirmModal.description', {
+                    database: testRestoreModalBackup.database,
+                    timestamp: formatTimestamp(testRestoreModalBackup.timestamp),
+                  })}
+                />
+              </FlexItem>
+              <FlexItem>
+                <TextInput
+                  id="test-restore-schema-name"
+                  value={testRestoreSchemaName}
+                  onChange={(_event, value) => setTestRestoreSchemaName(value)}
+                  aria-label={t('pages.tools.backup.testRestoreConfirmModal.schemaNameLabel')}
+                />
+                <p style={{ marginTop: '8px', fontSize: 'var(--pf-t--global--font--size--sm)' }}>
+                  {t('pages.tools.backup.testRestoreConfirmModal.schemaNameHelper')}
+                </p>
+              </FlexItem>
+            </Flex>
+          </ModalBody>
+          <ModalFooter>
+            <Button
+              variant="primary"
+              onClick={handleConfirmTestRestore}
+              isDisabled={!testRestoreSchemaName || testRestoreMutation.isLoading}
+              isLoading={testRestoreMutation.isLoading}
+            >
+              {t('pages.tools.backup.testRestore')}
+            </Button>
+            <Button variant="link" onClick={() => setTestRestoreModalBackup(null)}>
+              {t('common.cancel')}
+            </Button>
+          </ModalFooter>
+        </Modal>
+      )}
+
+      {/* Test Restore Result Modal */}
+      {testRestoreResult && (
+        <Modal
+          variant={ModalVariant.small}
+          isOpen={true}
+          onClose={() => setTestRestoreResult(null)}
+          aria-labelledby="test-restore-modal-title"
+        >
+          <ModalHeader
+            title={t('pages.tools.backup.testRestoreModal.title')}
+            labelId="test-restore-modal-title"
+          />
+          <ModalBody>
+            <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsMd' }}>
+              <FlexItem>
+                <Alert
+                  variant={testRestoreResult.success ? 'success' : 'danger'}
+                  isInline
+                  title={
+                    testRestoreResult.success
+                      ? t('pages.tools.backup.testRestoreModal.success')
+                      : t('pages.tools.backup.testRestoreModal.failure')
+                  }
+                />
+              </FlexItem>
+              <FlexItem>
+                <DescriptionList isCompact>
+                  <DescriptionListGroup>
+                    <DescriptionListTerm>
+                      {t('pages.tools.backup.testRestoreModal.tablesRestored')}
+                    </DescriptionListTerm>
+                    <DescriptionListDescription>
+                      {testRestoreResult.tablesRestored}
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>
+                  <DescriptionListGroup>
+                    <DescriptionListTerm>
+                      {t('pages.tools.backup.testRestoreModal.rowsRestored')}
+                    </DescriptionListTerm>
+                    <DescriptionListDescription>
+                      {testRestoreResult.rowsRestored}
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>
+                  <DescriptionListGroup>
+                    <DescriptionListTerm>
+                      {t('pages.tools.backup.testRestoreModal.duration')}
+                    </DescriptionListTerm>
+                    <DescriptionListDescription>
+                      {testRestoreResult.duration.toFixed(2)}s
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>
+                  <DescriptionListGroup>
+                    <DescriptionListTerm>
+                      {t('pages.tools.backup.testRestoreModal.testSchema')}
+                    </DescriptionListTerm>
+                    <DescriptionListDescription>
+                      {testRestoreResult.testSchema}
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>
+                </DescriptionList>
+              </FlexItem>
+              {testRestoreResult.warnings.length > 0 && (
+                <FlexItem>
+                  <Alert
+                    variant="warning"
+                    isInline
+                    title={t('pages.tools.backup.testRestoreModal.warnings')}
+                  >
+                    <ul style={{ marginTop: '8px' }}>
+                      {testRestoreResult.warnings.map((warning, index) => (
+                        <li key={index}>{warning}</li>
+                      ))}
+                    </ul>
+                  </Alert>
+                </FlexItem>
+              )}
+            </Flex>
+          </ModalBody>
+          <ModalFooter>
+            <Button variant="primary" onClick={() => setTestRestoreResult(null)}>
+              {t('common.close')}
+            </Button>
+          </ModalFooter>
+        </Modal>
+      )}
+    </Flex>
+  );
+};
+
+export default BackupTab;

--- a/frontend/src/constants/auditCategories.ts
+++ b/frontend/src/constants/auditCategories.ts
@@ -20,6 +20,7 @@ export const AUDIT_CATEGORIES: Record<string, LabelMapping> = {
   SYSTEM_SETTINGS: { i18nKey: 'pages.audit.categories.settings', defaultLabel: 'Settings' },
   USAGE_LOG: { i18nKey: 'pages.audit.categories.usage', defaultLabel: 'Usage' },
   API_ACCESS: { i18nKey: 'pages.audit.categories.apiAccess', defaultLabel: 'API Access' },
+  backup: { i18nKey: 'pages.audit.categories.backup', defaultLabel: 'Backup' },
 };
 
 export const AUDIT_ACTION_LABELS: Record<string, LabelMapping> = {
@@ -201,6 +202,28 @@ export const AUDIT_ACTION_LABELS: Record<string, LabelMapping> = {
   USAGE_DATA_CLEANUP: {
     i18nKey: 'pages.audit.actions.usageDataCleanup',
     defaultLabel: 'Usage Data Cleanup',
+  },
+
+  // Backup
+  'backup:create': {
+    i18nKey: 'pages.audit.actions.backupCreate',
+    defaultLabel: 'Backup Created',
+  },
+  'backup:download': {
+    i18nKey: 'pages.audit.actions.backupDownload',
+    defaultLabel: 'Backup Downloaded',
+  },
+  'backup:delete': {
+    i18nKey: 'pages.audit.actions.backupDelete',
+    defaultLabel: 'Backup Deleted',
+  },
+  'backup:restore': {
+    i18nKey: 'pages.audit.actions.backupRestore',
+    defaultLabel: 'Backup Restored',
+  },
+  'backup:test-restore': {
+    i18nKey: 'pages.audit.actions.backupTestRestore',
+    defaultLabel: 'Backup Test Restored',
   },
 };
 

--- a/frontend/src/i18n/locales/de/translation.json
+++ b/frontend/src/i18n/locales/de/translation.json
@@ -809,7 +809,12 @@
         "usageDataCleanup": "Nutzungsdaten-Bereinigung",
         "userBudgetUpdate": "Benutzer-Budget aktualisiert",
         "userSpendReset": "Benutzer-Ausgaben zurückgesetzt",
-        "userUpdate": "Benutzer aktualisiert"
+        "userUpdate": "Benutzer aktualisiert",
+        "backupCreate": "Sicherung erstellt",
+        "backupDownload": "Sicherung heruntergeladen",
+        "backupDelete": "Sicherung gelöscht",
+        "backupRestore": "Sicherung wiederhergestellt",
+        "backupTestRestore": "Testwiederherstellung durchgeführt"
       },
       "allActions": "Alle Aktionen",
       "allCategories": "Alle Kategorien",
@@ -824,7 +829,8 @@
         "subscription": "Abonnements",
         "team": "Teams",
         "usage": "Nutzung",
-        "user": "Benutzer"
+        "user": "Benutzer",
+        "backup": "Sicherung"
       },
       "categoryFilter": "Kategorie",
       "description": "Systemauditprotokoll aller administrativen Aktionen anzeigen.",
@@ -1301,6 +1307,65 @@
         "uploadSuccess": "Bild erfolgreich hochgeladen",
         "useCustom": "Benutzerdefiniert verwenden",
         "useDefault": "Standard verwenden"
+      },
+      "backup": {
+        "tabTitle": "Sicherung",
+        "litemaasCard": {
+          "title": "LiteMaaS-Datenbank",
+          "description": "Sicherung der LiteMaaS-Anwendungsdatenbank erstellen, einschließlich Benutzer, Modelle, Abonnements, API-Schlüssel und Einstellungen."
+        },
+        "litellmCard": {
+          "title": "LiteLLM-Datenbank",
+          "description": "Sicherung der LiteLLM-Proxy-Datenbank erstellen, einschließlich Nutzungsdaten und Konfiguration.",
+          "notConfigured": "Die LiteLLM-Datenbankverbindung ist nicht konfiguriert. Setzen Sie die Umgebungsvariable LITELLM_DATABASE_URL, um LiteLLM-Sicherungen zu aktivieren."
+        },
+        "createBackup": "Sicherung erstellen",
+        "creating": "Wird erstellt...",
+        "table": {
+          "database": "Datenbank",
+          "timestamp": "Zeitstempel",
+          "size": "Größe",
+          "actions": "Aktionen",
+          "empty": "Keine Sicherungen gefunden",
+          "emptyDescription": "Erstellen Sie eine Sicherung, um zu beginnen."
+        },
+        "download": "Herunterladen",
+        "restore": "Wiederherstellen",
+        "testRestore": "Testwiederherstellung",
+        "delete": "Löschen",
+        "restoreModal": {
+          "title": "Sicherung wiederherstellen",
+          "warning": "Dies ersetzt alle Daten in der {{database}}-Datenbank durch die Sicherung vom {{timestamp}}. Diese Aktion kann nicht rückgängig gemacht werden.",
+          "typeToConfirm": "Geben Sie \"{{database}}\" zur Bestätigung ein:",
+          "confirmPlaceholder": "Datenbankname zur Bestätigung eingeben"
+        },
+        "deleteModal": {
+          "title": "Sicherung löschen",
+          "message": "Sind Sie sicher, dass Sie die Sicherung \"{{filename}}\" löschen möchten? Diese Aktion kann nicht rückgängig gemacht werden."
+        },
+        "testRestoreModal": {
+          "title": "Ergebnis der Testwiederherstellung",
+          "success": "Die Testwiederherstellung wurde erfolgreich abgeschlossen.",
+          "failure": "Die Testwiederherstellung ist fehlgeschlagen.",
+          "tablesRestored": "Wiederhergestellte Tabellen",
+          "rowsRestored": "Wiederhergestellte Zeilen",
+          "duration": "Dauer",
+          "testSchema": "Test-Schema",
+          "warnings": "Warnungen"
+        },
+        "testRestoreConfirmModal": {
+          "title": "Testwiederherstellung bestätigen",
+          "description": "Dies stellt die Sicherung vom {{timestamp}} in einem separaten Test-Schema in der {{database}}-Datenbank wieder her. Die Originaldaten werden nicht verändert.",
+          "schemaNameLabel": "Name des Test-Schemas",
+          "schemaNameHelper": "Der Name des temporären Schemas, in dem die Sicherung zur Validierung wiederhergestellt wird."
+        },
+        "notifications": {
+          "backupCreated": "Sicherung erfolgreich erstellt.",
+          "backupDeleted": "Sicherung erfolgreich gelöscht.",
+          "restoreSuccess": "Datenbank erfolgreich aus der Sicherung wiederhergestellt.",
+          "testRestoreComplete": "Testwiederherstellung abgeschlossen.",
+          "error": "Bei der Sicherungsoperation ist ein Fehler aufgetreten."
+        }
       },
       "bulkUpdate": {
         "description": "Override resource limits for every active user at once. This does not change defaults for future users.",

--- a/frontend/src/i18n/locales/elv/translation.json
+++ b/frontend/src/i18n/locales/elv/translation.json
@@ -809,7 +809,12 @@
         "usageDataCleanup": "Usage Data Cleanup",
         "userBudgetUpdate": "User Budget Updated",
         "userSpendReset": "User Spend Reset",
-        "userUpdate": "User Updated"
+        "userUpdate": "User Updated",
+        "backupCreate": "Tië-ondonya ortanë",
+        "backupDownload": "Tië-ondonya lantanë",
+        "backupDelete": "Tië-ondonya harnaina",
+        "backupRestore": "Tië-ondonya enquantuva",
+        "backupTestRestore": "Tië-ondonya tyasta-enquantuva"
       },
       "allActions": "All actions",
       "allCategories": "All categories",
@@ -824,7 +829,8 @@
         "subscription": "Subscriptions",
         "team": "Teams",
         "usage": "Usage",
-        "user": "Users"
+        "user": "Users",
+        "backup": "Tië-ondonya"
       },
       "categoryFilter": "Category",
       "description": "View system audit trail of all administrative actions.",
@@ -1301,6 +1307,65 @@
         "uploadSuccess": "Thy image hath been bestowed upon the realm",
         "useCustom": "Bespoke heraldry",
         "useDefault": "Ancestral heraldry"
+      },
+      "backup": {
+        "tabTitle": "Tirith-gwaed",
+        "litemaasCard": {
+          "title": "Gwaed-dagor LiteMaaS",
+          "description": "Tirith gwaed-dagor LiteMaaS, ar aduiain, echuin, deri, têw-iant, a thinnath."
+        },
+        "litellmCard": {
+          "title": "Gwaed-dagor LiteLLM",
+          "description": "Tirith gwaed-dagor LiteLLM, ar aerlinn-gwaed a thinnath.",
+          "notConfigured": "Gwaed-dagor LiteLLM ú-dhannen. Panno LITELLM_DATABASE_URL ereb-gwain an tirith-gwaed LiteLLM."
+        },
+        "createBackup": "Caro tirith-gwaed",
+        "creating": "Carad...",
+        "table": {
+          "database": "Gwaed-dagor",
+          "timestamp": "Lû-anim",
+          "size": "Daer",
+          "actions": "Carith",
+          "empty": "Ú-ennen tirith-gwaed",
+          "emptyDescription": "Caro tirith-gwaed an eched."
+        },
+        "download": "Lanno",
+        "restore": "Adertho",
+        "testRestore": "Aderthad-thírad",
+        "delete": "Drego",
+        "restoreModal": {
+          "title": "Adertho tirith-gwaed",
+          "warning": "Hi aderthon ilphin gwaed i {{database}} gwaed-dagor ned tirith-gwaed o {{timestamp}}. Hi carith ú-aderthad.",
+          "typeToConfirm": "Teithio \"{{database}}\" an tirnad:",
+          "confirmPlaceholder": "Teithio eneth gwaed-dagor an tirnad"
+        },
+        "deleteModal": {
+          "title": "Drego tirith-gwaed",
+          "message": "Im-sennui drego tirith-gwaed \"{{filename}}\"? Hi carith ú-aderthad."
+        },
+        "testRestoreModal": {
+          "title": "Cann aderthad-thírad",
+          "success": "Aderthad-thírad tellin na galu.",
+          "failure": "Aderthad-thírad aun.",
+          "tablesRestored": "Taurain aderthannen",
+          "rowsRestored": "Ristain aderthannen",
+          "duration": "Lû-gûr",
+          "testSchema": "Thírad-echui",
+          "warnings": "Gellathon"
+        },
+        "testRestoreConfirmModal": {
+          "title": "Tirno aderthad-thírad",
+          "description": "Si aderthatha i tirith-gwaed o {{timestamp}} na thírad-echui erain i gwaed-dagor {{database}}. I dagor-gwaith ú-prestannar.",
+          "schemaNameLabel": "Eneth thírad-echui",
+          "schemaNameHelper": "I eneth en echui lû-vir ennas i tirith-gwaed aderthanner an thírad."
+        },
+        "notifications": {
+          "backupCreated": "Tirith-gwaed carnen na galu.",
+          "backupDeleted": "Tirith-gwaed dregon na galu.",
+          "restoreSuccess": "Gwaed-dagor aderthannen na galu o tirith-gwaed.",
+          "testRestoreComplete": "Aderthad-thírad tellin.",
+          "error": "Raeg tollen ned carith tirith-gwaed."
+        }
       },
       "bulkUpdate": {
         "description": "Override resource limits for every active user at once. This does not change defaults for future users.",

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -809,7 +809,12 @@
         "usageDataCleanup": "Usage Data Cleanup",
         "userBudgetUpdate": "User Budget Updated",
         "userSpendReset": "User Spend Reset",
-        "userUpdate": "User Updated"
+        "userUpdate": "User Updated",
+        "backupCreate": "Backup Created",
+        "backupDownload": "Backup Downloaded",
+        "backupDelete": "Backup Deleted",
+        "backupRestore": "Backup Restored",
+        "backupTestRestore": "Backup Test Restored"
       },
       "allActions": "All actions",
       "allCategories": "All categories",
@@ -824,7 +829,8 @@
         "subscription": "Subscriptions",
         "team": "Teams",
         "usage": "Usage",
-        "user": "Users"
+        "user": "Users",
+        "backup": "Backup"
       },
       "categoryFilter": "Category",
       "description": "View system audit trail of all administrative actions.",
@@ -1301,6 +1307,65 @@
         "uploadSuccess": "Image uploaded successfully",
         "useCustom": "Use custom",
         "useDefault": "Use default"
+      },
+      "backup": {
+        "tabTitle": "Backup",
+        "litemaasCard": {
+          "title": "LiteMaaS Database",
+          "description": "Back up the LiteMaaS application database including users, models, subscriptions, API keys, and settings."
+        },
+        "litellmCard": {
+          "title": "LiteLLM Database",
+          "description": "Back up the LiteLLM proxy database including usage data and configuration.",
+          "notConfigured": "LiteLLM database connection is not configured. Set the LITELLM_DATABASE_URL environment variable to enable LiteLLM backups."
+        },
+        "createBackup": "Create Backup",
+        "creating": "Creating...",
+        "table": {
+          "database": "Database",
+          "timestamp": "Timestamp",
+          "size": "Size",
+          "actions": "Actions",
+          "empty": "No backups found",
+          "emptyDescription": "Create a backup to get started."
+        },
+        "download": "Download",
+        "restore": "Restore",
+        "testRestore": "Test Restore",
+        "delete": "Delete",
+        "restoreModal": {
+          "title": "Restore Backup",
+          "warning": "This will replace all data in the {{database}} database with the backup from {{timestamp}}. This action cannot be undone.",
+          "typeToConfirm": "Type \"{{database}}\" to confirm:",
+          "confirmPlaceholder": "Type database name to confirm"
+        },
+        "deleteModal": {
+          "title": "Delete Backup",
+          "message": "Are you sure you want to delete the backup \"{{filename}}\"? This action cannot be undone."
+        },
+        "testRestoreModal": {
+          "title": "Test Restore Result",
+          "success": "Test restore completed successfully.",
+          "failure": "Test restore failed.",
+          "tablesRestored": "Tables Restored",
+          "rowsRestored": "Rows Restored",
+          "duration": "Duration",
+          "testSchema": "Test Schema",
+          "warnings": "Warnings"
+        },
+        "testRestoreConfirmModal": {
+          "title": "Confirm Test Restore",
+          "description": "This will restore the backup from {{timestamp}} into a separate test schema in the {{database}} database. The original data will not be modified.",
+          "schemaNameLabel": "Test Schema Name",
+          "schemaNameHelper": "The name of the temporary schema where the backup will be restored for validation."
+        },
+        "notifications": {
+          "backupCreated": "Backup created successfully.",
+          "backupDeleted": "Backup deleted successfully.",
+          "restoreSuccess": "Database restored successfully from backup.",
+          "testRestoreComplete": "Test restore completed.",
+          "error": "An error occurred during the backup operation."
+        }
       },
       "bulkUpdate": {
         "description": "Override resource limits for every active user at once. This does not change defaults for future users.",

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -809,7 +809,12 @@
         "usageDataCleanup": "Limpieza de datos de uso",
         "userBudgetUpdate": "Presupuesto de usuario actualizado",
         "userSpendReset": "Gasto de usuario reiniciado",
-        "userUpdate": "Usuario actualizado"
+        "userUpdate": "Usuario actualizado",
+        "backupCreate": "Copia de seguridad creada",
+        "backupDownload": "Copia de seguridad descargada",
+        "backupDelete": "Copia de seguridad eliminada",
+        "backupRestore": "Copia de seguridad restaurada",
+        "backupTestRestore": "Prueba de restauración completada"
       },
       "allActions": "Todas las acciones",
       "allCategories": "Todas las categorías",
@@ -824,7 +829,8 @@
         "subscription": "Suscripciones",
         "team": "Equipos",
         "usage": "Uso",
-        "user": "Usuarios"
+        "user": "Usuarios",
+        "backup": "Copia de seguridad"
       },
       "categoryFilter": "Categoría",
       "description": "Ver el registro de auditoría del sistema de todas las acciones administrativas.",
@@ -1301,6 +1307,65 @@
         "uploadSuccess": "Imagen subida correctamente",
         "useCustom": "Usar personalizado",
         "useDefault": "Usar predeterminado"
+      },
+      "backup": {
+        "tabTitle": "Copia de seguridad",
+        "litemaasCard": {
+          "title": "Base de datos LiteMaaS",
+          "description": "Respaldar la base de datos de la aplicación LiteMaaS, incluyendo usuarios, modelos, suscripciones, claves API y configuraciones."
+        },
+        "litellmCard": {
+          "title": "Base de datos LiteLLM",
+          "description": "Respaldar la base de datos del proxy LiteLLM, incluyendo datos de uso y configuración.",
+          "notConfigured": "La conexión a la base de datos LiteLLM no está configurada. Establezca la variable de entorno LITELLM_DATABASE_URL para habilitar las copias de seguridad de LiteLLM."
+        },
+        "createBackup": "Crear copia de seguridad",
+        "creating": "Creando...",
+        "table": {
+          "database": "Base de datos",
+          "timestamp": "Fecha y hora",
+          "size": "Tamaño",
+          "actions": "Acciones",
+          "empty": "No se encontraron copias de seguridad",
+          "emptyDescription": "Cree una copia de seguridad para comenzar."
+        },
+        "download": "Descargar",
+        "restore": "Restaurar",
+        "testRestore": "Restauración de prueba",
+        "delete": "Eliminar",
+        "restoreModal": {
+          "title": "Restaurar copia de seguridad",
+          "warning": "Esto reemplazará todos los datos en la base de datos {{database}} con la copia de seguridad de {{timestamp}}. Esta acción no se puede deshacer.",
+          "typeToConfirm": "Escriba \"{{database}}\" para confirmar:",
+          "confirmPlaceholder": "Escriba el nombre de la base de datos para confirmar"
+        },
+        "deleteModal": {
+          "title": "Eliminar copia de seguridad",
+          "message": "¿Está seguro de que desea eliminar la copia de seguridad \"{{filename}}\"? Esta acción no se puede deshacer."
+        },
+        "testRestoreModal": {
+          "title": "Resultado de la restauración de prueba",
+          "success": "La restauración de prueba se completó correctamente.",
+          "failure": "La restauración de prueba falló.",
+          "tablesRestored": "Tablas restauradas",
+          "rowsRestored": "Filas restauradas",
+          "duration": "Duración",
+          "testSchema": "Esquema de prueba",
+          "warnings": "Advertencias"
+        },
+        "testRestoreConfirmModal": {
+          "title": "Confirmar restauración de prueba",
+          "description": "Esto restaurará la copia de seguridad de {{timestamp}} en un esquema de prueba separado en la base de datos {{database}}. Los datos originales no se modificarán.",
+          "schemaNameLabel": "Nombre del esquema de prueba",
+          "schemaNameHelper": "El nombre del esquema temporal donde se restaurará la copia de seguridad para su validación."
+        },
+        "notifications": {
+          "backupCreated": "Copia de seguridad creada correctamente.",
+          "backupDeleted": "Copia de seguridad eliminada correctamente.",
+          "restoreSuccess": "Base de datos restaurada correctamente desde la copia de seguridad.",
+          "testRestoreComplete": "Restauración de prueba completada.",
+          "error": "Ocurrió un error durante la operación de copia de seguridad."
+        }
       },
       "bulkUpdate": {
         "description": "Override resource limits for every active user at once. This does not change defaults for future users.",

--- a/frontend/src/i18n/locales/fr/translation.json
+++ b/frontend/src/i18n/locales/fr/translation.json
@@ -809,7 +809,12 @@
         "usageDataCleanup": "Nettoyage des données d'utilisation",
         "userBudgetUpdate": "Budget utilisateur mis à jour",
         "userSpendReset": "Dépenses utilisateur réinitialisées",
-        "userUpdate": "Utilisateur mis à jour"
+        "userUpdate": "Utilisateur mis à jour",
+        "backupCreate": "Sauvegarde créée",
+        "backupDownload": "Sauvegarde téléchargée",
+        "backupDelete": "Sauvegarde supprimée",
+        "backupRestore": "Sauvegarde restaurée",
+        "backupTestRestore": "Test de restauration effectué"
       },
       "allActions": "Toutes les actions",
       "allCategories": "Toutes les catégories",
@@ -824,7 +829,8 @@
         "subscription": "Abonnements",
         "team": "Équipes",
         "usage": "Utilisation",
-        "user": "Utilisateurs"
+        "user": "Utilisateurs",
+        "backup": "Sauvegarde"
       },
       "categoryFilter": "Catégorie",
       "description": "Consulter la piste d'audit système de toutes les actions administratives.",
@@ -1301,6 +1307,65 @@
         "uploadSuccess": "Image téléchargée avec succès",
         "useCustom": "Personnalisé",
         "useDefault": "Par défaut"
+      },
+      "backup": {
+        "tabTitle": "Sauvegarde",
+        "litemaasCard": {
+          "title": "Base de données LiteMaaS",
+          "description": "Sauvegarder la base de données de l'application LiteMaaS, incluant les utilisateurs, modèles, abonnements, clés API et paramètres."
+        },
+        "litellmCard": {
+          "title": "Base de données LiteLLM",
+          "description": "Sauvegarder la base de données du proxy LiteLLM, incluant les données d'utilisation et la configuration.",
+          "notConfigured": "La connexion à la base de données LiteLLM n'est pas configurée. Définissez la variable d'environnement LITELLM_DATABASE_URL pour activer les sauvegardes LiteLLM."
+        },
+        "createBackup": "Créer une sauvegarde",
+        "creating": "Création en cours...",
+        "table": {
+          "database": "Base de données",
+          "timestamp": "Date et heure",
+          "size": "Taille",
+          "actions": "Actions",
+          "empty": "Aucune sauvegarde trouvée",
+          "emptyDescription": "Créez une sauvegarde pour commencer."
+        },
+        "download": "Télécharger",
+        "restore": "Restaurer",
+        "testRestore": "Restauration test",
+        "delete": "Supprimer",
+        "restoreModal": {
+          "title": "Restaurer la sauvegarde",
+          "warning": "Cela remplacera toutes les données de la base de données {{database}} par la sauvegarde du {{timestamp}}. Cette action est irréversible.",
+          "typeToConfirm": "Saisissez \"{{database}}\" pour confirmer :",
+          "confirmPlaceholder": "Saisissez le nom de la base de données pour confirmer"
+        },
+        "deleteModal": {
+          "title": "Supprimer la sauvegarde",
+          "message": "Êtes-vous sûr de vouloir supprimer la sauvegarde \"{{filename}}\" ? Cette action est irréversible."
+        },
+        "testRestoreModal": {
+          "title": "Résultat de la restauration test",
+          "success": "La restauration test s'est terminée avec succès.",
+          "failure": "La restauration test a échoué.",
+          "tablesRestored": "Tables restaurées",
+          "rowsRestored": "Lignes restaurées",
+          "duration": "Durée",
+          "testSchema": "Schéma de test",
+          "warnings": "Avertissements"
+        },
+        "testRestoreConfirmModal": {
+          "title": "Confirmer la restauration test",
+          "description": "Cela restaurera la sauvegarde du {{timestamp}} dans un schéma de test séparé dans la base de données {{database}}. Les données originales ne seront pas modifiées.",
+          "schemaNameLabel": "Nom du schéma de test",
+          "schemaNameHelper": "Le nom du schéma temporaire dans lequel la sauvegarde sera restaurée pour validation."
+        },
+        "notifications": {
+          "backupCreated": "Sauvegarde créée avec succès.",
+          "backupDeleted": "Sauvegarde supprimée avec succès.",
+          "restoreSuccess": "Base de données restaurée avec succès depuis la sauvegarde.",
+          "testRestoreComplete": "Restauration test terminée.",
+          "error": "Une erreur est survenue lors de l'opération de sauvegarde."
+        }
       },
       "bulkUpdate": {
         "description": "Override resource limits for every active user at once. This does not change defaults for future users.",

--- a/frontend/src/i18n/locales/it/translation.json
+++ b/frontend/src/i18n/locales/it/translation.json
@@ -809,7 +809,12 @@
         "usageDataCleanup": "Pulizia dati di utilizzo",
         "userBudgetUpdate": "Budget utente aggiornato",
         "userSpendReset": "Spesa utente reimpostata",
-        "userUpdate": "Utente aggiornato"
+        "userUpdate": "Utente aggiornato",
+        "backupCreate": "Backup creato",
+        "backupDownload": "Backup scaricato",
+        "backupDelete": "Backup eliminato",
+        "backupRestore": "Backup ripristinato",
+        "backupTestRestore": "Test di ripristino completato"
       },
       "allActions": "Tutte le azioni",
       "allCategories": "Tutte le categorie",
@@ -824,7 +829,8 @@
         "subscription": "Abbonamenti",
         "team": "Team",
         "usage": "Utilizzo",
-        "user": "Utenti"
+        "user": "Utenti",
+        "backup": "Backup"
       },
       "categoryFilter": "Categoria",
       "description": "Visualizza il registro di audit di sistema di tutte le azioni amministrative.",
@@ -1301,6 +1307,65 @@
         "uploadSuccess": "Immagine caricata con successo",
         "useCustom": "Usa personalizzato",
         "useDefault": "Usa predefinito"
+      },
+      "backup": {
+        "tabTitle": "Backup",
+        "litemaasCard": {
+          "title": "Database LiteMaaS",
+          "description": "Esegui il backup del database dell'applicazione LiteMaaS, inclusi utenti, modelli, abbonamenti, chiavi API e impostazioni."
+        },
+        "litellmCard": {
+          "title": "Database LiteLLM",
+          "description": "Esegui il backup del database del proxy LiteLLM, inclusi dati di utilizzo e configurazione.",
+          "notConfigured": "La connessione al database LiteLLM non è configurata. Imposta la variabile d'ambiente LITELLM_DATABASE_URL per abilitare i backup di LiteLLM."
+        },
+        "createBackup": "Crea backup",
+        "creating": "Creazione in corso...",
+        "table": {
+          "database": "Database",
+          "timestamp": "Data e ora",
+          "size": "Dimensione",
+          "actions": "Azioni",
+          "empty": "Nessun backup trovato",
+          "emptyDescription": "Crea un backup per iniziare."
+        },
+        "download": "Scarica",
+        "restore": "Ripristina",
+        "testRestore": "Ripristino di test",
+        "delete": "Elimina",
+        "restoreModal": {
+          "title": "Ripristina backup",
+          "warning": "Questa operazione sostituirà tutti i dati nel database {{database}} con il backup del {{timestamp}}. Questa azione non può essere annullata.",
+          "typeToConfirm": "Digita \"{{database}}\" per confermare:",
+          "confirmPlaceholder": "Digita il nome del database per confermare"
+        },
+        "deleteModal": {
+          "title": "Elimina backup",
+          "message": "Sei sicuro di voler eliminare il backup \"{{filename}}\"? Questa azione non può essere annullata."
+        },
+        "testRestoreModal": {
+          "title": "Risultato del ripristino di test",
+          "success": "Il ripristino di test è stato completato con successo.",
+          "failure": "Il ripristino di test è fallito.",
+          "tablesRestored": "Tabelle ripristinate",
+          "rowsRestored": "Righe ripristinate",
+          "duration": "Durata",
+          "testSchema": "Schema di test",
+          "warnings": "Avvisi"
+        },
+        "testRestoreConfirmModal": {
+          "title": "Conferma ripristino di test",
+          "description": "Questo ripristinerà il backup del {{timestamp}} in uno schema di test separato nel database {{database}}. I dati originali non verranno modificati.",
+          "schemaNameLabel": "Nome dello schema di test",
+          "schemaNameHelper": "Il nome dello schema temporaneo in cui il backup verrà ripristinato per la validazione."
+        },
+        "notifications": {
+          "backupCreated": "Backup creato con successo.",
+          "backupDeleted": "Backup eliminato con successo.",
+          "restoreSuccess": "Database ripristinato con successo dal backup.",
+          "testRestoreComplete": "Ripristino di test completato.",
+          "error": "Si è verificato un errore durante l'operazione di backup."
+        }
       },
       "bulkUpdate": {
         "description": "Override resource limits for every active user at once. This does not change defaults for future users.",

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -809,7 +809,12 @@
         "usageDataCleanup": "使用量データクリーンアップ",
         "userBudgetUpdate": "ユーザー予算更新",
         "userSpendReset": "ユーザー使用量リセット",
-        "userUpdate": "ユーザー更新"
+        "userUpdate": "ユーザー更新",
+        "backupCreate": "バックアップ作成",
+        "backupDownload": "バックアップダウンロード",
+        "backupDelete": "バックアップ削除",
+        "backupRestore": "バックアップ復元",
+        "backupTestRestore": "バックアップテスト復元完了"
       },
       "allActions": "すべてのアクション",
       "allCategories": "すべてのカテゴリ",
@@ -824,7 +829,8 @@
         "subscription": "サブスクリプション",
         "team": "チーム",
         "usage": "使用量",
-        "user": "ユーザー"
+        "user": "ユーザー",
+        "backup": "バックアップ"
       },
       "categoryFilter": "カテゴリ",
       "description": "すべての管理操作のシステム監査ログを表示します。",
@@ -1301,6 +1307,65 @@
         "uploadSuccess": "画像が正常にアップロードされました",
         "useCustom": "カスタムを使用",
         "useDefault": "デフォルトを使用"
+      },
+      "backup": {
+        "tabTitle": "バックアップ",
+        "litemaasCard": {
+          "title": "LiteMaaSデータベース",
+          "description": "ユーザー、モデル、サブスクリプション、APIキー、設定を含むLiteMaaSアプリケーションデータベースをバックアップします。"
+        },
+        "litellmCard": {
+          "title": "LiteLLMデータベース",
+          "description": "使用状況データと設定を含むLiteLLMプロキシデータベースをバックアップします。",
+          "notConfigured": "LiteLLMデータベース接続が設定されていません。LiteLLMバックアップを有効にするには、環境変数LITELLM_DATABASE_URLを設定してください。"
+        },
+        "createBackup": "バックアップを作成",
+        "creating": "作成中...",
+        "table": {
+          "database": "データベース",
+          "timestamp": "日時",
+          "size": "サイズ",
+          "actions": "操作",
+          "empty": "バックアップが見つかりません",
+          "emptyDescription": "バックアップを作成して開始しましょう。"
+        },
+        "download": "ダウンロード",
+        "restore": "復元",
+        "testRestore": "テスト復元",
+        "delete": "削除",
+        "restoreModal": {
+          "title": "バックアップの復元",
+          "warning": "{{database}}データベースのすべてのデータが{{timestamp}}のバックアップに置き換えられます。この操作は元に戻せません。",
+          "typeToConfirm": "確認のため「{{database}}」と入力してください：",
+          "confirmPlaceholder": "確認のためデータベース名を入力"
+        },
+        "deleteModal": {
+          "title": "バックアップの削除",
+          "message": "バックアップ「{{filename}}」を削除してもよろしいですか？この操作は元に戻せません。"
+        },
+        "testRestoreModal": {
+          "title": "テスト復元の結果",
+          "success": "テスト復元が正常に完了しました。",
+          "failure": "テスト復元に失敗しました。",
+          "tablesRestored": "復元されたテーブル数",
+          "rowsRestored": "復元された行数",
+          "duration": "所要時間",
+          "testSchema": "テストスキーマ",
+          "warnings": "警告"
+        },
+        "testRestoreConfirmModal": {
+          "title": "テスト復元の確認",
+          "description": "{{timestamp}}のバックアップを{{database}}データベース内の別のテストスキーマに復元します。元のデータは変更されません。",
+          "schemaNameLabel": "テストスキーマ名",
+          "schemaNameHelper": "バックアップの検証用に復元される一時スキーマの名前です。"
+        },
+        "notifications": {
+          "backupCreated": "バックアップが正常に作成されました。",
+          "backupDeleted": "バックアップが正常に削除されました。",
+          "restoreSuccess": "バックアップからデータベースが正常に復元されました。",
+          "testRestoreComplete": "テスト復元が完了しました。",
+          "error": "バックアップ操作中にエラーが発生しました。"
+        }
       },
       "bulkUpdate": {
         "description": "Override resource limits for every active user at once. This does not change defaults for future users.",

--- a/frontend/src/i18n/locales/ko/translation.json
+++ b/frontend/src/i18n/locales/ko/translation.json
@@ -809,7 +809,12 @@
         "usageDataCleanup": "사용량 데이터 정리",
         "userBudgetUpdate": "사용자 예산 업데이트",
         "userSpendReset": "사용자 사용량 초기화",
-        "userUpdate": "사용자 업데이트"
+        "userUpdate": "사용자 업데이트",
+        "backupCreate": "백업 생성됨",
+        "backupDownload": "백업 다운로드됨",
+        "backupDelete": "백업 삭제됨",
+        "backupRestore": "백업 복원됨",
+        "backupTestRestore": "백업 테스트 복원 완료"
       },
       "allActions": "모든 작업",
       "allCategories": "모든 카테고리",
@@ -824,7 +829,8 @@
         "subscription": "구독",
         "team": "팀",
         "usage": "사용량",
-        "user": "사용자"
+        "user": "사용자",
+        "backup": "백업"
       },
       "categoryFilter": "카테고리",
       "description": "모든 관리 작업의 시스템 감사 로그를 확인합니다.",
@@ -1301,6 +1307,65 @@
         "uploadSuccess": "이미지가 성공적으로 업로드되었습니다",
         "useCustom": "커스텀 사용",
         "useDefault": "기본값 사용"
+      },
+      "backup": {
+        "tabTitle": "백업",
+        "litemaasCard": {
+          "title": "LiteMaaS 데이터베이스",
+          "description": "사용자, 모델, 구독, API 키 및 설정을 포함한 LiteMaaS 애플리케이션 데이터베이스를 백업합니다."
+        },
+        "litellmCard": {
+          "title": "LiteLLM 데이터베이스",
+          "description": "사용량 데이터 및 구성을 포함한 LiteLLM 프록시 데이터베이스를 백업합니다.",
+          "notConfigured": "LiteLLM 데이터베이스 연결이 구성되지 않았습니다. LiteLLM 백업을 활성화하려면 LITELLM_DATABASE_URL 환경 변수를 설정하세요."
+        },
+        "createBackup": "백업 생성",
+        "creating": "생성 중...",
+        "table": {
+          "database": "데이터베이스",
+          "timestamp": "날짜 및 시간",
+          "size": "크기",
+          "actions": "작업",
+          "empty": "백업을 찾을 수 없습니다",
+          "emptyDescription": "백업을 생성하여 시작하세요."
+        },
+        "download": "다운로드",
+        "restore": "복원",
+        "testRestore": "테스트 복원",
+        "delete": "삭제",
+        "restoreModal": {
+          "title": "백업 복원",
+          "warning": "{{database}} 데이터베이스의 모든 데이터가 {{timestamp}} 백업으로 대체됩니다. 이 작업은 되돌릴 수 없습니다.",
+          "typeToConfirm": "확인하려면 \"{{database}}\"을(를) 입력하세요:",
+          "confirmPlaceholder": "확인을 위해 데이터베이스 이름을 입력하세요"
+        },
+        "deleteModal": {
+          "title": "백업 삭제",
+          "message": "백업 \"{{filename}}\"을(를) 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+        },
+        "testRestoreModal": {
+          "title": "테스트 복원 결과",
+          "success": "테스트 복원이 성공적으로 완료되었습니다.",
+          "failure": "테스트 복원에 실패했습니다.",
+          "tablesRestored": "복원된 테이블 수",
+          "rowsRestored": "복원된 행 수",
+          "duration": "소요 시간",
+          "testSchema": "테스트 스키마",
+          "warnings": "경고"
+        },
+        "testRestoreConfirmModal": {
+          "title": "테스트 복원 확인",
+          "description": "{{timestamp}}의 백업을 {{database}} 데이터베이스의 별도 테스트 스키마에 복원합니다. 원본 데이터는 수정되지 않습니다.",
+          "schemaNameLabel": "테스트 스키마 이름",
+          "schemaNameHelper": "백업이 검증을 위해 복원될 임시 스키마의 이름입니다."
+        },
+        "notifications": {
+          "backupCreated": "백업이 성공적으로 생성되었습니다.",
+          "backupDeleted": "백업이 성공적으로 삭제되었습니다.",
+          "restoreSuccess": "백업에서 데이터베이스가 성공적으로 복원되었습니다.",
+          "testRestoreComplete": "테스트 복원이 완료되었습니다.",
+          "error": "백업 작업 중 오류가 발생했습니다."
+        }
       },
       "bulkUpdate": {
         "description": "Override resource limits for every active user at once. This does not change defaults for future users.",

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -809,7 +809,12 @@
         "usageDataCleanup": "使用数据清理",
         "userBudgetUpdate": "用户预算已更新",
         "userSpendReset": "用户消费已重置",
-        "userUpdate": "用户已更新"
+        "userUpdate": "用户已更新",
+        "backupCreate": "备份已创建",
+        "backupDownload": "备份已下载",
+        "backupDelete": "备份已删除",
+        "backupRestore": "备份已恢复",
+        "backupTestRestore": "备份测试恢复完成"
       },
       "allActions": "所有操作",
       "allCategories": "所有类别",
@@ -824,7 +829,8 @@
         "subscription": "订阅",
         "team": "团队",
         "usage": "使用量",
-        "user": "用户"
+        "user": "用户",
+        "backup": "备份"
       },
       "categoryFilter": "类别",
       "description": "查看所有管理操作的系统审计日志。",
@@ -1301,6 +1307,65 @@
         "uploadSuccess": "图片上传成功",
         "useCustom": "使用自定义",
         "useDefault": "使用默认"
+      },
+      "backup": {
+        "tabTitle": "备份",
+        "litemaasCard": {
+          "title": "LiteMaaS 数据库",
+          "description": "备份 LiteMaaS 应用数据库，包括用户、模型、订阅、API 密钥和设置。"
+        },
+        "litellmCard": {
+          "title": "LiteLLM 数据库",
+          "description": "备份 LiteLLM 代理数据库，包括使用数据和配置。",
+          "notConfigured": "LiteLLM 数据库连接未配置。请设置 LITELLM_DATABASE_URL 环境变量以启用 LiteLLM 备份。"
+        },
+        "createBackup": "创建备份",
+        "creating": "创建中...",
+        "table": {
+          "database": "数据库",
+          "timestamp": "时间",
+          "size": "大小",
+          "actions": "操作",
+          "empty": "未找到备份",
+          "emptyDescription": "创建备份以开始使用。"
+        },
+        "download": "下载",
+        "restore": "恢复",
+        "testRestore": "测试恢复",
+        "delete": "删除",
+        "restoreModal": {
+          "title": "恢复备份",
+          "warning": "此操作将用 {{timestamp}} 的备份替换 {{database}} 数据库中的所有数据。此操作无法撤消。",
+          "typeToConfirm": "输入 \"{{database}}\" 以确认：",
+          "confirmPlaceholder": "输入数据库名称以确认"
+        },
+        "deleteModal": {
+          "title": "删除备份",
+          "message": "确定要删除备份 \"{{filename}}\" 吗？此操作无法撤消。"
+        },
+        "testRestoreModal": {
+          "title": "测试恢复结果",
+          "success": "测试恢复成功完成。",
+          "failure": "测试恢复失败。",
+          "tablesRestored": "已恢复的表数",
+          "rowsRestored": "已恢复的行数",
+          "duration": "耗时",
+          "testSchema": "测试架构",
+          "warnings": "警告"
+        },
+        "testRestoreConfirmModal": {
+          "title": "确认测试恢复",
+          "description": "这将把 {{timestamp}} 的备份恢复到 {{database}} 数据库中的一个独立测试架构中。原始数据不会被修改。",
+          "schemaNameLabel": "测试架构名称",
+          "schemaNameHelper": "用于验证备份恢复的临时架构名称。"
+        },
+        "notifications": {
+          "backupCreated": "备份创建成功。",
+          "backupDeleted": "备份删除成功。",
+          "restoreSuccess": "数据库已成功从备份恢复。",
+          "testRestoreComplete": "测试恢复已完成。",
+          "error": "备份操作过程中发生错误。"
+        }
       },
       "bulkUpdate": {
         "description": "Override resource limits for every active user at once. This does not change defaults for future users.",

--- a/frontend/src/pages/AuditPage.tsx
+++ b/frontend/src/pages/AuditPage.tsx
@@ -200,6 +200,7 @@ const AuditPage: React.FC = () => {
                   </SelectOption>
                   {categories
                     .filter((cat) => showApiAccess || cat !== 'API_ACCESS')
+                    .sort((a, b) => getCategoryLabel(a, t).localeCompare(getCategoryLabel(b, t)))
                     .map((category) => (
                       <SelectOption key={category} value={category}>
                         {getCategoryLabel(category, t)}

--- a/frontend/src/pages/ToolsPage.tsx
+++ b/frontend/src/pages/ToolsPage.tsx
@@ -47,6 +47,7 @@ import { BannerEditModal, BannerTable } from '../components/banners';
 import { ApiKeyQuotaDefaultsSection, UserDefaultsSection } from '../components/admin';
 import BrandingTab from '../components/branding/BrandingTab';
 import CurrencyTab from '../components/currency/CurrencyTab';
+import BackupTab from '../components/backup/BackupTab';
 import { useQuery, useQueryClient } from 'react-query';
 import { extractErrorDetails } from '../utils/error.utils';
 
@@ -109,6 +110,9 @@ const ToolsPage: React.FC = () => {
   const canViewCurrency =
     (user?.roles?.includes('admin') || user?.roles?.includes('admin-readonly')) ?? false;
   const canManageCurrency = user?.roles?.includes('admin') ?? false;
+  const canViewBackup =
+    (user?.roles?.includes('admin') || user?.roles?.includes('admin-readonly')) ?? false;
+  const canManageBackup = user?.roles?.includes('admin') ?? false;
 
   // Fetch all banners for admin management
   const { data: allBanners = [] } = useQuery(['allBanners'], () => bannerService.getAllBanners(), {
@@ -664,6 +668,19 @@ const ToolsPage: React.FC = () => {
               <TabContent id="currency-tab-content" style={{ paddingTop: '10px' }}>
                 <TabContentBody>
                   <CurrencyTab canManage={canManageCurrency} />
+                </TabContentBody>
+              </TabContent>
+            </Tab>
+          )}
+          {/* Backup Tab */}
+          {canViewBackup && (
+            <Tab
+              eventKey="backup"
+              title={<TabTitleText>{t('pages.tools.backup.tabTitle')}</TabTitleText>}
+            >
+              <TabContent id="backup-tab-content" style={{ paddingTop: '10px' }}>
+                <TabContentBody>
+                  <BackupTab canManage={canManageBackup} />
                 </TabContentBody>
               </TabContent>
             </Tab>

--- a/frontend/src/services/backup.service.ts
+++ b/frontend/src/services/backup.service.ts
@@ -1,0 +1,136 @@
+import { apiClient } from './api';
+
+// Types matching backend
+export type BackupDatabaseType = 'litemaas' | 'litellm';
+
+export interface BackupMetadata {
+  formatVersion: string;
+  database: BackupDatabaseType;
+  timestamp: string;
+  appVersion: string;
+  tableCount: number;
+  rowCounts: Record<string, number>;
+}
+
+export interface BackupCapabilities {
+  litemaasAvailable: boolean;
+  litellmAvailable: boolean;
+  litellmConfigured: boolean;
+  storagePath: string;
+}
+
+export interface BackupInfo {
+  id: string;
+  filename: string;
+  database: BackupDatabaseType;
+  timestamp: string;
+  size: number;
+  metadata: BackupMetadata;
+}
+
+export interface RestoreResult {
+  success: boolean;
+  tablesRestored: number;
+  rowsRestored: number;
+  duration: number;
+  warnings: string[];
+}
+
+export interface TestRestoreResult extends RestoreResult {
+  testSchema: string;
+}
+
+class BackupService {
+  /**
+   * Get backup capabilities and configuration
+   */
+  async getCapabilities(): Promise<BackupCapabilities> {
+    const response = await apiClient.get<{ data: BackupCapabilities }>(
+      '/admin/backup/capabilities',
+    );
+    return response.data;
+  }
+
+  /**
+   * List all available backups
+   */
+  async listBackups(): Promise<BackupInfo[]> {
+    const response = await apiClient.get<{ data: BackupInfo[] }>('/admin/backup');
+    return response.data;
+  }
+
+  /**
+   * Create a new backup for the specified database
+   */
+  async createBackup(dbType: BackupDatabaseType): Promise<BackupInfo> {
+    const response = await apiClient.post<{ data: BackupInfo }>('/admin/backup/create', {
+      database: dbType,
+    });
+    return response.data;
+  }
+
+  /**
+   * Download a backup file
+   * Uses fetch directly to trigger browser download with auth
+   */
+  async downloadBackup(id: string): Promise<void> {
+    // Get auth token for the download request
+    const token = localStorage.getItem('access_token');
+    const baseUrl = '/api/v1';
+    const url = `${baseUrl}/admin/backup/${encodeURIComponent(id)}/download`;
+
+    // Create a temporary link to trigger download with auth
+    const response = await fetch(url, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    if (!response.ok) {
+      throw new Error('Download failed');
+    }
+
+    const blob = await response.blob();
+    const downloadUrl = window.URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = downloadUrl;
+    a.download = id; // filename will be the id which includes .sql.gz
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    window.URL.revokeObjectURL(downloadUrl);
+  }
+
+  /**
+   * Delete a backup file
+   */
+  async deleteBackup(id: string): Promise<void> {
+    await apiClient.delete(`/admin/backup/${encodeURIComponent(id)}`);
+  }
+
+  /**
+   * Restore a backup to the database
+   */
+  async restoreBackup(id: string, database: BackupDatabaseType): Promise<RestoreResult> {
+    const response = await apiClient.post<{ data: RestoreResult }>(
+      `/admin/backup/${encodeURIComponent(id)}/restore`,
+      { database },
+    );
+    return response.data;
+  }
+
+  /**
+   * Test restore a backup (non-destructive)
+   */
+  async testRestoreBackup(
+    id: string,
+    database: BackupDatabaseType,
+    testSchemaName?: string,
+  ): Promise<TestRestoreResult> {
+    const response = await apiClient.post<{ data: TestRestoreResult }>(
+      `/admin/backup/${encodeURIComponent(id)}/test-restore`,
+      { database, testSchemaName },
+    );
+    return response.data;
+  }
+}
+
+export const backupService = new BackupService();


### PR DESCRIPTION
## Summary

- Full database backup & restore system for both LiteMaaS and LiteLLM databases
- Backend: `BackupService` with type-aware SQL serialization, gzip compression, PostgreSQL OID-based column type detection, mixed-case table name quoting for LiteLLM compatibility
- API: 8 endpoints (capabilities, list, create, download, delete, restore, test-restore) with `admin:backup` RBAC permission
- Frontend: Backup tab in Settings & Tools with create/download/delete/restore actions, test-restore with custom schema naming, confirmation modals
- CLI: Standalone restore script (`restore-backup.ts`) for catastrophic recovery scenarios
- Audit logging with human-readable labels and alphabetically sorted category dropdown
- Full i18n support across all 9 locales
- New env vars: `LITELLM_DATABASE_URL` (optional), `BACKUP_STORAGE_PATH` (default: `./data/backups`)

## Test plan

- [x] Create backup for LiteMaaS database, verify `.sql.gz` file saved
- [x] Create backup for LiteLLM database (requires `LITELLM_DATABASE_URL`)
- [x] List backups, verify metadata (size, timestamp, database type)
- [x] Download backup, verify valid gzipped SQL
- [x] Test-restore to temporary schema, verify row counts match
- [x] Restore backup, verify data integrity via SQL comparison
- [x] Delete backup, verify file removed
- [x] Verify admin-only access (adminReadonly sees read-only tab, user sees nothing)
- [x] Verify audit log shows "Backup" category and human-readable action labels
- [x] Verify category dropdown alphabetical ordering in Audit Logs page