### PR TITLE
Fix LiteLLM deployment: set DISABLE_SCHEMA_UPDATE to false

### DIFF
--- a/deployment/helm/litemaas/templates/litellm-deployment.yaml
+++ b/deployment/helm/litemaas/templates/litellm-deployment.yaml
@@ -58,7 +58,7 @@ spec:
             - name: STORE_MODEL_IN_DB
               value: "True"
             - name: DISABLE_SCHEMA_UPDATE
-              value: "true"
+              value: "false"
             {{- $redisHost := include "litemaas.redis.host" . }}
             {{- if $redisHost }}
             - name: REDIS_HOST

--- a/deployment/kustomize/litellm-deployment.yaml
+++ b/deployment/kustomize/litellm-deployment.yaml
@@ -70,7 +70,7 @@ spec:
             - name: STORE_MODEL_IN_DB
               value: 'True'
             - name: DISABLE_SCHEMA_UPDATE
-              value: 'true'
+              value: 'false'
             - name: REDIS_HOST
               value: 'litellm-redis'
             - name: REDIS_PORT


### PR DESCRIPTION
## Summary
- Set `DISABLE_SCHEMA_UPDATE` from `true` to `false` in both Helm and Kustomize LiteLLM deployment templates
- The flag was originally set to `true` to prevent Prisma from dropping non-LiteLLM tables on pod restart, but LiteMaaS and LiteLLM use **separate databases** (`litemaas_db` vs `litellm_db`), so the concern never applied
- With the flag set to `true`, fresh deployments fail because LiteLLM cannot create its schema tables

## Test plan
- [x] Deploy with a fresh (empty) `litellm_db` and verify LiteLLM creates its schema on startup
- [x] Deploy over an existing installation and verify no regressions