### PR TITLE
fix(backup): stream backup/restore to prevent OOM on large databases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-03-08
+
+### Fixed
+
+- **Backup OOM fix**: Streaming backup with PostgreSQL cursors and gzip file streams to prevent JavaScript heap out of memory crashes on large databases (e.g., LiteLLM with 1M+ rows)
+- **Backup restore OOM fix**: Streaming decompression and batched SQL execution for restore and test-restore operations
+- **CLI scripts OOM fix**: Streaming restore and verification in `restore-backup.ts` and `test-backup.ts` scripts
+
+### Added
+
+- **Async backup jobs**: Backup creation runs in the background with real-time progress polling (`GET /admin/backup/status`) — prevents gateway timeouts on large databases
+- **Backup progress UI**: Progress bar (row-based), current table, tables completed, elapsed time — persists across page navigation
+- **Backup test script**: `backend/src/scripts/test-backup.ts` for testing streaming backup against a live database without the full application
+
 ## [0.3.0] - 2026-03-08
 
 ### Added

--- a/backend/src/routes/admin-backup.ts
+++ b/backend/src/routes/admin-backup.ts
@@ -59,7 +59,7 @@ const adminBackupRoutes: FastifyPluginAsync = async (fastify) => {
     },
   );
 
-  // Create a new backup
+  // Start a new backup job (async - returns immediately)
   fastify.post<{
     Body: { database: BackupDatabaseType };
   }>(
@@ -67,8 +67,8 @@ const adminBackupRoutes: FastifyPluginAsync = async (fastify) => {
     {
       schema: {
         tags: ['Admin - Backup'],
-        summary: 'Create a database backup',
-        description: 'Create a compressed backup of the specified database',
+        summary: 'Start a database backup job',
+        description: 'Start a backup job in the background. Poll GET /status for progress.',
         security: [{ bearerAuth: [] }],
         body: {
           type: 'object',
@@ -89,35 +89,36 @@ const adminBackupRoutes: FastifyPluginAsync = async (fastify) => {
       const { database } = request.body as { database: BackupDatabaseType };
 
       try {
-        const backupInfo = await backupService.createBackup(database);
-
-        await logAudit(user.userId, 'backup:create', backupInfo.id, true, {
-          database,
-          filename: backupInfo.filename,
-          size: backupInfo.size,
-          tableCount: backupInfo.metadata.tableCount,
-        });
-
-        return { data: backupInfo };
+        const status = backupService.startBackupJob(database, user.userId);
+        return { data: status };
       } catch (error) {
-        await logAudit(
-          user.userId,
-          'backup:create',
-          database,
-          false,
-          { database },
-          error instanceof Error ? error.message : String(error),
-        );
-
-        fastify.log.error({ error, database }, 'Failed to create backup');
+        fastify.log.error({ error, database }, 'Failed to start backup job');
 
         if (error instanceof ApplicationError) {
           throw error;
         }
 
         const errorMessage = error instanceof Error ? error.message : String(error);
-        throw fastify.createError(500, `Failed to create backup: ${errorMessage}`);
+        throw fastify.createError(500, `Failed to start backup: ${errorMessage}`);
       }
+    },
+  );
+
+  // Get backup job status (for polling)
+  fastify.get(
+    '/status',
+    {
+      schema: {
+        tags: ['Admin - Backup'],
+        summary: 'Get backup job status',
+        description:
+          'Get the current backup job status including progress. Used for polling during backup.',
+        security: [{ bearerAuth: [] }],
+      },
+      preHandler: [fastify.authenticate, fastify.requirePermission('admin:backup')],
+    },
+    async (_request, _reply) => {
+      return { data: backupService.getJobStatus() };
     },
   );
 

--- a/backend/src/scripts/restore-backup.ts
+++ b/backend/src/scripts/restore-backup.ts
@@ -14,8 +14,9 @@
  */
 
 import { config } from 'dotenv';
-import { Pool } from 'pg';
+import { Pool, PoolClient } from 'pg';
 import { promises as fs } from 'fs';
+import { createReadStream } from 'fs';
 import * as zlib from 'zlib';
 
 // Load environment variables
@@ -80,10 +81,7 @@ async function getDatabaseUrl(database: 'litemaas' | 'litellm'): Promise<string>
   }
 }
 
-async function readBackup(filePath: string): Promise<{ sqlContent: string; metadata: any }> {
-  console.log(`Reading backup file: ${filePath}`);
-
-  // Read metadata if available
+async function readMetadata(filePath: string): Promise<any> {
   const metaPath = `${filePath}.meta.json`;
   let metadata: any = null;
 
@@ -95,23 +93,90 @@ async function readBackup(filePath: string): Promise<{ sqlContent: string; metad
     console.log(`  Timestamp: ${metadata.timestamp}`);
     console.log(`  Tables: ${metadata.tableCount}`);
     console.log(`  Format Version: ${metadata.formatVersion}`);
-  } catch (error) {
+  } catch {
     console.warn('Warning: Could not read metadata file, continuing anyway...');
   }
 
-  // Read and decompress backup file
-  console.log('Decompressing backup...');
-  const compressedData = await fs.readFile(filePath);
-  const sqlContent = zlib.gunzipSync(compressedData).toString('utf-8');
+  return metadata;
+}
 
-  console.log(`Backup decompressed successfully (${sqlContent.length} bytes)`);
+/**
+ * Stream-decompress a backup file and execute SQL statements in batches.
+ * Avoids loading the entire decompressed SQL into memory.
+ */
+async function streamRestoreSQL(backupPath: string, client: PoolClient): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    const gunzip = zlib.createGunzip();
+    const readStream = createReadStream(backupPath);
+    let buffer = '';
+    let statementsExecuted = 0;
 
-  return { sqlContent, metadata };
+    gunzip.on('data', (chunk: Buffer) => {
+      buffer += chunk.toString('utf-8');
+
+      const lastNewline = buffer.lastIndexOf('\n');
+      if (lastNewline === -1) return;
+
+      const processable = buffer.substring(0, lastNewline);
+      buffer = buffer.substring(lastNewline + 1);
+
+      const statements = processable.split('\n').filter((line) => {
+        const trimmed = line.trim();
+        return trimmed.length > 0 && !trimmed.startsWith('--');
+      });
+
+      if (statements.length > 0) {
+        gunzip.pause();
+        statementsExecuted += statements.length;
+
+        if (statementsExecuted % 10000 === 0) {
+          process.stdout.write(`  ... ${statementsExecuted} statements executed\n`);
+        }
+
+        const batch = statements.join('\n');
+        client
+          .query(batch)
+          .then(() => {
+            gunzip.resume();
+          })
+          .catch((err) => {
+            readStream.destroy();
+            gunzip.destroy();
+            reject(err);
+          });
+      }
+    });
+
+    gunzip.on('end', () => {
+      const remaining = buffer.split('\n').filter((line) => {
+        const trimmed = line.trim();
+        return trimmed.length > 0 && !trimmed.startsWith('--');
+      });
+
+      if (remaining.length > 0) {
+        client
+          .query(remaining.join('\n'))
+          .then(() => {
+            console.log(`  Total: ${statementsExecuted + remaining.length} statements executed`);
+            resolve();
+          })
+          .catch(reject);
+      } else {
+        console.log(`  Total: ${statementsExecuted} statements executed`);
+        resolve();
+      }
+    });
+
+    gunzip.on('error', reject);
+    readStream.on('error', reject);
+
+    readStream.pipe(gunzip);
+  });
 }
 
 async function restoreBackup(
   databaseUrl: string,
-  sqlContent: string,
+  backupPath: string,
   metadata: any,
 ): Promise<void> {
   const pool = new Pool({ connectionString: databaseUrl });
@@ -124,11 +189,10 @@ async function restoreBackup(
       console.log('Starting transaction...');
       await client.query('BEGIN');
 
-      console.log('Executing restore SQL...');
+      console.log('Executing restore SQL (streaming)...');
       console.log('⚠️  WARNING: This will TRUNCATE all tables and restore from backup!');
 
-      // Execute the SQL content
-      await client.query(sqlContent);
+      await streamRestoreSQL(backupPath, client);
 
       console.log('Committing transaction...');
       await client.query('COMMIT');
@@ -141,7 +205,7 @@ async function restoreBackup(
         console.log('Verifying restore:');
         for (const [table, expectedCount] of Object.entries(metadata.rowCounts)) {
           try {
-            const result = await client.query(`SELECT COUNT(*) as count FROM ${table}`);
+            const result = await client.query(`SELECT COUNT(*) as count FROM "${table}"`);
             const actualCount = parseInt(result.rows[0].count, 10);
 
             if (actualCount === expectedCount) {
@@ -149,7 +213,7 @@ async function restoreBackup(
             } else {
               console.log(`  ⚠ ${table}: ${actualCount} rows (expected ${expectedCount})`);
             }
-          } catch (error) {
+          } catch {
             console.log(`  ✗ ${table}: verification failed`);
           }
         }
@@ -203,11 +267,11 @@ async function main() {
 
     console.log('');
 
-    // Read backup
-    const { sqlContent, metadata } = await readBackup(options.file);
+    // Read metadata
+    const metadata = await readMetadata(options.file);
 
-    // Restore backup
-    await restoreBackup(databaseUrl, sqlContent, metadata);
+    // Restore backup (streaming)
+    await restoreBackup(databaseUrl, options.file, metadata);
 
     console.log('');
     console.log('========================================');

--- a/backend/src/scripts/test-backup.ts
+++ b/backend/src/scripts/test-backup.ts
@@ -1,0 +1,416 @@
+#!/usr/bin/env node
+
+/**
+ * CLI Backup Test Script
+ *
+ * Standalone script to test the streaming backup against a live database
+ * without needing the full application running.
+ *
+ * Usage:
+ *   npx tsx src/scripts/test-backup.ts --database litemaas|litellm [--output path/to/output.sql.gz]
+ *
+ * Environment variables:
+ *   DATABASE_URL         - LiteMaaS database connection string
+ *   LITELLM_DATABASE_URL - LiteLLM database connection string
+ *
+ * Examples:
+ *   # Test against local LiteMaaS database (uses DATABASE_URL from .env)
+ *   npx tsx src/scripts/test-backup.ts --database litemaas
+ *
+ *   # Test against production LiteLLM database
+ *   LITELLM_DATABASE_URL="postgresql://user:pass@host:5432/litellm" npx tsx src/scripts/test-backup.ts --database litellm
+ *
+ *   # Custom output path
+ *   npx tsx src/scripts/test-backup.ts --database litellm --output /tmp/test-backup.sql.gz
+ */
+
+import { Pool, PoolClient } from 'pg';
+import { promises as fs } from 'fs';
+import { createReadStream, createWriteStream } from 'fs';
+import * as path from 'path';
+import * as zlib from 'zlib';
+
+// Load environment variables from .env if dotenv is available (not needed in pods)
+try {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  require('dotenv').config();
+} catch {
+  // dotenv not installed — env vars expected to be set by deployment
+}
+
+// PostgreSQL OIDs for type-aware serialization
+const PG_JSON_OID = 114;
+const PG_JSONB_OID = 3802;
+const PG_TIMESTAMP_OID = 1114;
+const PG_TIMESTAMPTZ_OID = 1184;
+
+const CURSOR_BATCH_SIZE = 1000;
+
+interface TestOptions {
+  database: 'litemaas' | 'litellm';
+  output: string;
+}
+
+function parseArgs(): TestOptions {
+  const args = process.argv.slice(2);
+  let database: 'litemaas' | 'litellm' | undefined;
+  let output: string | undefined;
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--database' && args[i + 1]) {
+      const db = args[i + 1];
+      if (db !== 'litemaas' && db !== 'litellm') {
+        throw new Error('Database must be either "litemaas" or "litellm"');
+      }
+      database = db;
+      i++;
+    } else if (args[i] === '--output' && args[i + 1]) {
+      output = args[i + 1];
+      i++;
+    }
+  }
+
+  if (!database) {
+    console.error(
+      'Usage: npx tsx src/scripts/test-backup.ts --database <litemaas|litellm> [--output <path>]',
+    );
+    console.error('');
+    console.error('Options:');
+    console.error('  --database <litemaas|litellm>  Target database to backup');
+    console.error(
+      '  --output <path>               Output file path (default: ./data/backups/test-backup-<db>.sql.gz)',
+    );
+    console.error('');
+    console.error('Environment variables:');
+    console.error('  DATABASE_URL           LiteMaaS database connection string');
+    console.error('  LITELLM_DATABASE_URL   LiteLLM database connection string');
+    process.exit(1);
+  }
+
+  const timestamp = new Date().toISOString().replace(/:/g, '-');
+  const defaultOutput = `./data/backups/test-backup-${database}-${timestamp}.sql.gz`;
+
+  return { database, output: output || defaultOutput };
+}
+
+function getDatabaseUrl(database: 'litemaas' | 'litellm'): string {
+  if (database === 'litemaas') {
+    const url = process.env.DATABASE_URL;
+    if (!url) {
+      throw new Error('DATABASE_URL environment variable is not set');
+    }
+    return url;
+  } else {
+    const url = process.env.LITELLM_DATABASE_URL;
+    if (!url) {
+      throw new Error('LITELLM_DATABASE_URL environment variable is not set');
+    }
+    return url;
+  }
+}
+
+function quoteIdentifier(name: string): string {
+  return `"${name.replace(/"/g, '""')}"`;
+}
+
+function escapeSQLValue(value: any, isJsonColumn = false, isTimestamp = false): string {
+  if (value === null || value === undefined) {
+    return 'NULL';
+  }
+
+  if (isTimestamp && typeof value === 'string') {
+    return `'${value}'`;
+  }
+
+  if (typeof value === 'boolean') {
+    return value ? 'true' : 'false';
+  }
+
+  if (typeof value === 'number') {
+    return value.toString();
+  }
+
+  if (value instanceof Date) {
+    return `'${value.toISOString()}'`;
+  }
+
+  if (Array.isArray(value)) {
+    if (isJsonColumn) {
+      return `'${JSON.stringify(value).replace(/'/g, "''")}'`;
+    }
+    const elements = value.map((v) => {
+      if (v === null || v === undefined) return 'NULL';
+      const escaped = String(v).replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+      return `"${escaped}"`;
+    });
+    return `'{${elements.join(',')}}'`;
+  }
+
+  if (typeof value === 'object') {
+    return `'${JSON.stringify(value).replace(/'/g, "''")}'`;
+  }
+
+  return `'${String(value).replace(/'/g, "''")}'`;
+}
+
+async function streamTableBackup(
+  client: PoolClient,
+  table: string,
+  write: (data: string) => Promise<void>,
+  rowCounts: Record<string, number>,
+): Promise<void> {
+  const quotedTable = quoteIdentifier(table);
+
+  const metaResult = await client.query(`SELECT * FROM ${quotedTable} LIMIT 0`);
+  const fields = metaResult.fields;
+
+  if (fields.length === 0) {
+    rowCounts[table] = 0;
+    await write(`-- Table: ${table} (no columns)\n\n`);
+    return;
+  }
+
+  const columns = fields.map((f) => f.name);
+  const quotedColumns = columns.map((c) => quoteIdentifier(c)).join(', ');
+
+  const jsonColumns = new Set(
+    fields
+      .filter((f) => f.dataTypeID === PG_JSON_OID || f.dataTypeID === PG_JSONB_OID)
+      .map((f) => f.name),
+  );
+  const timestampColumns = new Set(
+    fields
+      .filter((f) => f.dataTypeID === PG_TIMESTAMP_OID || f.dataTypeID === PG_TIMESTAMPTZ_OID)
+      .map((f) => f.name),
+  );
+
+  const selectColumns = fields
+    .map((f) => {
+      if (f.dataTypeID === PG_TIMESTAMP_OID || f.dataTypeID === PG_TIMESTAMPTZ_OID) {
+        return `${quoteIdentifier(f.name)}::text AS ${quoteIdentifier(f.name)}`;
+      }
+      return quoteIdentifier(f.name);
+    })
+    .join(', ');
+
+  const cursorName = `backup_${table.replace(/[^a-zA-Z0-9_]/g, '_')}`;
+  await client.query(
+    `DECLARE ${quoteIdentifier(cursorName)} CURSOR FOR SELECT ${selectColumns} FROM ${quotedTable}`,
+  );
+
+  await write(`-- Table: ${table}\n`);
+  await write(`TRUNCATE TABLE ${quotedTable} CASCADE;\n`);
+
+  let totalRows = 0;
+  let hasMore = true;
+
+  try {
+    while (hasMore) {
+      const batch = await client.query(
+        `FETCH ${CURSOR_BATCH_SIZE} FROM ${quoteIdentifier(cursorName)}`,
+      );
+      if (batch.rows.length === 0) {
+        hasMore = false;
+        break;
+      }
+
+      totalRows += batch.rows.length;
+
+      for (const row of batch.rows) {
+        const values = columns.map((col) =>
+          escapeSQLValue(row[col], jsonColumns.has(col), timestampColumns.has(col)),
+        );
+        await write(
+          `INSERT INTO ${quotedTable} (${quotedColumns}) VALUES (${values.join(', ')});\n`,
+        );
+      }
+
+      // Progress indicator for large tables
+      if (totalRows % 10000 === 0) {
+        process.stdout.write(`    ... ${totalRows} rows\n`);
+      }
+    }
+  } finally {
+    await client.query(`CLOSE ${quoteIdentifier(cursorName)}`);
+  }
+
+  rowCounts[table] = totalRows;
+  await write('\n');
+}
+
+async function main() {
+  const options = parseArgs();
+
+  console.log('========================================');
+  console.log('LiteMaaS Streaming Backup Test');
+  console.log('========================================');
+  console.log('');
+
+  const databaseUrl = getDatabaseUrl(options.database);
+  console.log(`Database:    ${options.database}`);
+  console.log(`URL:         ${databaseUrl.replace(/:[^:@]+@/, ':****@')}`);
+  console.log(`Output:      ${options.output}`);
+  console.log(`Batch size:  ${CURSOR_BATCH_SIZE} rows`);
+  console.log('');
+
+  // Ensure output directory exists
+  await fs.mkdir(path.dirname(options.output), { recursive: true });
+
+  const pool = new Pool({ connectionString: databaseUrl });
+
+  try {
+    // Discover tables
+    console.log('Discovering tables...');
+    const tableResult = await pool.query(`
+      SELECT tablename
+      FROM pg_tables
+      WHERE schemaname = 'public'
+      ORDER BY tablename
+    `);
+    const tables = tableResult.rows.map((row) => row.tablename);
+    console.log(`Found ${tables.length} tables: ${tables.join(', ')}`);
+    console.log('');
+
+    // Set up streaming gzip writer
+    const gzip = zlib.createGzip();
+    const fileStream = createWriteStream(options.output);
+    gzip.pipe(fileStream);
+
+    const write = (data: string): Promise<void> => {
+      return new Promise((resolve, reject) => {
+        const ok = gzip.write(data);
+        if (ok) {
+          resolve();
+        } else {
+          gzip.once('drain', resolve);
+          gzip.once('error', reject);
+        }
+      });
+    };
+
+    const rowCounts: Record<string, number> = {};
+    const startTime = Date.now();
+
+    // Track memory usage
+    const startMem = process.memoryUsage();
+    let peakHeapUsed = startMem.heapUsed;
+
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+
+      const timestamp = new Date().toISOString();
+      await write(`-- Database backup for ${options.database}\n`);
+      await write(`-- Generated at ${timestamp}\n\n`);
+
+      for (const table of tables) {
+        process.stdout.write(`  Backing up: ${table}...`);
+        const tableStart = Date.now();
+
+        await streamTableBackup(client, table, write, rowCounts);
+
+        const tableDuration = Date.now() - tableStart;
+        const currentMem = process.memoryUsage();
+        peakHeapUsed = Math.max(peakHeapUsed, currentMem.heapUsed);
+
+        console.log(
+          ` ${rowCounts[table]} rows (${tableDuration}ms, heap: ${Math.round(currentMem.heapUsed / 1024 / 1024)}MB)`,
+        );
+      }
+
+      await client.query('COMMIT');
+    } catch (error) {
+      await client.query('ROLLBACK');
+      throw error;
+    } finally {
+      client.release();
+    }
+
+    // Finalize gzip stream
+    await new Promise<void>((resolve, reject) => {
+      fileStream.on('finish', resolve);
+      fileStream.on('error', reject);
+      gzip.on('error', reject);
+      gzip.end();
+    });
+
+    const duration = Date.now() - startTime;
+    const stats = await fs.stat(options.output);
+    const totalRows = Object.values(rowCounts).reduce((sum, count) => sum + count, 0);
+
+    console.log('');
+    console.log('========================================');
+    console.log('Backup completed successfully!');
+    console.log('========================================');
+    console.log(`  Tables:      ${tables.length}`);
+    console.log(`  Total rows:  ${totalRows}`);
+    console.log(`  File size:   ${(stats.size / 1024 / 1024).toFixed(2)} MB`);
+    console.log(`  Duration:    ${(duration / 1000).toFixed(1)}s`);
+    console.log(`  Peak heap:   ${Math.round(peakHeapUsed / 1024 / 1024)} MB`);
+    console.log(`  Output:      ${options.output}`);
+    console.log('');
+
+    // Verify the backup file can be decompressed (stream just the first bytes)
+    console.log('Verifying backup file integrity...');
+    const header = await new Promise<string>((resolve, reject) => {
+      const chunks: Buffer[] = [];
+      let totalBytes = 0;
+      const gunzip = zlib.createGunzip();
+      const readStream = createReadStream(options.output);
+
+      gunzip.on('data', (chunk: Buffer) => {
+        chunks.push(chunk);
+        totalBytes += chunk.length;
+        if (totalBytes >= 200) {
+          readStream.destroy();
+          gunzip.destroy();
+          resolve(Buffer.concat(chunks).subarray(0, 200).toString('utf-8'));
+        }
+      });
+      gunzip.on('end', () => {
+        resolve(Buffer.concat(chunks).toString('utf-8'));
+      });
+      gunzip.on('error', reject);
+      readStream.on('error', reject);
+
+      readStream.pipe(gunzip);
+    });
+
+    if (header.includes('-- Database backup for')) {
+      console.log('  File integrity: OK');
+    } else {
+      console.error('  File integrity: FAILED - unexpected header');
+      process.exit(1);
+    }
+
+    process.exit(0);
+  } catch (error) {
+    console.error('');
+    console.error('========================================');
+    console.error('Backup FAILED!');
+    console.error('========================================');
+
+    if (error instanceof Error) {
+      console.error(`Error: ${error.message}`);
+      if (error.stack) {
+        console.error('');
+        console.error(error.stack);
+      }
+    } else {
+      console.error(`Error: ${String(error)}`);
+    }
+
+    // Clean up partial file
+    try {
+      await fs.unlink(options.output);
+    } catch {
+      // ignore
+    }
+
+    process.exit(1);
+  } finally {
+    await pool.end();
+  }
+}
+
+main();

--- a/backend/src/services/backup.service.ts
+++ b/backend/src/services/backup.service.ts
@@ -1,13 +1,15 @@
 import { FastifyInstance } from 'fastify';
 import { BaseService } from './base.service';
-import { Pool } from 'pg';
+import { Pool, PoolClient } from 'pg';
 import { promises as fs } from 'fs';
+import { createReadStream, createWriteStream } from 'fs';
 import * as path from 'path';
 import * as zlib from 'zlib';
 import {
   BackupCapabilities,
   BackupDatabaseType,
   BackupInfo,
+  BackupJobStatus,
   BackupMetadata,
   RestoreResult,
   TestRestoreResult,
@@ -46,8 +48,128 @@ export class BackupService extends BaseService {
     'system_settings',
   ];
 
+  // In-memory job state (singleton per pod — only one backup at a time)
+  private jobStatus: BackupJobStatus = { state: 'idle' };
+  private jobStartTime = 0;
+
   constructor(fastify: FastifyInstance) {
     super(fastify);
+  }
+
+  /**
+   * Get the current backup job status.
+   * Called by the frontend on mount and during polling.
+   */
+  getJobStatus(): BackupJobStatus {
+    // Update elapsed time for running jobs
+    if (this.jobStatus.state === 'running' && this.jobStatus.progress) {
+      this.jobStatus.progress.elapsed = Math.round((Date.now() - this.jobStartTime) / 1000);
+    }
+    return { ...this.jobStatus };
+  }
+
+  /**
+   * Start a backup job in the background.
+   * Returns immediately with status. The frontend polls getJobStatus() for progress.
+   */
+  startBackupJob(dbType: BackupDatabaseType, userId: string): BackupJobStatus {
+    if (this.jobStatus.state === 'running') {
+      throw ApplicationError.validation(
+        'A backup is already in progress',
+        'database',
+        this.jobStatus.database,
+      );
+    }
+
+    this.jobStartTime = Date.now();
+    this.jobStatus = {
+      state: 'running',
+      database: dbType,
+      startedAt: new Date().toISOString(),
+      progress: {
+        currentTable: '',
+        tablesCompleted: 0,
+        tablesTotal: 0,
+        rowsProcessed: 0,
+        rowsTotal: 0,
+        elapsed: 0,
+      },
+    };
+
+    // Fire and forget — errors are captured in jobStatus
+    this.runBackupJob(dbType, userId).catch((error) => {
+      this.fastify.log.error({ error, dbType }, 'Background backup job failed');
+    });
+
+    return this.getJobStatus();
+  }
+
+  /**
+   * Run the backup job in the background, updating progress as it goes.
+   */
+  private async runBackupJob(dbType: BackupDatabaseType, userId: string): Promise<void> {
+    try {
+      const backupInfo = await this.createBackup(dbType);
+
+      this.jobStatus = {
+        state: 'completed',
+        database: dbType,
+        backup: backupInfo,
+        startedAt: this.jobStatus.startedAt,
+        completedAt: new Date().toISOString(),
+      };
+
+      // Audit log
+      try {
+        await this.fastify.pg.query(
+          `INSERT INTO audit_logs (user_id, action, resource_type, resource_id, success, metadata, created_at)
+           VALUES ($1, $2, $3, $4, $5, $6, NOW())`,
+          [
+            userId,
+            'backup:create',
+            'backup',
+            backupInfo.id,
+            true,
+            JSON.stringify({
+              database: dbType,
+              filename: backupInfo.filename,
+              size: backupInfo.size,
+              tableCount: backupInfo.metadata.tableCount,
+            }),
+          ],
+        );
+      } catch (auditError) {
+        this.fastify.log.error({ error: auditError }, 'Failed to log backup audit trail');
+      }
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      this.jobStatus = {
+        state: 'failed',
+        database: dbType,
+        error: errorMessage,
+        startedAt: this.jobStatus.startedAt,
+        completedAt: new Date().toISOString(),
+      };
+
+      // Audit log failure
+      try {
+        await this.fastify.pg.query(
+          `INSERT INTO audit_logs (user_id, action, resource_type, resource_id, success, error_message, metadata, created_at)
+           VALUES ($1, $2, $3, $4, $5, $6, $7, NOW())`,
+          [
+            userId,
+            'backup:create',
+            'backup',
+            dbType,
+            false,
+            errorMessage,
+            JSON.stringify({ database: dbType }),
+          ],
+        );
+      } catch (auditError) {
+        this.fastify.log.error({ error: auditError }, 'Failed to log backup audit trail');
+      }
+    }
   }
 
   /**
@@ -87,7 +209,8 @@ export class BackupService extends BaseService {
   }
 
   /**
-   * Create a backup of the specified database
+   * Create a backup of the specified database.
+   * Uses streaming with cursors to avoid loading entire tables into memory.
    */
   async createBackup(dbType: BackupDatabaseType): Promise<BackupInfo> {
     const capabilities = await this.getCapabilities();
@@ -125,21 +248,8 @@ export class BackupService extends BaseService {
       // Get tables to backup
       const tables = await this.getTableList(pool, dbType);
 
-      // Generate SQL content
-      const sqlContent = await this.generateBackupSQL(pool, tables, dbType);
-
-      // Compress and save
-      const compressedData = zlib.gzipSync(sqlContent);
-      await fs.writeFile(backupPath, compressedData);
-
-      // Calculate row counts
-      const rowCounts: Record<string, number> = {};
-      for (const table of tables) {
-        const result = await pool.query(
-          `SELECT COUNT(*) as count FROM ${this.quoteIdentifier(table)}`,
-        );
-        rowCounts[table] = parseInt(result.rows[0].count, 10);
-      }
+      // Stream backup SQL directly to gzip file using cursors
+      const rowCounts = await this.streamBackupSQL(pool, tables, dbType, backupPath, timestamp);
 
       // Create metadata
       const metadata: BackupMetadata = {
@@ -278,7 +388,8 @@ export class BackupService extends BaseService {
   }
 
   /**
-   * Restore a backup to the specified database
+   * Restore a backup to the specified database.
+   * Streams the backup file and executes SQL statements in batches to avoid OOM.
    */
   async restoreBackup(id: string, dbType: BackupDatabaseType): Promise<RestoreResult> {
     const backupPath = this.getBackupPath(id);
@@ -296,10 +407,6 @@ export class BackupService extends BaseService {
       if (metadata.database !== dbType) {
         warnings.push(`Backup was created for ${metadata.database} but restoring to ${dbType}`);
       }
-
-      // Read and decompress backup
-      const compressedData = await fs.readFile(backupPath);
-      const sqlContent = zlib.gunzipSync(compressedData).toString('utf-8');
 
       // Get database pool
       let pool: Pool | undefined;
@@ -320,13 +427,12 @@ export class BackupService extends BaseService {
         throw this.createValidationError('Database pool not available', 'database');
       }
 
-      // Execute restore in transaction
+      // Execute restore in transaction, streaming SQL from the gzip file
       const client = await pool.connect();
       try {
         await client.query('BEGIN');
 
-        // Execute SQL content
-        await client.query(sqlContent);
+        await this.streamRestoreSQL(backupPath, client);
 
         await client.query('COMMIT');
 
@@ -388,10 +494,6 @@ export class BackupService extends BaseService {
       const metaContent = await fs.readFile(metaPath, 'utf-8');
       const metadata: BackupMetadata = JSON.parse(metaContent);
 
-      // Read and decompress backup
-      const compressedData = await fs.readFile(backupPath);
-      const sqlContent = zlib.gunzipSync(compressedData).toString('utf-8');
-
       // Get database pool
       let pool: Pool | undefined;
       let shouldClosePool = false;
@@ -429,11 +531,8 @@ export class BackupService extends BaseService {
           );
         }
 
-        // Modify SQL to use test schema
-        const testSqlContent = this.modifySQLForSchema(sqlContent, testSchema);
-
-        // Execute restore in test schema
-        await client.query(testSqlContent);
+        // Stream restore into the test schema
+        await this.streamRestoreSQL(backupPath, client, testSchema);
 
         await client.query('COMMIT');
 
@@ -517,74 +616,184 @@ export class BackupService extends BaseService {
   private readonly PG_TIMESTAMPTZ_OID = 1184;
 
   /**
-   * Generate SQL content for backup
+   * Number of rows to fetch per cursor batch during backup.
+   * Balances memory usage vs. number of database round-trips.
    */
-  private async generateBackupSQL(
+  private readonly CURSOR_BATCH_SIZE = 1000;
+
+  /**
+   * Stream backup SQL directly to a gzip-compressed file using database cursors.
+   * This avoids loading entire tables into memory, preventing OOM on large databases.
+   * Returns row counts per table for metadata.
+   */
+  private async streamBackupSQL(
     pool: Pool,
     tables: string[],
     dbType: BackupDatabaseType,
-  ): Promise<string> {
-    let sql = `-- Database backup for ${dbType}\n`;
-    sql += `-- Generated at ${new Date().toISOString()}\n\n`;
+    backupPath: string,
+    timestamp: string,
+  ): Promise<Record<string, number>> {
+    const rowCounts: Record<string, number> = {};
 
-    for (const table of tables) {
-      const quotedTable = this.quoteIdentifier(table);
-      sql += `-- Table: ${table}\n`;
-      sql += `TRUNCATE TABLE ${quotedTable} CASCADE;\n`;
+    // Set up streaming gzip writer
+    const gzip = zlib.createGzip();
+    const fileStream = createWriteStream(backupPath);
+    gzip.pipe(fileStream);
 
-      // First, get column metadata to identify types
-      const metaResult = await pool.query(`SELECT * FROM ${quotedTable} LIMIT 0`);
-      const fields = metaResult.fields;
+    // Helper to write to gzip stream with backpressure handling
+    const write = (data: string): Promise<void> => {
+      return new Promise((resolve, reject) => {
+        const ok = gzip.write(data);
+        if (ok) {
+          resolve();
+        } else {
+          gzip.once('drain', resolve);
+          gzip.once('error', reject);
+        }
+      });
+    };
 
-      if (fields.length > 0) {
-        const columns = fields.map((f) => f.name);
-        const quotedColumns = columns.map((c) => this.quoteIdentifier(c)).join(', ');
+    // Use a single client with a transaction for cursor support
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
 
-        // Build sets of columns by type for proper serialization
-        const jsonColumns = new Set(
-          fields
-            .filter((f) => f.dataTypeID === this.PG_JSON_OID || f.dataTypeID === this.PG_JSONB_OID)
-            .map((f) => f.name),
-        );
-        const timestampColumns = new Set(
-          fields
-            .filter(
-              (f) =>
-                f.dataTypeID === this.PG_TIMESTAMP_OID ||
-                f.dataTypeID === this.PG_TIMESTAMPTZ_OID,
-            )
-            .map((f) => f.name),
-        );
-
-        // Cast timestamp columns to text in the query to preserve exact precision and timezone
-        const selectColumns = fields
-          .map((f) => {
-            if (
-              f.dataTypeID === this.PG_TIMESTAMP_OID ||
-              f.dataTypeID === this.PG_TIMESTAMPTZ_OID
-            ) {
-              return `${this.quoteIdentifier(f.name)}::text AS ${this.quoteIdentifier(f.name)}`;
-            }
-            return this.quoteIdentifier(f.name);
-          })
-          .join(', ');
-
-        // Get all rows with timestamps as text
-        const result = await pool.query(`SELECT ${selectColumns} FROM ${quotedTable}`);
-
-        // Generate INSERT statements
-        for (const row of result.rows) {
-          const values = columns.map((col) =>
-            this.escapeSQLValue(row[col], jsonColumns.has(col), timestampColumns.has(col)),
+      // Count total rows across all tables for accurate progress tracking
+      if (this.jobStatus.progress) {
+        this.jobStatus.progress.tablesTotal = tables.length;
+        let totalRows = 0;
+        for (const table of tables) {
+          const countResult = await client.query(
+            `SELECT COUNT(*) as count FROM ${this.quoteIdentifier(table)}`,
           );
-          sql += `INSERT INTO ${quotedTable} (${quotedColumns}) VALUES (${values.join(', ')});\n`;
+          totalRows += parseInt(countResult.rows[0].count, 10);
+        }
+        this.jobStatus.progress.rowsTotal = totalRows;
+      }
+
+      await write(`-- Database backup for ${dbType}\n`);
+      await write(`-- Generated at ${timestamp}\n\n`);
+
+      for (const table of tables) {
+        // Update progress with current table
+        if (this.jobStatus.progress) {
+          this.jobStatus.progress.currentTable = table;
+        }
+
+        await this.streamTableBackup(client, table, write, rowCounts);
+
+        // Update progress after each table
+        if (this.jobStatus.progress) {
+          this.jobStatus.progress.tablesCompleted += 1;
+          this.jobStatus.progress.rowsProcessed += rowCounts[table] || 0;
         }
       }
 
-      sql += '\n';
+      await client.query('COMMIT');
+    } catch (error) {
+      await client.query('ROLLBACK');
+      throw error;
+    } finally {
+      client.release();
     }
 
-    return sql;
+    // Finalize gzip stream and wait for file write to complete
+    await new Promise<void>((resolve, reject) => {
+      fileStream.on('finish', resolve);
+      fileStream.on('error', reject);
+      gzip.on('error', reject);
+      gzip.end();
+    });
+
+    return rowCounts;
+  }
+
+  /**
+   * Stream a single table's backup data using a cursor.
+   */
+  private async streamTableBackup(
+    client: PoolClient,
+    table: string,
+    write: (data: string) => Promise<void>,
+    rowCounts: Record<string, number>,
+  ): Promise<void> {
+    const quotedTable = this.quoteIdentifier(table);
+    await write(`-- Table: ${table}\n`);
+    await write(`TRUNCATE TABLE ${quotedTable} CASCADE;\n`);
+
+    // Get column metadata to identify types
+    const metaResult = await client.query(`SELECT * FROM ${quotedTable} LIMIT 0`);
+    const fields = metaResult.fields;
+
+    if (fields.length === 0) {
+      rowCounts[table] = 0;
+      await write('\n');
+      return;
+    }
+
+    const columns = fields.map((f) => f.name);
+    const quotedColumns = columns.map((c) => this.quoteIdentifier(c)).join(', ');
+
+    // Build sets of columns by type for proper serialization
+    const jsonColumns = new Set(
+      fields
+        .filter((f) => f.dataTypeID === this.PG_JSON_OID || f.dataTypeID === this.PG_JSONB_OID)
+        .map((f) => f.name),
+    );
+    const timestampColumns = new Set(
+      fields
+        .filter(
+          (f) => f.dataTypeID === this.PG_TIMESTAMP_OID || f.dataTypeID === this.PG_TIMESTAMPTZ_OID,
+        )
+        .map((f) => f.name),
+    );
+
+    // Cast timestamp columns to text to preserve exact precision and timezone
+    const selectColumns = fields
+      .map((f) => {
+        if (f.dataTypeID === this.PG_TIMESTAMP_OID || f.dataTypeID === this.PG_TIMESTAMPTZ_OID) {
+          return `${this.quoteIdentifier(f.name)}::text AS ${this.quoteIdentifier(f.name)}`;
+        }
+        return this.quoteIdentifier(f.name);
+      })
+      .join(', ');
+
+    // Use a cursor to fetch rows in batches
+    const cursorName = `backup_${table.replace(/[^a-zA-Z0-9_]/g, '_')}`;
+    await client.query(
+      `DECLARE ${this.quoteIdentifier(cursorName)} CURSOR FOR SELECT ${selectColumns} FROM ${quotedTable}`,
+    );
+
+    let totalRows = 0;
+    let hasMore = true;
+
+    try {
+      while (hasMore) {
+        const batch = await client.query(
+          `FETCH ${this.CURSOR_BATCH_SIZE} FROM ${this.quoteIdentifier(cursorName)}`,
+        );
+        if (batch.rows.length === 0) {
+          hasMore = false;
+          break;
+        }
+
+        totalRows += batch.rows.length;
+
+        for (const row of batch.rows) {
+          const values = columns.map((col) =>
+            this.escapeSQLValue(row[col], jsonColumns.has(col), timestampColumns.has(col)),
+          );
+          await write(
+            `INSERT INTO ${quotedTable} (${quotedColumns}) VALUES (${values.join(', ')});\n`,
+          );
+        }
+      }
+    } finally {
+      await client.query(`CLOSE ${this.quoteIdentifier(cursorName)}`);
+    }
+
+    rowCounts[table] = totalRows;
+    await write('\n');
   }
 
   /**
@@ -640,21 +849,100 @@ export class BackupService extends BaseService {
   /**
    * Modify SQL to use a specific schema
    */
-  private modifySQLForSchema(sql: string, schema: string): string {
-    // Replace table references with schema-qualified references
-    // Handles both quoted ("table") and unquoted (table) identifiers
-    const lines = sql.split('\n');
-    return lines
-      .map((line) => {
-        if (line.startsWith('TRUNCATE TABLE ')) {
-          return line.replace('TRUNCATE TABLE ', `TRUNCATE TABLE ${schema}.`);
+  /**
+   * Stream-decompress a backup file and execute SQL statements in batches.
+   * Avoids loading the entire decompressed SQL into memory.
+   * Optionally rewrites table references to a different schema (for test restore).
+   */
+  private async streamRestoreSQL(
+    backupPath: string,
+    client: PoolClient,
+    schema?: string,
+  ): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      const gunzip = zlib.createGunzip();
+      const readStream = createReadStream(backupPath);
+      let buffer = '';
+
+      gunzip.on('data', (chunk: Buffer) => {
+        buffer += chunk.toString('utf-8');
+
+        // Process complete statements (lines ending with ;)
+        const lastNewline = buffer.lastIndexOf('\n');
+        if (lastNewline === -1) return;
+
+        const processable = buffer.substring(0, lastNewline);
+        buffer = buffer.substring(lastNewline + 1);
+
+        const statements = processable
+          .split('\n')
+          .filter((line) => {
+            const trimmed = line.trim();
+            return trimmed.length > 0 && !trimmed.startsWith('--');
+          })
+          .map((line) => {
+            if (!schema) return line;
+            // Rewrite table references to the target schema
+            if (line.startsWith('TRUNCATE TABLE ')) {
+              return line.replace('TRUNCATE TABLE ', `TRUNCATE TABLE ${schema}.`);
+            }
+            if (line.startsWith('INSERT INTO ')) {
+              return line.replace('INSERT INTO ', `INSERT INTO ${schema}.`);
+            }
+            return line;
+          });
+
+        if (statements.length > 0) {
+          // Pause the stream while we execute, to avoid unbounded buffering
+          gunzip.pause();
+          const batch = statements.join('\n');
+          client
+            .query(batch)
+            .then(() => {
+              gunzip.resume();
+            })
+            .catch((err) => {
+              readStream.destroy();
+              gunzip.destroy();
+              reject(err);
+            });
         }
-        if (line.startsWith('INSERT INTO ')) {
-          return line.replace('INSERT INTO ', `INSERT INTO ${schema}.`);
+      });
+
+      gunzip.on('end', () => {
+        // Process any remaining buffer
+        const remaining = buffer
+          .split('\n')
+          .filter((line) => {
+            const trimmed = line.trim();
+            return trimmed.length > 0 && !trimmed.startsWith('--');
+          })
+          .map((line) => {
+            if (!schema) return line;
+            if (line.startsWith('TRUNCATE TABLE ')) {
+              return line.replace('TRUNCATE TABLE ', `TRUNCATE TABLE ${schema}.`);
+            }
+            if (line.startsWith('INSERT INTO ')) {
+              return line.replace('INSERT INTO ', `INSERT INTO ${schema}.`);
+            }
+            return line;
+          });
+
+        if (remaining.length > 0) {
+          client
+            .query(remaining.join('\n'))
+            .then(() => resolve())
+            .catch(reject);
+        } else {
+          resolve();
         }
-        return line;
-      })
-      .join('\n');
+      });
+
+      gunzip.on('error', reject);
+      readStream.on('error', reject);
+
+      readStream.pipe(gunzip);
+    });
   }
 
   /**

--- a/backend/src/types/backup.types.ts
+++ b/backend/src/types/backup.types.ts
@@ -25,6 +25,27 @@ export interface BackupInfo {
   metadata: BackupMetadata;
 }
 
+export type BackupJobState = 'idle' | 'running' | 'completed' | 'failed';
+
+export interface BackupJobProgress {
+  currentTable: string;
+  tablesCompleted: number;
+  tablesTotal: number;
+  rowsProcessed: number;
+  rowsTotal: number;
+  elapsed: number;
+}
+
+export interface BackupJobStatus {
+  state: BackupJobState;
+  database?: BackupDatabaseType;
+  progress?: BackupJobProgress;
+  backup?: BackupInfo;
+  error?: string;
+  startedAt?: string;
+  completedAt?: string;
+}
+
 export interface RestoreResult {
   success: boolean;
   tablesRestored: number;

--- a/deployment/helm/README.md
+++ b/deployment/helm/README.md
@@ -32,7 +32,7 @@ helm install litemaas deployment/helm/litemaas/ \
 | Backend    | `quay.io/rh-aiservices-bu/litemaas-backend:<appVersion>` |
 | Frontend   | `quay.io/rh-aiservices-bu/litemaas-frontend:<appVersion>` |
 
-Backend and frontend image tags default to the chart's `appVersion` (currently `0.3.0`). Override with `backend.image.tag` / `frontend.image.tag`.
+Backend and frontend image tags default to the chart's `appVersion` (currently `0.3.1`). Override with `backend.image.tag` / `frontend.image.tag`.
 
 ## Documentation
 

--- a/deployment/helm/litemaas/Chart.yaml
+++ b/deployment/helm/litemaas/Chart.yaml
@@ -3,7 +3,7 @@ name: litemaas
 description: LiteMaaS - Model subscription and management platform with LiteLLM integration
 type: application
 version: 0.1.0
-appVersion: "0.3.0"
+appVersion: "0.3.1"
 keywords:
   - litemaas
   - litellm

--- a/deployment/kustomize/user-values.env.example
+++ b/deployment/kustomize/user-values.env.example
@@ -1,4 +1,4 @@
-LITEMAAS_VERSION=0.3.0
+LITEMAAS_VERSION=0.3.1
 CLUSTER_DOMAIN_NAME=your-cluster-domain
 NAMESPACE=your-namespace
 PG_ADMIN_PASSWORD=change-me-pg-password

--- a/frontend/src/components/backup/BackupTab.tsx
+++ b/frontend/src/components/backup/BackupTab.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useQuery, useMutation, useQueryClient } from 'react-query';
 import {
@@ -25,6 +25,8 @@ import {
   DescriptionListTerm,
   DescriptionListDescription,
   Tooltip,
+  Progress,
+  ProgressMeasureLocation,
 } from '@patternfly/react-core';
 import { Table, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
 import {
@@ -39,6 +41,7 @@ import {
   backupService,
   type BackupDatabaseType,
   type BackupInfo,
+  type BackupJobStatus,
   type TestRestoreResult,
 } from '../../services/backup.service';
 import { extractErrorDetails } from '../../utils/error.utils';
@@ -69,40 +72,87 @@ const BackupTab: React.FC<BackupTabProps> = ({ canManage }) => {
     backupService.listBackups(),
   );
 
-  // Mutations
-  const createLitemaasBackup = useMutation(() => backupService.createBackup('litemaas'), {
-    onSuccess: () => {
-      queryClient.invalidateQueries(['backupList']);
-      addNotification({
-        variant: 'success',
-        title: t('pages.tools.backup.notifications.backupCreated'),
-      });
-    },
-    onError: (error: Error) => {
-      addNotification({
-        variant: 'danger',
-        title: t('pages.tools.backup.notifications.error'),
-        description: extractErrorDetails(error).message || undefined,
-      });
-    },
-  });
+  // Backup job state and polling
+  const [jobStatus, setJobStatus] = useState<BackupJobStatus | null>(null);
+  const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  const createLitellmBackup = useMutation(() => backupService.createBackup('litellm'), {
-    onSuccess: () => {
-      queryClient.invalidateQueries(['backupList']);
-      addNotification({
-        variant: 'success',
-        title: t('pages.tools.backup.notifications.backupCreated'),
-      });
+  const stopPolling = useCallback(() => {
+    if (pollingRef.current) {
+      clearInterval(pollingRef.current);
+      pollingRef.current = null;
+    }
+  }, []);
+
+  const pollJobStatus = useCallback(async () => {
+    try {
+      const status = await backupService.getJobStatus();
+      setJobStatus(status);
+
+      if (status.state === 'completed') {
+        stopPolling();
+        queryClient.invalidateQueries(['backupList']);
+        addNotification({
+          variant: 'success',
+          title: t('pages.tools.backup.notifications.backupCompleted'),
+        });
+      } else if (status.state === 'failed') {
+        stopPolling();
+        addNotification({
+          variant: 'danger',
+          title: t('pages.tools.backup.notifications.backupFailed'),
+          description: status.error || undefined,
+        });
+      }
+    } catch {
+      // Polling failure is non-fatal — will retry on next interval
+    }
+  }, [stopPolling, queryClient, addNotification, t]);
+
+  const startPolling = useCallback(() => {
+    stopPolling();
+    pollingRef.current = setInterval(pollJobStatus, 2000);
+  }, [stopPolling, pollJobStatus]);
+
+  // On mount, check if there's an active job (e.g., admin navigated away and back)
+  useEffect(() => {
+    const checkActiveJob = async () => {
+      try {
+        const status = await backupService.getJobStatus();
+        setJobStatus(status);
+        if (status.state === 'running') {
+          startPolling();
+        }
+      } catch {
+        // Ignore — no active job
+      }
+    };
+    checkActiveJob();
+    return stopPolling;
+  }, [startPolling, stopPolling]);
+
+  const isBackupRunning = jobStatus?.state === 'running';
+
+  // Mutations
+  const startBackupMutation = useMutation(
+    (dbType: BackupDatabaseType) => backupService.startBackup(dbType),
+    {
+      onSuccess: (status) => {
+        setJobStatus(status);
+        startPolling();
+        addNotification({
+          variant: 'info',
+          title: t('pages.tools.backup.notifications.backupStarted'),
+        });
+      },
+      onError: (error: Error) => {
+        addNotification({
+          variant: 'danger',
+          title: t('pages.tools.backup.notifications.error'),
+          description: extractErrorDetails(error).message || undefined,
+        });
+      },
     },
-    onError: (error: Error) => {
-      addNotification({
-        variant: 'danger',
-        title: t('pages.tools.backup.notifications.error'),
-        description: extractErrorDetails(error).message || undefined,
-      });
-    },
-  });
+  );
 
   const deleteBackupMutation = useMutation((id: string) => backupService.deleteBackup(id), {
     onSuccess: () => {
@@ -262,14 +312,12 @@ const BackupTab: React.FC<BackupTabProps> = ({ canManage }) => {
                   <FlexItem>
                     <Button
                       variant="primary"
-                      onClick={() => createLitemaasBackup.mutate()}
-                      isDisabled={!canManage || createLitemaasBackup.isLoading}
-                      isLoading={createLitemaasBackup.isLoading}
+                      onClick={() => startBackupMutation.mutate('litemaas')}
+                      isDisabled={!canManage || isBackupRunning || startBackupMutation.isLoading}
+                      isLoading={startBackupMutation.isLoading}
                       icon={<DatabaseIcon />}
                     >
-                      {createLitemaasBackup.isLoading
-                        ? t('pages.tools.backup.creating')
-                        : t('pages.tools.backup.createBackup')}
+                      {t('pages.tools.backup.createBackup')}
                     </Button>
                   </FlexItem>
                 </Flex>
@@ -290,14 +338,12 @@ const BackupTab: React.FC<BackupTabProps> = ({ canManage }) => {
                     <FlexItem>
                       <Button
                         variant="primary"
-                        onClick={() => createLitellmBackup.mutate()}
-                        isDisabled={!canManage || createLitellmBackup.isLoading}
-                        isLoading={createLitellmBackup.isLoading}
+                        onClick={() => startBackupMutation.mutate('litellm')}
+                        isDisabled={!canManage || isBackupRunning || startBackupMutation.isLoading}
+                        isLoading={startBackupMutation.isLoading}
                         icon={<DatabaseIcon />}
                       >
-                        {createLitellmBackup.isLoading
-                          ? t('pages.tools.backup.creating')
-                          : t('pages.tools.backup.createBackup')}
+                        {t('pages.tools.backup.createBackup')}
                       </Button>
                     </FlexItem>
                   ) : (
@@ -315,6 +361,78 @@ const BackupTab: React.FC<BackupTabProps> = ({ canManage }) => {
           </SplitItem>
         </Split>
       </FlexItem>
+
+      {/* Progress Section: shown when a backup job is running */}
+      {isBackupRunning && jobStatus?.progress && (
+        <FlexItem>
+          <Card isCompact>
+            <CardTitle>
+              <Flex
+                spaceItems={{ default: 'spaceItemsSm' }}
+                alignItems={{ default: 'alignItemsCenter' }}
+              >
+                <FlexItem>
+                  <Spinner size="md" />
+                </FlexItem>
+                <FlexItem>
+                  {t('pages.tools.backup.progress.title')} ({jobStatus.database})
+                </FlexItem>
+              </Flex>
+            </CardTitle>
+            <CardBody>
+              <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsMd' }}>
+                <FlexItem>
+                  <Progress
+                    value={
+                      jobStatus.progress.rowsTotal > 0
+                        ? Math.round(
+                            (jobStatus.progress.rowsProcessed / jobStatus.progress.rowsTotal) * 100,
+                          )
+                        : 0
+                    }
+                    title={t('pages.tools.backup.progress.rows')}
+                    measureLocation={ProgressMeasureLocation.outside}
+                    label={`${jobStatus.progress.rowsProcessed.toLocaleString()} / ${jobStatus.progress.rowsTotal.toLocaleString()}`}
+                  />
+                </FlexItem>
+                <FlexItem>
+                  <DescriptionList isCompact isHorizontal>
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>
+                        {t('pages.tools.backup.progress.table')}
+                      </DescriptionListTerm>
+                      <DescriptionListDescription>
+                        {jobStatus.progress.currentTable || '—'}
+                      </DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>
+                        {t('pages.tools.backup.progress.tables')}
+                      </DescriptionListTerm>
+                      <DescriptionListDescription>
+                        {t('pages.tools.backup.progress.tablesProgress', {
+                          completed: jobStatus.progress.tablesCompleted,
+                          total: jobStatus.progress.tablesTotal,
+                        })}
+                      </DescriptionListDescription>
+                    </DescriptionListGroup>
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>
+                        {t('pages.tools.backup.progress.elapsed')}
+                      </DescriptionListTerm>
+                      <DescriptionListDescription>
+                        {t('pages.tools.backup.progress.seconds', {
+                          seconds: jobStatus.progress.elapsed,
+                        })}
+                      </DescriptionListDescription>
+                    </DescriptionListGroup>
+                  </DescriptionList>
+                </FlexItem>
+              </Flex>
+            </CardBody>
+          </Card>
+        </FlexItem>
+      )}
 
       {/* Bottom Section: Backups Table */}
       <FlexItem>

--- a/frontend/src/i18n/locales/de/translation.json
+++ b/frontend/src/i18n/locales/de/translation.json
@@ -1364,7 +1364,21 @@
           "backupDeleted": "Sicherung erfolgreich gelöscht.",
           "restoreSuccess": "Datenbank erfolgreich aus der Sicherung wiederhergestellt.",
           "testRestoreComplete": "Testwiederherstellung abgeschlossen.",
-          "error": "Bei der Sicherungsoperation ist ein Fehler aufgetreten."
+          "error": "Bei der Sicherungsoperation ist ein Fehler aufgetreten.",
+          "backupStarted": "Sicherung gestartet.",
+          "backupCompleted": "Sicherung erfolgreich abgeschlossen.",
+          "backupFailed": "Sicherung fehlgeschlagen."
+        },
+        "progress": {
+          "title": "Sicherung läuft",
+          "database": "Datenbank",
+          "table": "Aktuelle Tabelle",
+          "tables": "Tabellen",
+          "tablesProgress": "{{completed}} / {{total}}",
+          "rows": "Verarbeitete Zeilen",
+          "elapsed": "Verstrichene Zeit",
+          "seconds": "{{seconds}}s",
+          "alreadyRunning": "Eine Sicherung wird bereits durchgeführt."
         }
       },
       "bulkUpdate": {

--- a/frontend/src/i18n/locales/elv/translation.json
+++ b/frontend/src/i18n/locales/elv/translation.json
@@ -1359,12 +1359,26 @@
           "schemaNameLabel": "Eneth thírad-echui",
           "schemaNameHelper": "I eneth en echui lû-vir ennas i tirith-gwaed aderthanner an thírad."
         },
+        "progress": {
+          "title": "Tirith-gwaed ned carith",
+          "database": "Gwaed-dagor",
+          "table": "Taur i-sí",
+          "tables": "Taurain",
+          "tablesProgress": "{{completed}} / {{total}}",
+          "rows": "Ristain cernin",
+          "elapsed": "Lû gwannen",
+          "seconds": "{{seconds}}s",
+          "alreadyRunning": "Tirith-gwaed ned carith erin."
+        },
         "notifications": {
           "backupCreated": "Tirith-gwaed carnen na galu.",
           "backupDeleted": "Tirith-gwaed dregon na galu.",
           "restoreSuccess": "Gwaed-dagor aderthannen na galu o tirith-gwaed.",
           "testRestoreComplete": "Aderthad-thírad tellin.",
-          "error": "Raeg tollen ned carith tirith-gwaed."
+          "error": "Raeg tollen ned carith tirith-gwaed.",
+          "backupStarted": "Tirith-gwaed carith orthad.",
+          "backupCompleted": "Tirith-gwaed tellin na galu.",
+          "backupFailed": "Tirith-gwaed aun."
         }
       },
       "bulkUpdate": {

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -1321,6 +1321,17 @@
         },
         "createBackup": "Create Backup",
         "creating": "Creating...",
+        "progress": {
+          "title": "Backup in progress",
+          "database": "Database",
+          "table": "Current table",
+          "tables": "Tables",
+          "tablesProgress": "{{completed}} / {{total}}",
+          "rows": "Rows processed",
+          "elapsed": "Elapsed time",
+          "seconds": "{{seconds}}s",
+          "alreadyRunning": "A backup is already in progress."
+        },
         "table": {
           "database": "Database",
           "timestamp": "Timestamp",
@@ -1360,6 +1371,9 @@
           "schemaNameHelper": "The name of the temporary schema where the backup will be restored for validation."
         },
         "notifications": {
+          "backupStarted": "Backup job started.",
+          "backupCompleted": "Backup completed successfully.",
+          "backupFailed": "Backup failed.",
           "backupCreated": "Backup created successfully.",
           "backupDeleted": "Backup deleted successfully.",
           "restoreSuccess": "Database restored successfully from backup.",

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -1360,11 +1360,25 @@
           "schemaNameHelper": "El nombre del esquema temporal donde se restaurará la copia de seguridad para su validación."
         },
         "notifications": {
+          "backupCompleted": "Copia de seguridad completada con éxito.",
           "backupCreated": "Copia de seguridad creada correctamente.",
           "backupDeleted": "Copia de seguridad eliminada correctamente.",
+          "backupFailed": "La copia de seguridad ha fallado.",
+          "backupStarted": "Se ha iniciado la copia de seguridad.",
           "restoreSuccess": "Base de datos restaurada correctamente desde la copia de seguridad.",
           "testRestoreComplete": "Restauración de prueba completada.",
           "error": "Ocurrió un error durante la operación de copia de seguridad."
+        },
+        "progress": {
+          "title": "Copia de seguridad en progreso",
+          "database": "Base de datos",
+          "table": "Tabla actual",
+          "tables": "Tablas",
+          "tablesProgress": "{{completed}} / {{total}}",
+          "rows": "Filas procesadas",
+          "elapsed": "Tiempo transcurrido",
+          "seconds": "{{seconds}}s",
+          "alreadyRunning": "Ya hay una copia de seguridad en curso."
         }
       },
       "bulkUpdate": {

--- a/frontend/src/i18n/locales/fr/translation.json
+++ b/frontend/src/i18n/locales/fr/translation.json
@@ -1359,9 +1359,23 @@
           "schemaNameLabel": "Nom du schéma de test",
           "schemaNameHelper": "Le nom du schéma temporaire dans lequel la sauvegarde sera restaurée pour validation."
         },
+        "progress": {
+          "title": "Sauvegarde en cours",
+          "database": "Base de données",
+          "table": "Table en cours",
+          "tables": "Tables",
+          "tablesProgress": "{{completed}} / {{total}}",
+          "rows": "Lignes traitées",
+          "elapsed": "Temps écoulé",
+          "seconds": "{{seconds}}s",
+          "alreadyRunning": "Une sauvegarde est déjà en cours."
+        },
         "notifications": {
           "backupCreated": "Sauvegarde créée avec succès.",
           "backupDeleted": "Sauvegarde supprimée avec succès.",
+          "backupStarted": "La sauvegarde a démarré.",
+          "backupCompleted": "Sauvegarde terminée avec succès.",
+          "backupFailed": "La sauvegarde a échoué.",
           "restoreSuccess": "Base de données restaurée avec succès depuis la sauvegarde.",
           "testRestoreComplete": "Restauration test terminée.",
           "error": "Une erreur est survenue lors de l'opération de sauvegarde."

--- a/frontend/src/i18n/locales/it/translation.json
+++ b/frontend/src/i18n/locales/it/translation.json
@@ -1359,9 +1359,23 @@
           "schemaNameLabel": "Nome dello schema di test",
           "schemaNameHelper": "Il nome dello schema temporaneo in cui il backup verrà ripristinato per la validazione."
         },
+        "progress": {
+          "title": "Backup in corso",
+          "database": "Database",
+          "table": "Tabella corrente",
+          "tables": "Tabelle",
+          "tablesProgress": "{{completed}} / {{total}}",
+          "rows": "Righe elaborate",
+          "elapsed": "Tempo trascorso",
+          "seconds": "{{seconds}}s",
+          "alreadyRunning": "Un backup è già in corso."
+        },
         "notifications": {
           "backupCreated": "Backup creato con successo.",
+          "backupCompleted": "Backup completato con successo.",
           "backupDeleted": "Backup eliminato con successo.",
+          "backupFailed": "Il backup non è riuscito.",
+          "backupStarted": "Il backup è stato avviato.",
           "restoreSuccess": "Database ripristinato con successo dal backup.",
           "testRestoreComplete": "Ripristino di test completato.",
           "error": "Si è verificato un errore durante l'operazione di backup."

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -1359,12 +1359,26 @@
           "schemaNameLabel": "テストスキーマ名",
           "schemaNameHelper": "バックアップの検証用に復元される一時スキーマの名前です。"
         },
+        "progress": {
+          "title": "バックアップ実行中",
+          "database": "データベース",
+          "table": "現在のテーブル",
+          "tables": "テーブル",
+          "tablesProgress": "{{completed}} / {{total}}",
+          "rows": "処理済み行数",
+          "elapsed": "経過時間",
+          "seconds": "{{seconds}}秒",
+          "alreadyRunning": "バックアップが既に実行中です。"
+        },
         "notifications": {
           "backupCreated": "バックアップが正常に作成されました。",
           "backupDeleted": "バックアップが正常に削除されました。",
           "restoreSuccess": "バックアップからデータベースが正常に復元されました。",
           "testRestoreComplete": "テスト復元が完了しました。",
-          "error": "バックアップ操作中にエラーが発生しました。"
+          "error": "バックアップ操作中にエラーが発生しました。",
+          "backupStarted": "バックアップを開始しました。",
+          "backupCompleted": "バックアップが正常に完了しました。",
+          "backupFailed": "バックアップに失敗しました。"
         }
       },
       "bulkUpdate": {

--- a/frontend/src/i18n/locales/ko/translation.json
+++ b/frontend/src/i18n/locales/ko/translation.json
@@ -1359,12 +1359,26 @@
           "schemaNameLabel": "테스트 스키마 이름",
           "schemaNameHelper": "백업이 검증을 위해 복원될 임시 스키마의 이름입니다."
         },
+        "progress": {
+          "title": "백업 진행 중",
+          "database": "데이터베이스",
+          "table": "현재 테이블",
+          "tables": "테이블",
+          "tablesProgress": "{{completed}} / {{total}}",
+          "rows": "처리된 행",
+          "elapsed": "경과 시간",
+          "seconds": "{{seconds}}초",
+          "alreadyRunning": "백업이 이미 진행 중입니다."
+        },
         "notifications": {
           "backupCreated": "백업이 성공적으로 생성되었습니다.",
           "backupDeleted": "백업이 성공적으로 삭제되었습니다.",
           "restoreSuccess": "백업에서 데이터베이스가 성공적으로 복원되었습니다.",
           "testRestoreComplete": "테스트 복원이 완료되었습니다.",
-          "error": "백업 작업 중 오류가 발생했습니다."
+          "error": "백업 작업 중 오류가 발생했습니다.",
+          "backupStarted": "백업이 시작되었습니다.",
+          "backupCompleted": "백업이 성공적으로 완료되었습니다.",
+          "backupFailed": "백업에 실패했습니다."
         }
       },
       "bulkUpdate": {

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -1359,12 +1359,26 @@
           "schemaNameLabel": "测试架构名称",
           "schemaNameHelper": "用于验证备份恢复的临时架构名称。"
         },
+        "progress": {
+          "title": "备份进行中",
+          "database": "数据库",
+          "table": "当前表",
+          "tables": "表",
+          "tablesProgress": "{{completed}} / {{total}}",
+          "rows": "已处理行数",
+          "elapsed": "已用时间",
+          "seconds": "{{seconds}}秒",
+          "alreadyRunning": "已有备份正在进行中。"
+        },
         "notifications": {
           "backupCreated": "备份创建成功。",
           "backupDeleted": "备份删除成功。",
           "restoreSuccess": "数据库已成功从备份恢复。",
           "testRestoreComplete": "测试恢复已完成。",
-          "error": "备份操作过程中发生错误。"
+          "error": "备份操作过程中发生错误。",
+          "backupStarted": "备份任务已启动。",
+          "backupCompleted": "备份成功完成。",
+          "backupFailed": "备份失败。"
         }
       },
       "bulkUpdate": {

--- a/frontend/src/services/backup.service.ts
+++ b/frontend/src/services/backup.service.ts
@@ -40,6 +40,27 @@ export interface TestRestoreResult extends RestoreResult {
   testSchema: string;
 }
 
+export type BackupJobState = 'idle' | 'running' | 'completed' | 'failed';
+
+export interface BackupJobProgress {
+  currentTable: string;
+  tablesCompleted: number;
+  tablesTotal: number;
+  rowsProcessed: number;
+  rowsTotal: number;
+  elapsed: number;
+}
+
+export interface BackupJobStatus {
+  state: BackupJobState;
+  database?: BackupDatabaseType;
+  progress?: BackupJobProgress;
+  backup?: BackupInfo;
+  error?: string;
+  startedAt?: string;
+  completedAt?: string;
+}
+
 class BackupService {
   /**
    * Get backup capabilities and configuration
@@ -60,12 +81,20 @@ class BackupService {
   }
 
   /**
-   * Create a new backup for the specified database
+   * Start a backup job (returns immediately, poll getJobStatus for progress)
    */
-  async createBackup(dbType: BackupDatabaseType): Promise<BackupInfo> {
-    const response = await apiClient.post<{ data: BackupInfo }>('/admin/backup/create', {
+  async startBackup(dbType: BackupDatabaseType): Promise<BackupJobStatus> {
+    const response = await apiClient.post<{ data: BackupJobStatus }>('/admin/backup/create', {
       database: dbType,
     });
+    return response.data;
+  }
+
+  /**
+   * Get the current backup job status (for polling)
+   */
+  async getJobStatus(): Promise<BackupJobStatus> {
+    const response = await apiClient.get<{ data: BackupJobStatus }>('/admin/backup/status');
     return response.data;
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "litemaas",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "LiteLLM User Application - Model subscription and management platform",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
## Summary

- **OOM fix**: Replace in-memory backup with PostgreSQL cursor streaming and gzip file streams, preventing heap crashes on large databases (1M+ rows in LiteLLM)
- **Async backup jobs**: Backup runs in background with real-time progress polling, avoiding gateway timeouts
- **Streaming restore**: Restore and test-restore also stream-decompress and execute SQL in batches
- **Version bump**: 0.3.0 → 0.3.1

## Test plan

- [x] Verify LiteMaaS database backup completes without OOM
- [x] Verify LiteLLM database backup completes without OOM (1M+ rows)
- [x] Verify progress bar updates in real-time during backup
- [x] Navigate away from backup tab and return — confirm progress resumes
- [x] Verify backup file appears in list after completion
- [x] Test restore of a backup created with the new streaming method
- [x] Test test-restore with a large backup file
- [x] Verify second backup attempt while one is running shows error
- [x] Run `test-backup.ts` CLI script against production database