### PR TITLE
Redact API keys from audit log metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Kustomize overlay**: `deployment/kustomize/overlays/oidc/`
   - **59 unit tests**: Comprehensive OIDC test coverage
 
+### Security
+
+- **Audit log API key redaction**: API keys are no longer stored or displayed in clear text in audit log details
+  - Removed `liteLLMKeyId` (full API key value) from `API_KEY_CREATE` audit log metadata and application logs
+  - Added server-side sanitization to strip `liteLLMKeyId` from all audit log API responses, protecting historical entries
+
 ### Fixed
 
 - **Model sync reliability**: Comprehensive fixes to model synchronization and lifecycle management

--- a/backend/src/routes/admin-audit.ts
+++ b/backend/src/routes/admin-audit.ts
@@ -106,8 +106,17 @@ const adminAuditRoutes: FastifyPluginAsync = async (fastify) => {
           [...params, limitNum, offset],
         );
 
+        // Sanitize sensitive fields from audit log metadata
+        const sanitizedRows = dataResult.rows.map((row: any) => {
+          if (row.metadata && typeof row.metadata === 'object') {
+            const { liteLLMKeyId, ...safeMetadata } = row.metadata;
+            return { ...row, metadata: safeMetadata };
+          }
+          return row;
+        });
+
         return {
-          data: dataResult.rows,
+          data: sanitizedRows,
           pagination: {
             page: pageNum,
             limit: limitNum,

--- a/backend/src/services/api-key.service.ts
+++ b/backend/src/services/api-key.service.ts
@@ -474,7 +474,6 @@ export class ApiKeyService extends BaseService {
             JSON.stringify({
               name: request.name,
               keyPrefix,
-              liteLLMKeyId: liteLLMResponse.key,
               models: modelIds,
               modelCount: modelIds.length,
               legacy: isLegacyRequest,
@@ -489,7 +488,6 @@ export class ApiKeyService extends BaseService {
             userId,
             apiKeyId: apiKey.rows[0].id,
             keyPrefix,
-            liteLLMKeyId: liteLLMResponse.key,
             models: modelIds,
             modelCount: modelIds.length,
             keyAlias: liteLLMRequest.key_alias,


### PR DESCRIPTION
## Summary

- Remove full API key values (`liteLLMKeyId`) from `API_KEY_CREATE` audit log metadata and application logs, preventing exposure to admin/adminReadonly users viewing the Audit Logs page
- Add server-side sanitization in the audit log API endpoint to strip `liteLLMKeyId` from all responses, protecting historical entries already stored in the database

## Test plan

- [x] Create a new API key and verify the audit log entry no longer contains `liteLLMKeyId` in its details
- [x] Verify historical `API Key Created` audit entries have `liteLLMKeyId` stripped from the displayed metadata
- [x] Confirm audit log still shows useful context (key name, prefix, models, model count)
- [x] Run backend unit tests (`npm run test:unit`)