### PR TITLE
fix(backup): add PVC for persistent backup storage

### DIFF
--- a/deployment/helm/litemaas/templates/backend-deployment.yaml
+++ b/deployment/helm/litemaas/templates/backend-deployment.yaml
@@ -99,6 +99,9 @@ spec:
                 secretKeyRef:
                   name: {{ include "litemaas.backend.secretName" . }}
                   key: litellm-database-url
+          volumeMounts:
+            - name: backup-storage
+              mountPath: {{ .Values.backend.backup.storagePath }}
           resources:
             {{- toYaml .Values.backend.resources | nindent 12 }}
           livenessProbe:
@@ -117,3 +120,7 @@ spec:
             periodSeconds: {{ .Values.backend.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.backend.readinessProbe.timeoutSeconds }}
             failureThreshold: {{ .Values.backend.readinessProbe.failureThreshold }}
+      volumes:
+        - name: backup-storage
+          persistentVolumeClaim:
+            claimName: {{ include "litemaas.backend.fullname" . }}-backup

--- a/deployment/helm/litemaas/templates/backend-pvc.yaml
+++ b/deployment/helm/litemaas/templates/backend-pvc.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "litemaas.backend.fullname" . }}-backup
+  labels:
+    {{- include "litemaas.componentLabels" (dict "context" . "component" "api") | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  {{- if .Values.backend.backup.persistence.storageClass }}
+  storageClassName: {{ .Values.backend.backup.persistence.storageClass | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.backend.backup.persistence.size }}

--- a/deployment/helm/litemaas/values.yaml
+++ b/deployment/helm/litemaas/values.yaml
@@ -201,8 +201,15 @@ backend:
     # -- LiteLLM database URL for backup/restore. Auto-constructed when postgresql.enabled is true.
     # Required only if you want to backup/restore the LiteLLM database.
     litellmDatabaseUrl: ""
-    # -- Directory where backup files are stored inside the backend container.
-    storagePath: "./data/backups"
+    # -- Mount path for backup storage inside the container.
+    # This value is set as BACKUP_STORAGE_PATH env var.
+    storagePath: "/data/backups"
+
+    persistence:
+      # -- Storage size for the backup PVC
+      size: 5Gi
+      # -- StorageClass name (empty = cluster default)
+      storageClass: ""
 
   # -- Set to "0" to disable TLS verification (not recommended for production)
   nodeTlsRejectUnauthorized: ""

--- a/deployment/kustomize/backend-deployment.yaml.template
+++ b/deployment/kustomize/backend-deployment.yaml.template
@@ -122,6 +122,10 @@ spec:
                   name: backend-secret
                   key: litellm-database-url
 
+            # Backup Storage Path
+            - name: BACKUP_STORAGE_PATH
+              value: '/data/backups'
+
             # Backend API Rate Limiting (NOT for LLM requests)
             - name: RATE_LIMIT_MAX
               value: '1000'
@@ -147,6 +151,10 @@ spec:
               memory: '512Mi'
               cpu: '500m'
 
+          volumeMounts:
+            - name: backup-storage
+              mountPath: /data/backups
+
           livenessProbe:
             httpGet:
               path: /api/v1/health/live
@@ -163,3 +171,7 @@ spec:
             periodSeconds: 5
             timeoutSeconds: 3
             failureThreshold: 3
+      volumes:
+        - name: backup-storage
+          persistentVolumeClaim:
+            claimName: backend-backup

--- a/deployment/kustomize/backend-pvc.yaml
+++ b/deployment/kustomize/backend-pvc.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: backend-backup
+  labels:
+    app: backend
+    component: api
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi

--- a/deployment/kustomize/kustomization.yaml.template
+++ b/deployment/kustomize/kustomization.yaml.template
@@ -24,6 +24,7 @@ resources:
   - litellm-service.yaml
 
   # Backend API
+  - backend-pvc.yaml
   - backend-deployment.yaml.local
   - backend-service.yaml
 

--- a/docs/deployment/configuration.md
+++ b/docs/deployment/configuration.md
@@ -251,6 +251,8 @@ In Helm deployments, `LITELLM_DATABASE_URL` is auto-constructed from PostgreSQL 
 
 In Kustomize deployments, the value is stored in `backend-secret` and constructed from `PG_ADMIN_PASSWORD` by default.
 
+**Persistent Storage**: Both Helm and Kustomize deployments provision a PersistentVolumeClaim (`5Gi` by default) mounted at `/data/backups` to ensure backup files survive pod restarts. In the Helm chart, configure via `backend.backup.persistence.size` and `backend.backup.persistence.storageClass`. Without persistent storage, backups are written to the ephemeral container filesystem and lost on pod restart.
+
 ## Backend API Protection
 
 > **Important**: These settings protect the LiteMaaS backend management API endpoints (user management, API key creation, etc.). They do NOT affect LLM request rate limits, which are configured in LiteLLM using the TPM/RPM values from the Default User Values section.

--- a/docs/deployment/helm-deployment.md
+++ b/docs/deployment/helm-deployment.md
@@ -155,7 +155,9 @@ helm test litemaas -n litemaas
 | `backend.defaultUser.tpmLimit` | Default user TPM limit | `100000` |
 | `backend.defaultUser.rpmLimit` | Default user RPM limit | `120` |
 | `backend.backup.litellmDatabaseUrl` | LiteLLM database URL for backup/restore (auto-built when `postgresql.enabled`) | `""` |
-| `backend.backup.storagePath` | Directory for backup file storage inside the container | `./data/backups` |
+| `backend.backup.storagePath` | Mount path for backup storage inside the container | `/data/backups` |
+| `backend.backup.persistence.size` | Backup PVC storage size | `5Gi` |
+| `backend.backup.persistence.storageClass` | StorageClass for backup PVC (empty = cluster default) | `""` |
 | `backend.nodeTlsRejectUnauthorized` | Set to `"0"` to disable TLS verification | `""` |
 
 ### Frontend


### PR DESCRIPTION
## Summary
- Add a PersistentVolumeClaim (5Gi default) for backup storage in both Helm and Kustomize deployments
- Mount the PVC at `/data/backups` in the backend container so backup files survive pod restarts
- Update deployment docs with new `backend.backup.persistence.*` Helm parameters

## Test plan
- [x] Run `helm template litemaas deployment/helm/litemaas/ --set route.enabled=true` and verify the rendered output includes the PVC, volumeMounts, and volumes
- [x] Verify `BACKUP_STORAGE_PATH` is set to `/data/backups` in the backend configmap
- [x] Deploy to a test cluster and confirm backups persist across pod restarts