### PR TITLE
Fix LiteLLM schema creation and usage analytics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Usage analytics enrichment**: Revoked or inactive API keys are now included in user mapping during usage report enrichment, fixing undercounted requests and spend for users whose keys were later deactivated
+- **Usage cache staleness**: Yesterday's completed usage data is now permanently cached instead of being re-fetched on every request, improving performance and consistency
+- **Notification timer cleanup**: Success notification auto-dismiss timers are now properly cleared on component unmount, fixing intermittent `window is not defined` errors during test runs
+
 ## [0.4.0] - 2026-03-11
 
 ### Added

--- a/backend/src/routes/admin-audit.ts
+++ b/backend/src/routes/admin-audit.ts
@@ -109,7 +109,7 @@ const adminAuditRoutes: FastifyPluginAsync = async (fastify) => {
         // Sanitize sensitive fields from audit log metadata
         const sanitizedRows = dataResult.rows.map((row: any) => {
           if (row.metadata && typeof row.metadata === 'object') {
-            const { liteLLMKeyId, ...safeMetadata } = row.metadata;
+            const { liteLLMKeyId: _liteLLMKeyId, ...safeMetadata } = row.metadata;
             return { ...row, metadata: safeMetadata };
           }
           return row;

--- a/backend/src/routes/admin-models.ts
+++ b/backend/src/routes/admin-models.ts
@@ -43,7 +43,13 @@ const adminModelsRoutes: FastifyPluginAsync = async (fastify) => {
     },
     preHandler: [fastify.authenticate, fastify.requirePermission('admin:models')],
     handler: async (request) => {
-      const { api_base, api_key: providedApiKey, backend_model_name, model_id, supports_convert } = request.body;
+      const {
+        api_base,
+        api_key: providedApiKey,
+        backend_model_name,
+        model_id,
+        supports_convert,
+      } = request.body;
 
       let apiKey = providedApiKey;
 
@@ -293,28 +299,28 @@ const adminModelsRoutes: FastifyPluginAsync = async (fastify) => {
               max_tokens = $20,
               updated_at = CURRENT_TIMESTAMP`,
             [
-              model_name,                    // $1 id
-              model_name,                    // $2 name
-              'openai',                      // $3 provider
-              description || null,           // $4 description
-              'Language Model',              // $5 category
-              max_tokens || null,            // $6 context_length
-              input_cost_per_token || null,  // $7
+              model_name, // $1 id
+              model_name, // $2 name
+              'openai', // $3 provider
+              description || null, // $4 description
+              'Language Model', // $5 category
+              max_tokens || null, // $6 context_length
+              input_cost_per_token || null, // $7
               output_cost_per_token || null, // $8
-              supports_vision || false,      // $9
+              supports_vision || false, // $9
               supports_function_calling || false, // $10
               supports_tool_choice || false, // $11
               supports_parallel_function_calling || false, // $12
-              true,                          // $13 supports_streaming
-              features,                      // $14
-              'available',                   // $15 availability
-              '1.0',                         // $16 version
-              api_base || null,              // $17
-              tpm || null,                   // $18
-              rpm || null,                   // $19
-              max_tokens || null,            // $20
-              litellmModelId,                // $21
-              backend_model_name || null,    // $22
+              true, // $13 supports_streaming
+              features, // $14
+              'available', // $15 availability
+              '1.0', // $16 version
+              api_base || null, // $17
+              tpm || null, // $18
+              rpm || null, // $19
+              max_tokens || null, // $20
+              litellmModelId, // $21
+              backend_model_name || null, // $22
               restrictedAccess !== undefined ? restrictedAccess : false, // $23
             ],
           );
@@ -327,7 +333,10 @@ const adminModelsRoutes: FastifyPluginAsync = async (fastify) => {
           // Flush LiteLLM's Redis cache so all proxy pods pick up the new model
           await fastify.flushLiteLLMCache();
         } catch (dbError) {
-          fastify.log.warn({ dbError, model_name }, 'Failed to directly insert model - falling back to sync');
+          fastify.log.warn(
+            { dbError, model_name },
+            'Failed to directly insert model - falling back to sync',
+          );
           // Fall back to sync approach
           try {
             await liteLLMService.clearCache('models:');
@@ -403,7 +412,6 @@ const adminModelsRoutes: FastifyPluginAsync = async (fastify) => {
         } catch (syncError) {
           fastify.log.warn({ syncError }, 'Model synchronization failed after model creation');
         }
-
 
         reply.status(201);
         return {
@@ -723,13 +731,19 @@ const adminModelsRoutes: FastifyPluginAsync = async (fastify) => {
         // Delete model from LiteLLM using the correct LiteLLM model ID
         try {
           await liteLLMService.deleteModel(modelRecord.litellm_model_id);
-          fastify.log.info({ modelId, litellmModelId: modelRecord.litellm_model_id }, 'Model deleted from LiteLLM');
+          fastify.log.info(
+            { modelId, litellmModelId: modelRecord.litellm_model_id },
+            'Model deleted from LiteLLM',
+          );
 
           // Flush LiteLLM's Redis cache so all proxy pods stop serving the deleted model
           await fastify.flushLiteLLMCache();
         } catch (deleteError: any) {
           // If model is already gone from LiteLLM (404), proceed with local cleanup
-          if (deleteError.statusCode === 404 || (deleteError.message && deleteError.message.includes('not found'))) {
+          if (
+            deleteError.statusCode === 404 ||
+            (deleteError.message && deleteError.message.includes('not found'))
+          ) {
             fastify.log.warn(
               { modelId, litellmModelId: modelRecord.litellm_model_id },
               'Model not found in LiteLLM (already deleted) - proceeding with local cleanup',
@@ -754,13 +768,19 @@ const adminModelsRoutes: FastifyPluginAsync = async (fastify) => {
             'Cascade operations completed (subscriptions deactivated, API key associations removed)',
           );
         } catch (dbError) {
-          fastify.log.warn({ dbError, modelId }, 'Cascade operations failed - proceeding with delete');
+          fastify.log.warn(
+            { dbError, modelId },
+            'Cascade operations failed - proceeding with delete',
+          );
         }
 
         // Delete referencing rows then the model row itself.
         // The cascade above deactivates subscriptions but doesn't delete the rows,
         // so we must remove them to satisfy the foreign key constraint.
-        await fastify.dbUtils.query(`DELETE FROM subscription_status_history WHERE subscription_id IN (SELECT id FROM subscriptions WHERE model_id = $1)`, [modelId]);
+        await fastify.dbUtils.query(
+          `DELETE FROM subscription_status_history WHERE subscription_id IN (SELECT id FROM subscriptions WHERE model_id = $1)`,
+          [modelId],
+        );
         await fastify.dbUtils.query(`DELETE FROM subscriptions WHERE model_id = $1`, [modelId]);
         await fastify.dbUtils.query(`DELETE FROM models WHERE id = $1`, [modelId]);
         fastify.log.info({ modelId }, 'Model row deleted from local database');

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -313,7 +313,9 @@ const authRoutes: FastifyPluginAsync = async (fastify) => {
         // Use stored frontend origin for cross-origin dev setups (e.g., frontend :3000, backend :8081).
         // Falls back to relative redirect for same-origin deployments (production behind reverse proxy).
         const callbackPath = `/auth/callback#token=${token}&expires_in=${24 * 60 * 60}`;
-        const redirectUrl = storedFrontendOrigin ? `${storedFrontendOrigin}${callbackPath}` : callbackPath;
+        const redirectUrl = storedFrontendOrigin
+          ? `${storedFrontendOrigin}${callbackPath}`
+          : callbackPath;
 
         return reply.redirect(redirectUrl);
       } catch (error) {

--- a/backend/src/services/admin-usage/admin-usage-aggregation.service.ts
+++ b/backend/src/services/admin-usage/admin-usage-aggregation.service.ts
@@ -1508,7 +1508,7 @@ export class AdminUsageAggregationService extends BaseService {
     this.fastify.log.debug({ date: dayData.date }, 'Enriching data with user mappings');
 
     try {
-      // Query all active API keys with their pre-computed key_hash
+      // Query all API keys (including inactive/revoked) with their pre-computed key_hash
       // This approach is resilient to API key renaming since we match by the stable
       // hash of the actual LiteLLM key value (stored in key_hash), not the mutable alias
       let apiKeyMappings: ApiKeyUserMapping[] = [];
@@ -1525,7 +1525,6 @@ export class AdminUsageAggregationService extends BaseService {
             u.roles[1] as role
           FROM api_keys ak
           JOIN users u ON ak.user_id = u.id
-          WHERE ak.is_active = true
         `;
 
         const result = await this.executeQuery<{ rows: any[] }>(
@@ -1547,7 +1546,7 @@ export class AdminUsageAggregationService extends BaseService {
 
         this.fastify.log.debug(
           {
-            totalActiveKeys: result.rows.length,
+            totalKeys: result.rows.length,
             mappedCount: apiKeyMappings.length,
           },
           'API key mappings retrieved using pre-computed key_hash',

--- a/backend/src/services/admin-usage/admin-usage.utils.ts
+++ b/backend/src/services/admin-usage/admin-usage.utils.ts
@@ -376,7 +376,7 @@ export function extractProviderFromModel(modelName: string): string {
 // ============================================================================
 
 /**
- * Check if date is historical (more than 1 day old)
+ * Check if date is historical (at least 1 day old, yesterday or older)
  *
  * @param date - Date to check
  * @returns true if historical
@@ -384,7 +384,7 @@ export function extractProviderFromModel(modelName: string): string {
 export function isHistoricalDate(date: Date): boolean {
   const now = new Date();
   const daysDiff = Math.floor((now.getTime() - date.getTime()) / (1000 * 60 * 60 * 24));
-  return daysDiff > 1;
+  return daysDiff >= 1;
 }
 
 /**

--- a/backend/src/services/litellm.service.ts
+++ b/backend/src/services/litellm.service.ts
@@ -468,10 +468,10 @@ export class LiteLLMService extends BaseService {
           id: string;
           litellm_model_id: string;
           availability: string;
-        }>('SELECT id, litellm_model_id, availability FROM models WHERE id = $1 AND availability = $2', [
-          modelId,
-          'available',
-        ]);
+        }>(
+          'SELECT id, litellm_model_id, availability FROM models WHERE id = $1 AND availability = $2',
+          [modelId, 'available'],
+        );
 
         if (localModel) {
           this.fastify.log.info(

--- a/backend/src/services/model-sync.service.ts
+++ b/backend/src/services/model-sync.service.ts
@@ -76,7 +76,9 @@ export class ModelSyncService {
         }
       } else {
         // No LiteLLM DB configured — skip cross-reference, trust the API response
-        this.fastify.log.warn('LITELLM_DATABASE_URL not set — skipping DB cross-reference, using API response directly');
+        this.fastify.log.warn(
+          'LITELLM_DATABASE_URL not set — skipping DB cross-reference, using API response directly',
+        );
         dbModelNames = new Set(litellmModels.map((m: any) => m.model_name));
       }
 
@@ -236,7 +238,10 @@ export class ModelSyncService {
 
     // Build features array
     const features = [];
-    const supportsEmbeddings = litellmModel.model_info?.supports_embeddings || litellmModel.model_info?.supports_embedding || false;
+    const supportsEmbeddings =
+      litellmModel.model_info?.supports_embeddings ||
+      litellmModel.model_info?.supports_embedding ||
+      false;
     const supportsTokenize = litellmModel.model_info?.supports_tokenize || false;
     const supportsConvert = litellmModel.model_info?.supports_convert || false;
 
@@ -335,7 +340,10 @@ export class ModelSyncService {
     const supportsToolChoice = litellmModel.model_info?.supports_tool_choice || false;
 
     const features = [];
-    const supportsEmbeddings = litellmModel.model_info?.supports_embeddings || litellmModel.model_info?.supports_embedding || false;
+    const supportsEmbeddings =
+      litellmModel.model_info?.supports_embeddings ||
+      litellmModel.model_info?.supports_embedding ||
+      false;
     const supportsTokenize = litellmModel.model_info?.supports_tokenize || false;
     const supportsConvert = litellmModel.model_info?.supports_convert || false;
 
@@ -630,7 +638,10 @@ export class ModelSyncService {
 
     // Build expected features
     const expectedFeatures = [];
-    const supportsEmbeddings = litellmModel.model_info?.supports_embeddings || litellmModel.model_info?.supports_embedding || false;
+    const supportsEmbeddings =
+      litellmModel.model_info?.supports_embeddings ||
+      litellmModel.model_info?.supports_embedding ||
+      false;
     const supportsTokenize = litellmModel.model_info?.supports_tokenize || false;
     const supportsConvert = litellmModel.model_info?.supports_convert || false;
 

--- a/backend/src/services/oauth.service.ts
+++ b/backend/src/services/oauth.service.ts
@@ -372,10 +372,7 @@ export class OAuthService extends BaseService {
     try {
       tokenResponse = await response.json();
     } catch (parseError) {
-      this.fastify.log.error(
-        { parseError, tokenUrl },
-        'Failed to parse token response as JSON',
-      );
+      this.fastify.log.error({ parseError, tokenUrl }, 'Failed to parse token response as JSON');
       throw this.createValidationError(
         'Invalid token response',
         'code',
@@ -524,8 +521,7 @@ export class OAuthService extends BaseService {
 
     return {
       sub: userResponse.sub,
-      preferred_username:
-        userResponse.preferred_username || userResponse.email || userResponse.sub,
+      preferred_username: userResponse.preferred_username || userResponse.email || userResponse.sub,
       name: userResponse.name,
       email:
         userResponse.email ||
@@ -846,10 +842,10 @@ export class OAuthService extends BaseService {
           // Update our users table to use the LiteLLM user_id so they stay in sync.
           // This handles the case where migration created users with gen_random_uuid()
           // but LiteLLM already had them with a different user_id.
-          await this.fastify.dbUtils.query(
-            `UPDATE users SET id = $1 WHERE id = $2`,
-            [litellmUser.user_id, user.id],
-          );
+          await this.fastify.dbUtils.query(`UPDATE users SET id = $1 WHERE id = $2`, [
+            litellmUser.user_id,
+            user.id,
+          ]);
 
           // Update dependent tables
           const dependentUpdates = [

--- a/backend/tests/unit/services/admin-usage/admin-usage.utils.test.ts
+++ b/backend/tests/unit/services/admin-usage/admin-usage.utils.test.ts
@@ -5,6 +5,7 @@ import {
   calculateComparisonPeriod,
   parseDateAsUTC,
   isTodayUTC,
+  isHistoricalDate,
   formatLargeNumber,
   formatCurrency,
   formatPercentage,
@@ -285,6 +286,28 @@ describe('admin-usage.utils', () => {
 
     it('should handle empty array', () => {
       expect(sumBy([], 'value')).toBe(0);
+    });
+  });
+
+  describe('isHistoricalDate', () => {
+    it('should return false for today', () => {
+      expect(isHistoricalDate(new Date())).toBe(false);
+    });
+
+    it('should return true for yesterday', () => {
+      const yesterday = new Date();
+      yesterday.setDate(yesterday.getDate() - 1);
+      expect(isHistoricalDate(yesterday)).toBe(true);
+    });
+
+    it('should return true for two days ago', () => {
+      const twoDaysAgo = new Date();
+      twoDaysAgo.setDate(twoDaysAgo.getDate() - 2);
+      expect(isHistoricalDate(twoDaysAgo)).toBe(true);
+    });
+
+    it('should return true for far past dates', () => {
+      expect(isHistoricalDate(new Date('2020-01-01'))).toBe(true);
     });
   });
 });

--- a/backend/tests/unit/services/litellm.service.test.ts
+++ b/backend/tests/unit/services/litellm.service.test.ts
@@ -73,7 +73,7 @@ describe('LiteLLMService', () => {
 
     service = new LiteLLMService(mockFastify as FastifyInstance, {
       baseUrl: 'http://localhost:4000',
-      apiKey: 'sk-1104',
+      apiKey: 'sk-test-master-key',
       enableMocking: false,
     });
     vi.clearAllMocks();
@@ -94,7 +94,7 @@ describe('LiteLLMService', () => {
         method: 'GET',
         headers: {
           'Content-Type': 'application/json',
-          'x-litellm-api-key': 'sk-1104',
+          'x-litellm-api-key': 'sk-test-master-key',
         },
         body: undefined,
         signal: expect.any(AbortSignal),
@@ -151,7 +151,7 @@ describe('LiteLLMService', () => {
         method: 'GET',
         headers: {
           'Content-Type': 'application/json',
-          'x-litellm-api-key': 'sk-1104',
+          'x-litellm-api-key': 'sk-test-master-key',
         },
         body: undefined,
         signal: expect.any(AbortSignal),

--- a/backend/tests/unit/services/oauth.service.oidc.test.ts
+++ b/backend/tests/unit/services/oauth.service.oidc.test.ts
@@ -77,8 +77,7 @@ const createMockOIDCDiscovery = (overrides = {}) => ({
   authorization_endpoint: 'https://keycloak.example.com/realms/test/protocol/openid-connect/auth',
   token_endpoint: 'https://keycloak.example.com/realms/test/protocol/openid-connect/token',
   userinfo_endpoint: 'https://keycloak.example.com/realms/test/protocol/openid-connect/userinfo',
-  end_session_endpoint:
-    'https://keycloak.example.com/realms/test/protocol/openid-connect/logout',
+  end_session_endpoint: 'https://keycloak.example.com/realms/test/protocol/openid-connect/logout',
   ...overrides,
 });
 
@@ -1106,9 +1105,7 @@ describe('OAuthService - OIDC Specific Tests', () => {
       const idToken = `header.${Buffer.from(JSON.stringify(payload)).toString('base64')}.signature`;
       const tokenResponse = { access_token: 'at', token_type: 'Bearer', id_token: idToken } as any;
 
-      expect(() => service.validateIdToken(tokenResponse)).toThrow(
-        'Invalid audience in ID token',
-      );
+      expect(() => service.validateIdToken(tokenResponse)).toThrow('Invalid audience in ID token');
     });
 
     it('should skip validation when no ID token is present', () => {
@@ -1121,9 +1118,11 @@ describe('OAuthService - OIDC Specific Tests', () => {
   describe('email validation in OIDC userinfo', () => {
     it('should not use non-email preferred_username as email', async () => {
       const mockDiscovery = {
-        authorization_endpoint: 'https://keycloak.example.com/realms/test/protocol/openid-connect/auth',
+        authorization_endpoint:
+          'https://keycloak.example.com/realms/test/protocol/openid-connect/auth',
         token_endpoint: 'https://keycloak.example.com/realms/test/protocol/openid-connect/token',
-        userinfo_endpoint: 'https://keycloak.example.com/realms/test/protocol/openid-connect/userinfo',
+        userinfo_endpoint:
+          'https://keycloak.example.com/realms/test/protocol/openid-connect/userinfo',
         issuer: 'https://keycloak.example.com/realms/test',
       };
 
@@ -1160,9 +1159,11 @@ describe('OAuthService - OIDC Specific Tests', () => {
   describe('discovery cache failover', () => {
     it('should use stale cache when refetch fails', async () => {
       const mockDiscovery = {
-        authorization_endpoint: 'https://keycloak.example.com/realms/test/protocol/openid-connect/auth',
+        authorization_endpoint:
+          'https://keycloak.example.com/realms/test/protocol/openid-connect/auth',
         token_endpoint: 'https://keycloak.example.com/realms/test/protocol/openid-connect/token',
-        userinfo_endpoint: 'https://keycloak.example.com/realms/test/protocol/openid-connect/userinfo',
+        userinfo_endpoint:
+          'https://keycloak.example.com/realms/test/protocol/openid-connect/userinfo',
         issuer: 'https://keycloak.example.com/realms/test',
       };
 
@@ -1194,9 +1195,11 @@ describe('OAuthService - OIDC Specific Tests', () => {
   describe('nonce in generateAuthUrl', () => {
     it('should include nonce in OIDC auth URL', async () => {
       const mockDiscovery = {
-        authorization_endpoint: 'https://keycloak.example.com/realms/test/protocol/openid-connect/auth',
+        authorization_endpoint:
+          'https://keycloak.example.com/realms/test/protocol/openid-connect/auth',
         token_endpoint: 'https://keycloak.example.com/realms/test/protocol/openid-connect/token',
-        userinfo_endpoint: 'https://keycloak.example.com/realms/test/protocol/openid-connect/userinfo',
+        userinfo_endpoint:
+          'https://keycloak.example.com/realms/test/protocol/openid-connect/userinfo',
         issuer: 'https://keycloak.example.com/realms/test',
       };
 

--- a/deployment/helm/litemaas/templates/litellm-deployment.yaml
+++ b/deployment/helm/litemaas/templates/litellm-deployment.yaml
@@ -58,7 +58,7 @@ spec:
             - name: STORE_MODEL_IN_DB
               value: "True"
             - name: DISABLE_SCHEMA_UPDATE
-              value: "true"
+              value: "false"
             {{- $redisHost := include "litemaas.redis.host" . }}
             {{- if $redisHost }}
             - name: REDIS_HOST

--- a/deployment/kustomize/litellm-deployment.yaml
+++ b/deployment/kustomize/litellm-deployment.yaml
@@ -70,7 +70,7 @@ spec:
             - name: STORE_MODEL_IN_DB
               value: 'True'
             - name: DISABLE_SCHEMA_UPDATE
-              value: 'true'
+              value: 'false'
             - name: REDIS_HOST
               value: 'litellm-redis'
             - name: REDIS_PORT

--- a/dev-tools/test-cache-staleness.sh
+++ b/dev-tools/test-cache-staleness.sh
@@ -1,0 +1,498 @@
+#!/usr/bin/env bash
+#
+# Test script: Reproduce stale cache / missing request count issue
+#
+# This script demonstrates two bugs in the usage analytics pipeline:
+#
+# BUG 1: Enrichment only uses active keys (WHERE is_active = true)
+#   - If a key is revoked/deleted BEFORE its usage data is cached,
+#     its requests are attributed to "Unknown User" and lost when filtering by userId
+#
+# BUG 2: Permanent historical cache with baked-in enrichment
+#   - Once a day's data is cached as "historical" (is_complete=true),
+#     it's never re-enriched even if key mappings change
+#   - Combined with Bug 1: clearing the cache and re-enriching loses data
+#     for deleted keys
+#
+# BUG 3: Yesterday (daysDiff=1) always re-fetched
+#   - isHistoricalDate() returns true only for daysDiff > 1
+#   - isToday() returns true only for daysDiff == 0
+#   - Yesterday falls through both checks and is always re-fetched
+#
+# This script bypasses the backend API entirely and tests the enrichment
+# and caching logic directly via LiteLLM API + PostgreSQL queries.
+#
+# Prerequisites:
+#   - LiteLLM running on port 4000 (via host.containers.internal)
+#   - PostgreSQL accessible
+#   - At least one working model in LiteLLM
+#
+# Usage:
+#   PGPASSWORD="thisisadmin" ./dev-tools/test-cache-staleness.sh
+
+set -euo pipefail
+
+# Configuration
+LITELLM_URL="${LITELLM_URL:-http://host.containers.internal:4000}"
+LITELLM_MASTER_KEY="${LITELLM_MASTER_KEY:-sk-your-master-key}"
+DB_HOST="${DB_HOST:-host.containers.internal}"
+DB_PORT="${DB_PORT:-5432}"
+DB_NAME="${DB_NAME:-litemaas}"
+DB_USER="${DB_USER:-pgadmin}"
+# PGPASSWORD should be set in environment
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+NC='\033[0m' # No Color
+
+log() { echo -e "${BLUE}[INFO]${NC} $1"; }
+ok()  { echo -e "${GREEN}[OK]${NC}   $1"; }
+warn(){ echo -e "${YELLOW}[WARN]${NC} $1"; }
+fail(){ echo -e "${RED}[FAIL]${NC} $1"; }
+header() { echo -e "\n${CYAN}=== $1 ===${NC}\n"; }
+
+psql_cmd() {
+  PGPASSWORD="${PGPASSWORD}" psql -U "$DB_USER" -h "$DB_HOST" -p "$DB_PORT" -d "$DB_NAME" -t -A -q -c "$1"
+}
+
+echo "============================================================"
+echo " Test: Usage Analytics Enrichment & Cache Bugs"
+echo " (Direct DB + LiteLLM API - no backend auth needed)"
+echo "============================================================"
+echo ""
+
+# ---------------------------------------------------------------
+# Step 0: Pick a real user and model to test with
+# ---------------------------------------------------------------
+header "Step 0: Finding test user and model"
+
+# Exclude the system user (00000000-0000-0000-0000-000000000001)
+TEST_USER_ID=$(psql_cmd "SELECT id FROM users WHERE id <> '00000000-0000-0000-0000-000000000001' LIMIT 1;")
+if [[ -z "$TEST_USER_ID" ]]; then
+  fail "No non-system user found in database"
+  exit 1
+fi
+TEST_USERNAME=$(psql_cmd "SELECT username FROM users WHERE id = '$TEST_USER_ID';")
+log "Test user: $TEST_USERNAME ($TEST_USER_ID)"
+
+# Find a model that works (try chat completion)
+TEST_MODEL=$(curl -s "$LITELLM_URL/model/info" -H "Authorization: Bearer $LITELLM_MASTER_KEY" | \
+  python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+for m in data.get('data', []):
+    name = m.get('model_name', '')
+    mode = m.get('model_info', {}).get('mode', '')
+    if mode not in ('embedding',):
+        print(name)
+        break
+" 2>/dev/null)
+
+if [[ -z "$TEST_MODEL" ]]; then
+  fail "No suitable model found in LiteLLM"
+  exit 1
+fi
+log "Test model: $TEST_MODEL"
+
+# ---------------------------------------------------------------
+# Step 1: Create a temporary API key via LiteLLM directly
+# ---------------------------------------------------------------
+header "Step 1: Creating temporary test key in LiteLLM"
+
+KEY_ALIAS="cache-test-key-$(date +%s)"
+KEY_RESPONSE=$(curl -s "$LITELLM_URL/key/generate" \
+  -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"user_id\": \"$TEST_USER_ID\",
+    \"key_alias\": \"$KEY_ALIAS\",
+    \"models\": [\"$TEST_MODEL\"],
+    \"max_budget\": 100
+  }")
+
+TEST_KEY=$(echo "$KEY_RESPONSE" | python3 -c "import json,sys; print(json.load(sys.stdin)['key'])" 2>/dev/null)
+if [[ -z "$TEST_KEY" ]]; then
+  fail "Failed to create test key in LiteLLM"
+  echo "Response: $KEY_RESPONSE"
+  exit 1
+fi
+
+TEST_KEY_HASH=$(echo -n "$TEST_KEY" | sha256sum | awk '{print $1}')
+
+ok "Created key: $KEY_ALIAS"
+log "Key hash: $TEST_KEY_HASH"
+log "Key value: ${TEST_KEY:0:20}..."
+
+# Clean up any leftover test keys from previous runs
+psql_cmd "DELETE FROM api_keys WHERE name = 'cache-test-key';" > /dev/null
+
+# Register key in LiteMaaS database so enrichment can find it
+psql_cmd "
+INSERT INTO api_keys (user_id, name, key_hash, key_prefix, lite_llm_key_value, litellm_key_alias, is_active, sync_status, migration_status)
+VALUES ('$TEST_USER_ID', 'cache-test-key', '$TEST_KEY_HASH', '${TEST_KEY:0:10}', '$TEST_KEY', '$KEY_ALIAS', true, 'synced', 'complete');
+" > /dev/null
+ok "Registered key in LiteMaaS database (is_active=true)"
+
+# ---------------------------------------------------------------
+# Step 2: Generate usage data by making a request through LiteLLM
+# ---------------------------------------------------------------
+header "Step 2: Making test request through LiteLLM"
+
+CHAT_RESPONSE=$(curl -s "$LITELLM_URL/v1/chat/completions" \
+  -H "Authorization: Bearer $TEST_KEY" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"model\": \"$TEST_MODEL\",
+    \"messages\": [{\"role\": \"user\", \"content\": \"Say hello in one word\"}],
+    \"max_tokens\": 10
+  }" 2>/dev/null)
+
+CHAT_STATUS=$(echo "$CHAT_RESPONSE" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+if 'choices' in d:
+    print('success')
+elif 'error' in d:
+    print(f\"error: {d['error'].get('message', 'unknown')[:80]}\")
+else:
+    print('unknown')
+" 2>/dev/null)
+
+if [[ "$CHAT_STATUS" == "success" ]]; then
+  ok "Chat request succeeded"
+else
+  warn "Chat request status: $CHAT_STATUS (test will continue - failed requests also count)"
+fi
+
+# Wait for LiteLLM to record the spend log
+sleep 5
+
+# ---------------------------------------------------------------
+# Step 3: Verify LiteLLM recorded the activity
+# ---------------------------------------------------------------
+header "Step 3: Verifying LiteLLM recorded the activity"
+
+TODAY=$(date +%Y-%m-%d)
+
+# Query all activity for today and extract our test key's requests from the breakdown
+ACTIVITY=$(curl -s "$LITELLM_URL/user/daily/activity?start_date=$TODAY&end_date=$TODAY&page=1&page_size=100" \
+  -H "Authorization: Bearer $LITELLM_MASTER_KEY" 2>/dev/null)
+
+LITELLM_REQUESTS=$(echo "$ACTIVITY" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+key_hash = '$TEST_KEY_HASH'
+total = 0
+for result in d.get('results', []):
+    api_keys = result.get('breakdown', {}).get('api_keys', {})
+    if key_hash in api_keys:
+        total += api_keys[key_hash]['metrics']['api_requests']
+print(total)
+" 2>/dev/null)
+
+if [[ "$LITELLM_REQUESTS" -gt 0 ]]; then
+  ok "LiteLLM recorded $LITELLM_REQUESTS request(s) for test key hash"
+else
+  # LiteLLM may take a few seconds to index - retry once
+  log "No requests found yet, waiting 5 more seconds..."
+  sleep 5
+  ACTIVITY=$(curl -s "$LITELLM_URL/user/daily/activity?start_date=$TODAY&end_date=$TODAY&page=1&page_size=100" \
+    -H "Authorization: Bearer $LITELLM_MASTER_KEY" 2>/dev/null)
+  LITELLM_REQUESTS=$(echo "$ACTIVITY" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+key_hash = '$TEST_KEY_HASH'
+total = 0
+for result in d.get('results', []):
+    api_keys = result.get('breakdown', {}).get('api_keys', {})
+    if key_hash in api_keys:
+        total += api_keys[key_hash]['metrics']['api_requests']
+print(total)
+" 2>/dev/null)
+  if [[ "$LITELLM_REQUESTS" -gt 0 ]]; then
+    ok "LiteLLM recorded $LITELLM_REQUESTS request(s) for test key hash (after retry)"
+  else
+    fail "LiteLLM shows 0 requests for test key - cannot proceed"
+    echo "  Key hash: $TEST_KEY_HASH"
+    echo "  Available keys in today's activity:"
+    echo "$ACTIVITY" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+for result in d.get('results', []):
+    for kh, info in result.get('breakdown', {}).get('api_keys', {}).items():
+        print(f'    {kh[:20]}... = {info[\"metrics\"][\"api_requests\"]} requests')
+" 2>/dev/null
+    exit 1
+  fi
+fi
+
+# ---------------------------------------------------------------
+# Step 4: Test Bug 1 - Enrichment only queries active keys
+# ---------------------------------------------------------------
+header "Step 4: Testing Bug 1 - Enrichment WHERE is_active = true"
+
+log "Simulating enrichment query WITH is_active filter (current buggy code)..."
+ENRICHED_ACTIVE=$(psql_cmd "
+  SELECT ak.key_hash, ak.user_id, u.username
+  FROM api_keys ak
+  JOIN users u ON ak.user_id = u.id
+  WHERE ak.is_active = true
+    AND ak.key_hash = '$TEST_KEY_HASH';
+")
+
+if [[ -n "$ENRICHED_ACTIVE" ]]; then
+  ok "Key IS found when active: $ENRICHED_ACTIVE"
+else
+  fail "Key NOT found even when active - test setup error"
+  exit 1
+fi
+
+# Now deactivate the key
+log "Deactivating the test key (is_active=false)..."
+psql_cmd "UPDATE api_keys SET is_active = false WHERE key_hash = '$TEST_KEY_HASH';" > /dev/null
+ok "Key deactivated"
+
+log "Simulating enrichment query WITH is_active filter (buggy)..."
+ENRICHED_AFTER_DEACTIVATE=$(psql_cmd "
+  SELECT ak.key_hash, ak.user_id, u.username
+  FROM api_keys ak
+  JOIN users u ON ak.user_id = u.id
+  WHERE ak.is_active = true
+    AND ak.key_hash = '$TEST_KEY_HASH';
+")
+
+log "Simulating enrichment query WITHOUT is_active filter (fixed)..."
+ENRICHED_WITHOUT_FILTER=$(psql_cmd "
+  SELECT ak.key_hash, ak.user_id, u.username
+  FROM api_keys ak
+  JOIN users u ON ak.user_id = u.id
+  WHERE ak.key_hash = '$TEST_KEY_HASH';
+")
+
+echo ""
+echo "  Results after key deactivation:"
+if [[ -z "$ENRICHED_AFTER_DEACTIVATE" ]]; then
+  fail "BUG 1 CONFIRMED: Buggy query (WHERE is_active=true) returns NO results"
+  echo "       -> This key's requests would be attributed to 'Unknown User'"
+  echo "       -> They would be filtered out in user-scoped views"
+else
+  ok "Buggy query still finds the key (unexpected)"
+fi
+
+if [[ -n "$ENRICHED_WITHOUT_FILTER" ]]; then
+  ok "Fixed query (no is_active filter) finds key: $ENRICHED_WITHOUT_FILTER"
+else
+  fail "Fixed query also misses the key (unexpected)"
+fi
+
+# ---------------------------------------------------------------
+# Step 5: Test Bug 2 - Permanent cache with stale enrichment
+# ---------------------------------------------------------------
+header "Step 5: Testing Bug 2 - Permanent historical cache"
+
+# Reactivate the key first
+psql_cmd "UPDATE api_keys SET is_active = true WHERE key_hash = '$TEST_KEY_HASH';" > /dev/null
+
+log "Simulating cache write with key ACTIVE (enrichment succeeds)..."
+# The enrichment result when key is active
+ENRICHED_USER=$(psql_cmd "
+  SELECT u.username FROM api_keys ak
+  JOIN users u ON ak.user_id = u.id
+  WHERE ak.is_active = true AND ak.key_hash = '$TEST_KEY_HASH';
+")
+ok "Enrichment maps key to user: $ENRICHED_USER"
+
+log "Writing simulated cache entry for today (is_complete=false, current day)..."
+# Simulate what the backend does: cache the enriched data
+# Schema: raw_data, aggregated_by_user, aggregated_by_model, aggregated_by_provider, total_metrics
+RAW_DATA=$(python3 -c "
+import json
+data = {'breakdowns': [{'api_key': '$TEST_KEY_HASH', 'model': '$TEST_MODEL', 'total_requests': $LITELLM_REQUESTS, 'total_tokens': 100, 'total_spend': 0.01}]}
+print(json.dumps(data))
+")
+AGG_BY_USER=$(python3 -c "
+import json
+data = {
+    '$TEST_USER_ID': {
+        'userId': '$TEST_USER_ID',
+        'username': '$ENRICHED_USER',
+        'totalRequests': $LITELLM_REQUESTS,
+        'totalTokens': 100,
+        'totalSpend': 0.01,
+        'models': {}
+    }
+}
+print(json.dumps(data))
+")
+TOTAL_METRICS=$(python3 -c "
+import json
+data = {'totalRequests': $LITELLM_REQUESTS, 'totalTokens': 100, 'totalSpend': 0.01}
+print(json.dumps(data))
+")
+
+psql_cmd "
+  DELETE FROM daily_usage_cache WHERE date = '$TODAY';
+  INSERT INTO daily_usage_cache (date, raw_data, aggregated_by_user, total_metrics, is_complete, updated_at)
+  VALUES ('$TODAY', '$RAW_DATA'::jsonb, '$AGG_BY_USER'::jsonb, '$TOTAL_METRICS'::jsonb, false, NOW());
+" > /dev/null
+ok "Cache written with user mapping intact"
+
+# Verify we can find the user's data in the cache
+CACHED_REQUESTS=$(psql_cmd "
+  SELECT (aggregated_by_user->'$TEST_USER_ID'->>'totalRequests')::int
+  FROM daily_usage_cache WHERE date = '$TODAY';
+")
+ok "Cache shows $CACHED_REQUESTS request(s) for user $TEST_USERNAME"
+
+# Now simulate Bug 2: mark as historical, deactivate key, clear and rebuild
+log ""
+log "Now simulating Bug 2 scenario:"
+log "  1. Mark cache as historical (is_complete=true)"
+log "  2. Deactivate the key"
+log "  3. Clear and re-enrich the cache"
+log "  -> The permanently cached data should be stale"
+
+psql_cmd "UPDATE daily_usage_cache SET is_complete = true WHERE date = '$TODAY';" > /dev/null
+ok "Cache marked as historical (is_complete=true)"
+
+psql_cmd "UPDATE api_keys SET is_active = false WHERE key_hash = '$TEST_KEY_HASH';" > /dev/null
+ok "Key deactivated"
+
+log ""
+log "Scenario A: Cache NOT cleared -> serves old (correct) data"
+CACHED_REQUESTS_STALE=$(psql_cmd "
+  SELECT (aggregated_by_user->'$TEST_USER_ID'->>'totalRequests')::int
+  FROM daily_usage_cache WHERE date = '$TODAY';
+")
+if [[ "$CACHED_REQUESTS_STALE" -gt 0 ]]; then
+  ok "Historical cache still has $CACHED_REQUESTS_STALE request(s) (stale but correct)"
+  warn "This data is frozen - if re-enriched, it would lose the user mapping"
+fi
+
+log ""
+log "Scenario B: Cache cleared -> re-enrichment loses data"
+psql_cmd "DELETE FROM daily_usage_cache WHERE date = '$TODAY';" > /dev/null
+ok "Cache cleared"
+
+# Simulate re-enrichment with deactivated key
+ENRICHED_AFTER=$(psql_cmd "
+  SELECT u.username FROM api_keys ak
+  JOIN users u ON ak.user_id = u.id
+  WHERE ak.is_active = true AND ak.key_hash = '$TEST_KEY_HASH';
+")
+
+if [[ -z "$ENRICHED_AFTER" ]]; then
+  fail "BUG 2 CONFIRMED: Re-enrichment after cache clear cannot map key to user"
+  echo "       -> Key hash '$TEST_KEY_HASH' has no match in active keys"
+  echo "       -> LiteLLM still shows $LITELLM_REQUESTS request(s) for this key"
+  echo "       -> But re-cached data would attribute them to 'Unknown User'"
+  echo "       -> User-scoped views would show 0 requests"
+else
+  ok "Re-enrichment still finds the key (unexpected)"
+fi
+
+# ---------------------------------------------------------------
+# Step 6: Test Bug 3 - Yesterday cache gap
+# ---------------------------------------------------------------
+header "Step 6: Testing Bug 3 - Yesterday cache gap"
+
+log "Testing isHistoricalDate() and isToday() logic:"
+log ""
+
+# Show the logic
+python3 -c "
+from datetime import datetime, timedelta
+import math
+
+now = datetime.now()
+dates = {
+    'Today': now,
+    'Yesterday': now - timedelta(days=1),
+    'Two days ago': now - timedelta(days=2),
+    'Three days ago': now - timedelta(days=3),
+}
+
+for label, d in dates.items():
+    days_diff = math.floor((now.timestamp() - d.timestamp()) / (60*60*24))
+    is_historical = days_diff > 1
+    is_today = d.date() == now.date()
+
+    # Determine cache behavior
+    if is_historical:
+        behavior = 'CACHED (permanent, is_complete=true)'
+    elif is_today:
+        behavior = 'CACHED (5-min TTL, is_complete=false)'
+    else:
+        behavior = 'ALWAYS RE-FETCHED (falls through both checks!)'
+
+    status = '  OK ' if (is_historical or is_today) else ' BUG'
+    print(f'  [{status}] {label:16s} daysDiff={days_diff}  isHistorical={str(is_historical):5s}  isToday={str(is_today):5s}  -> {behavior}')
+"
+
+echo ""
+warn "Bug 3: Yesterday (daysDiff=1) is neither historical (>1) nor today (==0)"
+warn "       It falls through both cache checks and is ALWAYS re-fetched from LiteLLM"
+warn "       Impact: Performance - unnecessary API calls for yesterday's data"
+
+# ---------------------------------------------------------------
+# Step 7: Show the actual buggy code locations
+# ---------------------------------------------------------------
+header "Step 7: Summary of bug locations"
+
+echo ""
+echo "  BUG 1: Enrichment only queries active keys"
+echo "  ----------------------------------------"
+echo "  File: backend/src/services/admin-usage/admin-usage-aggregation.service.ts"
+echo "  Look for: WHERE ak.is_active = true"
+echo "  Fix: Remove is_active filter from enrichment query, or use:"
+echo "       WHERE (ak.is_active = true OR ak.is_active = false)"
+echo "       This ensures deleted/revoked keys still map to their users."
+echo ""
+echo "  BUG 2: Historical cache never re-enriches"
+echo "  ----------------------------------------"
+echo "  File: backend/src/services/admin-usage/admin-usage-aggregation.service.ts"
+echo "  Method: getCachedOrFetch()"
+echo "  Issue: Enrichment is baked in at cache-write time."
+echo "         If cache is invalidated and rebuilt after key deletion,"
+echo "         the re-enrichment misses inactive keys (compounds with Bug 1)."
+echo "  Fix: Either fix Bug 1 (preferred) or store raw LiteLLM data"
+echo "       separately from enriched data."
+echo ""
+echo "  BUG 3: Yesterday always re-fetched"
+echo "  ----------------------------------------"
+echo "  File: backend/src/services/admin-usage/admin-usage-aggregation.service.ts"
+echo "  Method: getCachedOrFetch()"
+echo "  File: backend/src/services/admin-usage/admin-usage.utils.ts"
+echo "  Function: isHistoricalDate() - uses daysDiff > 1 (should be >= 1)"
+echo "  Fix: Change isHistoricalDate() to: return daysDiff >= 1"
+echo "       Or add explicit yesterday check in getCachedOrFetch()"
+echo ""
+
+# ---------------------------------------------------------------
+# Cleanup
+# ---------------------------------------------------------------
+header "Cleanup"
+
+# Delete test key from LiteLLM
+curl -s "$LITELLM_URL/key/delete" \
+  -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
+  -H "Content-Type: application/json" \
+  -d "{\"keys\": [\"$TEST_KEY\"]}" > /dev/null 2>&1
+
+# Delete test key from LiteMaaS
+psql_cmd "DELETE FROM api_keys WHERE key_hash = '$TEST_KEY_HASH';" > /dev/null
+
+# Reset cache for today
+psql_cmd "DELETE FROM daily_usage_cache WHERE date = '$TODAY';" > /dev/null
+
+ok "Test key and cache cleaned up"
+
+echo ""
+echo "============================================================"
+echo " Test complete. See bug locations above for fixes."
+echo "============================================================"
+echo ""

--- a/docs/architecture/litellm-integration.md
+++ b/docs/architecture/litellm-integration.md
@@ -671,7 +671,7 @@ if (error.message?.includes('already exists')) {
 
 ```bash
 LITELLM_API_URL=http://localhost:4000
-LITELLM_API_KEY=sk-1104
+LITELLM_API_KEY=sk-your-master-key
 ```
 
 ### Mock Mode
@@ -702,7 +702,7 @@ LITELLM_API_KEY=sk-1104
 All LiteLLM API requests require authentication via the `x-litellm-api-key` header:
 
 ```http
-x-litellm-api-key: sk-1104
+x-litellm-api-key: sk-your-master-key
 ```
 
 **Exception**: The `/key/info` endpoint uses the actual API key being queried as the authentication header value. LiteMaaS's `makeRequest()` method sets the master key as the default `x-litellm-api-key` header, but callers can override this by passing their own headers (e.g., `getKeyInfo` passes the specific API key for self-lookup).

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -582,7 +582,11 @@ const Layout: React.FC = () => {
             <br />
             {t('ui.footer.version')} {config?.version || t('ui.footer.noVersion')}
             <br />
-            <Flex direction={{ default: 'column' }} gap={{ default: 'gapXs' }} style={{ width: '100%', alignItems: 'center' }}>
+            <Flex
+              direction={{ default: 'column' }}
+              gap={{ default: 'gapXs' }}
+              style={{ width: '100%', alignItems: 'center' }}
+            >
               <FlexItem>
                 <Flex direction={{ default: 'row' }} alignItems={{ default: 'alignItemsCenter' }}>
                   <FlexItem>

--- a/frontend/src/contexts/NotificationContext.tsx
+++ b/frontend/src/contexts/NotificationContext.tsx
@@ -1,4 +1,12 @@
-import React, { createContext, useContext, useState, useCallback, useRef, ReactNode } from 'react';
+import React, {
+  createContext,
+  useContext,
+  useState,
+  useCallback,
+  useRef,
+  useEffect,
+  ReactNode,
+} from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import { ToastNotification } from '../components/AlertToastGroup';
 
@@ -49,6 +57,13 @@ export const NotificationProvider: React.FC<NotificationProviderProps> = ({ chil
     description: '',
     timestamp: 0,
   });
+  const timersRef = useRef<Set<ReturnType<typeof setTimeout>>>(new Set());
+
+  useEffect(() => {
+    return () => {
+      timersRef.current.forEach((timer) => clearTimeout(timer));
+    };
+  }, []);
 
   const addNotification = useCallback(
     (notification: Omit<Notification, 'id' | 'timestamp' | 'isRead'>) => {
@@ -94,9 +109,11 @@ export const NotificationProvider: React.FC<NotificationProviderProps> = ({ chil
 
       // Auto-remove success notifications from drawer after 5 seconds
       if (notification.variant === 'success') {
-        setTimeout(() => {
+        const timer = setTimeout(() => {
+          timersRef.current.delete(timer);
           setNotifications((prev) => prev.filter((n) => n.id !== newNotification.id));
         }, 2000);
+        timersRef.current.add(timer);
       }
     },
     [],

--- a/frontend/src/pages/AdminModelsPage.tsx
+++ b/frontend/src/pages/AdminModelsPage.tsx
@@ -689,7 +689,11 @@ const AdminModelsPage: React.FC = () => {
                     )}
                   </Td>
                   <Td>{model.rpm?.toLocaleString() || t('models.admin.table.nA')}</Td>
-                  <Td>{model.supportsConvert ? t('models.admin.table.nA') : (model.tpm?.toLocaleString() || t('models.admin.table.nA'))}</Td>
+                  <Td>
+                    {model.supportsConvert
+                      ? t('models.admin.table.nA')
+                      : model.tpm?.toLocaleString() || t('models.admin.table.nA')}
+                  </Td>
                   <Td>
                     {model.inputCostPerToken
                       ? formatCurrency(model.inputCostPerToken * 1000000)
@@ -700,7 +704,11 @@ const AdminModelsPage: React.FC = () => {
                       ? formatCurrency(model.outputCostPerToken * 1000000)
                       : t('models.admin.table.nA')}
                   </Td>
-                  <Td>{model.supportsConvert ? t('models.admin.table.nA') : (model.maxTokens?.toLocaleString() || t('models.admin.table.nA'))}</Td>
+                  <Td>
+                    {model.supportsConvert
+                      ? t('models.admin.table.nA')
+                      : model.maxTokens?.toLocaleString() || t('models.admin.table.nA')}
+                  </Td>
                   <Td>
                     <Flex spaceItems={{ default: 'spaceItemsXs' }} flexWrap={{ default: 'wrap' }}>
                       {getModelFlairs(model).map(({ key, label, color }) => (
@@ -773,7 +781,11 @@ const AdminModelsPage: React.FC = () => {
                           label={t('models.admin.modelTypeChat')}
                           isChecked={!formData.supports_embeddings && !formData.supports_convert}
                           onChange={() =>
-                            setFormData({ ...formData, supports_embeddings: false, supports_convert: false })
+                            setFormData({
+                              ...formData,
+                              supports_embeddings: false,
+                              supports_convert: false,
+                            })
                           }
                           isDisabled={isViewModalOpen}
                         />
@@ -785,7 +797,11 @@ const AdminModelsPage: React.FC = () => {
                           label={t('models.admin.modelTypeEmbeddings')}
                           isChecked={formData.supports_embeddings}
                           onChange={() =>
-                            setFormData({ ...formData, supports_embeddings: true, supports_convert: false })
+                            setFormData({
+                              ...formData,
+                              supports_embeddings: true,
+                              supports_convert: false,
+                            })
                           }
                           isDisabled={isViewModalOpen}
                         />
@@ -797,7 +813,12 @@ const AdminModelsPage: React.FC = () => {
                           label={t('models.admin.modelTypeConvert')}
                           isChecked={formData.supports_convert}
                           onChange={() =>
-                            setFormData({ ...formData, supports_convert: true, supports_embeddings: false, backend_model_name: 'docling' })
+                            setFormData({
+                              ...formData,
+                              supports_convert: true,
+                              supports_embeddings: false,
+                              backend_model_name: 'docling',
+                            })
                           }
                           isDisabled={isViewModalOpen}
                         />
@@ -851,31 +872,31 @@ const AdminModelsPage: React.FC = () => {
                   </FormGroup>
                 </GridItem>
                 {!formData.supports_convert && (
-                <GridItem span={12}>
-                  <FormGroup
-                    label={t('models.admin.backendModelName')}
-                    isRequired
-                    fieldId="backend-model-name"
-                  >
-                    <TextInput
-                      id="backend-model-name"
-                      value={formData.backend_model_name}
-                      onChange={(_event, value) =>
-                        setFormData({ ...formData, backend_model_name: value })
-                      }
-                      validated={formErrors.backend_model_name ? 'error' : 'default'}
-                      placeholder={t('models.admin.enterBackendModelName')}
-                      isDisabled={isViewModalOpen}
-                    />
-                    {formErrors.backend_model_name && (
-                      <HelperText>
-                        <HelperTextItem variant="error">
-                          {formErrors.backend_model_name}
-                        </HelperTextItem>
-                      </HelperText>
-                    )}
-                  </FormGroup>
-                </GridItem>
+                  <GridItem span={12}>
+                    <FormGroup
+                      label={t('models.admin.backendModelName')}
+                      isRequired
+                      fieldId="backend-model-name"
+                    >
+                      <TextInput
+                        id="backend-model-name"
+                        value={formData.backend_model_name}
+                        onChange={(_event, value) =>
+                          setFormData({ ...formData, backend_model_name: value })
+                        }
+                        validated={formErrors.backend_model_name ? 'error' : 'default'}
+                        placeholder={t('models.admin.enterBackendModelName')}
+                        isDisabled={isViewModalOpen}
+                      />
+                      {formErrors.backend_model_name && (
+                        <HelperText>
+                          <HelperTextItem variant="error">
+                            {formErrors.backend_model_name}
+                          </HelperTextItem>
+                        </HelperText>
+                      )}
+                    </FormGroup>
+                  </GridItem>
                 )}
                 <GridItem span={12}>
                   <FormGroup
@@ -930,194 +951,197 @@ const AdminModelsPage: React.FC = () => {
                   </FormGroup>
                 </GridItem>
                 {!formData.supports_convert && (
-                <GridItem span={6}>
-                  <FormGroup label={t('models.admin.tpmTokensPerMinute')} fieldId="tpm">
-                    <NumberInput
-                      id="tpm"
-                      value={formData.tpm}
-                      onChange={(event) => {
-                        const value = parseInt((event.target as HTMLInputElement).value) || 1;
-                        setFormData({ ...formData, tpm: value });
-                      }}
-                      onPlus={() => {
-                        setFormData({ ...formData, tpm: formData.tpm + 1 });
-                      }}
-                      onMinus={() => {
-                        setFormData({ ...formData, tpm: Math.max(1, formData.tpm - 1) });
-                      }}
-                      min={1}
-                      validated={formErrors.tpm ? 'error' : 'default'}
-                      isDisabled={isViewModalOpen}
-                    />
-                    {formErrors.tpm && (
-                      <HelperText>
-                        <HelperTextItem variant="error">{formErrors.tpm}</HelperTextItem>
-                      </HelperText>
-                    )}
-                  </FormGroup>
-                </GridItem>
+                  <GridItem span={6}>
+                    <FormGroup label={t('models.admin.tpmTokensPerMinute')} fieldId="tpm">
+                      <NumberInput
+                        id="tpm"
+                        value={formData.tpm}
+                        onChange={(event) => {
+                          const value = parseInt((event.target as HTMLInputElement).value) || 1;
+                          setFormData({ ...formData, tpm: value });
+                        }}
+                        onPlus={() => {
+                          setFormData({ ...formData, tpm: formData.tpm + 1 });
+                        }}
+                        onMinus={() => {
+                          setFormData({ ...formData, tpm: Math.max(1, formData.tpm - 1) });
+                        }}
+                        min={1}
+                        validated={formErrors.tpm ? 'error' : 'default'}
+                        isDisabled={isViewModalOpen}
+                      />
+                      {formErrors.tpm && (
+                        <HelperText>
+                          <HelperTextItem variant="error">{formErrors.tpm}</HelperTextItem>
+                        </HelperText>
+                      )}
+                    </FormGroup>
+                  </GridItem>
                 )}
                 {!formData.supports_convert && (
-                <>
-                <GridItem span={6}>
-                  <FormGroup
-                    label={t('models.admin.inputCostPerMillionTokens')}
-                    fieldId="input-cost"
-                  >
-                    <NumberInput
-                      id="input-cost"
-                      value={displayInputCost}
-                      onChange={(event) => {
-                        const value = parseFloat((event.target as HTMLInputElement).value) || 0;
-                        setDisplayInputCost(value);
-                        setFormData({ ...formData, input_cost_per_token: value / 1000000 });
-                      }}
-                      onPlus={() => {
-                        const newValue = Math.round((displayInputCost + 0.01) * 10000) / 10000;
-                        setDisplayInputCost(newValue);
-                        setFormData({ ...formData, input_cost_per_token: newValue / 1000000 });
-                      }}
-                      onMinus={() => {
-                        const newValue =
-                          Math.round(Math.max(0, displayInputCost - 0.01) * 10000) / 10000;
-                        setDisplayInputCost(newValue);
-                        setFormData({ ...formData, input_cost_per_token: newValue / 1000000 });
-                      }}
-                      min={0}
-                      step={0.01}
-                      validated={formErrors.input_cost_per_token ? 'error' : 'default'}
-                      isDisabled={isViewModalOpen}
-                    />
-                    {formErrors.input_cost_per_token && (
-                      <HelperText>
-                        <HelperTextItem variant="error">
-                          {formErrors.input_cost_per_token}
-                        </HelperTextItem>
-                      </HelperText>
-                    )}
-                  </FormGroup>
-                </GridItem>
-                <GridItem span={6}>
-                  <FormGroup
-                    label={t('models.admin.outputCostPerMillionTokens')}
-                    fieldId="output-cost"
-                  >
-                    <NumberInput
-                      id="output-cost"
-                      value={displayOutputCost}
-                      onChange={(event) => {
-                        const value = parseFloat((event.target as HTMLInputElement).value) || 0;
-                        setDisplayOutputCost(value);
-                        setFormData({ ...formData, output_cost_per_token: value / 1000000 });
-                      }}
-                      onPlus={() => {
-                        const newValue = Math.round((displayOutputCost + 0.01) * 10000) / 10000;
-                        setDisplayOutputCost(newValue);
-                        setFormData({ ...formData, output_cost_per_token: newValue / 1000000 });
-                      }}
-                      onMinus={() => {
-                        const newValue =
-                          Math.round(Math.max(0, displayOutputCost - 0.01) * 10000) / 10000;
-                        setDisplayOutputCost(newValue);
-                        setFormData({ ...formData, output_cost_per_token: newValue / 1000000 });
-                      }}
-                      min={0}
-                      step={0.01}
-                      validated={formErrors.output_cost_per_token ? 'error' : 'default'}
-                      isDisabled={isViewModalOpen}
-                    />
-                    {formErrors.output_cost_per_token && (
-                      <HelperText>
-                        <HelperTextItem variant="error">
-                          {formErrors.output_cost_per_token}
-                        </HelperTextItem>
-                      </HelperText>
-                    )}
-                  </FormGroup>
-                </GridItem>
-                <GridItem span={6}>
-                  <FormGroup label={t('models.admin.maxTokens')} fieldId="max-tokens">
-                    <NumberInput
-                      id="max-tokens"
-                      value={formData.max_tokens}
-                      onChange={(event) => {
-                        const value = parseInt((event.target as HTMLInputElement).value) || 1;
-                        setFormData({ ...formData, max_tokens: value });
-                      }}
-                      onPlus={() => {
-                        setFormData({ ...formData, max_tokens: formData.max_tokens + 1 });
-                      }}
-                      onMinus={() => {
-                        setFormData({
-                          ...formData,
-                          max_tokens: Math.max(1, formData.max_tokens - 1),
-                        });
-                      }}
-                      min={1}
-                      validated={formErrors.max_tokens ? 'error' : 'default'}
-                      isDisabled={isViewModalOpen}
-                    />
-                    {formErrors.max_tokens && (
-                      <HelperText>
-                        <HelperTextItem variant="error">{formErrors.max_tokens}</HelperTextItem>
-                      </HelperText>
-                    )}
-                  </FormGroup>
-                </GridItem>
-                </>
+                  <>
+                    <GridItem span={6}>
+                      <FormGroup
+                        label={t('models.admin.inputCostPerMillionTokens')}
+                        fieldId="input-cost"
+                      >
+                        <NumberInput
+                          id="input-cost"
+                          value={displayInputCost}
+                          onChange={(event) => {
+                            const value = parseFloat((event.target as HTMLInputElement).value) || 0;
+                            setDisplayInputCost(value);
+                            setFormData({ ...formData, input_cost_per_token: value / 1000000 });
+                          }}
+                          onPlus={() => {
+                            const newValue = Math.round((displayInputCost + 0.01) * 10000) / 10000;
+                            setDisplayInputCost(newValue);
+                            setFormData({ ...formData, input_cost_per_token: newValue / 1000000 });
+                          }}
+                          onMinus={() => {
+                            const newValue =
+                              Math.round(Math.max(0, displayInputCost - 0.01) * 10000) / 10000;
+                            setDisplayInputCost(newValue);
+                            setFormData({ ...formData, input_cost_per_token: newValue / 1000000 });
+                          }}
+                          min={0}
+                          step={0.01}
+                          validated={formErrors.input_cost_per_token ? 'error' : 'default'}
+                          isDisabled={isViewModalOpen}
+                        />
+                        {formErrors.input_cost_per_token && (
+                          <HelperText>
+                            <HelperTextItem variant="error">
+                              {formErrors.input_cost_per_token}
+                            </HelperTextItem>
+                          </HelperText>
+                        )}
+                      </FormGroup>
+                    </GridItem>
+                    <GridItem span={6}>
+                      <FormGroup
+                        label={t('models.admin.outputCostPerMillionTokens')}
+                        fieldId="output-cost"
+                      >
+                        <NumberInput
+                          id="output-cost"
+                          value={displayOutputCost}
+                          onChange={(event) => {
+                            const value = parseFloat((event.target as HTMLInputElement).value) || 0;
+                            setDisplayOutputCost(value);
+                            setFormData({ ...formData, output_cost_per_token: value / 1000000 });
+                          }}
+                          onPlus={() => {
+                            const newValue = Math.round((displayOutputCost + 0.01) * 10000) / 10000;
+                            setDisplayOutputCost(newValue);
+                            setFormData({ ...formData, output_cost_per_token: newValue / 1000000 });
+                          }}
+                          onMinus={() => {
+                            const newValue =
+                              Math.round(Math.max(0, displayOutputCost - 0.01) * 10000) / 10000;
+                            setDisplayOutputCost(newValue);
+                            setFormData({ ...formData, output_cost_per_token: newValue / 1000000 });
+                          }}
+                          min={0}
+                          step={0.01}
+                          validated={formErrors.output_cost_per_token ? 'error' : 'default'}
+                          isDisabled={isViewModalOpen}
+                        />
+                        {formErrors.output_cost_per_token && (
+                          <HelperText>
+                            <HelperTextItem variant="error">
+                              {formErrors.output_cost_per_token}
+                            </HelperTextItem>
+                          </HelperText>
+                        )}
+                      </FormGroup>
+                    </GridItem>
+                    <GridItem span={6}>
+                      <FormGroup label={t('models.admin.maxTokens')} fieldId="max-tokens">
+                        <NumberInput
+                          id="max-tokens"
+                          value={formData.max_tokens}
+                          onChange={(event) => {
+                            const value = parseInt((event.target as HTMLInputElement).value) || 1;
+                            setFormData({ ...formData, max_tokens: value });
+                          }}
+                          onPlus={() => {
+                            setFormData({ ...formData, max_tokens: formData.max_tokens + 1 });
+                          }}
+                          onMinus={() => {
+                            setFormData({
+                              ...formData,
+                              max_tokens: Math.max(1, formData.max_tokens - 1),
+                            });
+                          }}
+                          min={1}
+                          validated={formErrors.max_tokens ? 'error' : 'default'}
+                          isDisabled={isViewModalOpen}
+                        />
+                        {formErrors.max_tokens && (
+                          <HelperText>
+                            <HelperTextItem variant="error">{formErrors.max_tokens}</HelperTextItem>
+                          </HelperText>
+                        )}
+                      </FormGroup>
+                    </GridItem>
+                  </>
                 )}
                 {!formData.supports_convert && (
-                <GridItem span={12}>
-                  <FormGroup label={t('common.features')} fieldId="features">
-                    <Stack hasGutter>
-                      <Checkbox
-                        id="supports-tokenize"
-                        label={t('models.admin.supportsTokenize')}
-                        isChecked={formData.supports_tokenize}
-                        onChange={(_event, checked) =>
-                          setFormData({ ...formData, supports_tokenize: checked })
-                        }
-                        isDisabled={isViewModalOpen}
-                      />
-                      <Checkbox
-                        id="supports-vision"
-                        label={t('models.admin.supportsVision')}
-                        isChecked={formData.supports_vision}
-                        onChange={(_event, checked) =>
-                          setFormData({ ...formData, supports_vision: checked })
-                        }
-                        isDisabled={isViewModalOpen}
-                      />
-                      <Checkbox
-                        id="supports-function-calling"
-                        label={t('models.admin.supportsFunctionCalling')}
-                        isChecked={formData.supports_function_calling}
-                        onChange={(_event, checked) =>
-                          setFormData({ ...formData, supports_function_calling: checked })
-                        }
-                        isDisabled={isViewModalOpen}
-                      />
-                      <Checkbox
-                        id="supports-parallel-function-calling"
-                        label={t('models.admin.supportsParallelFunctionCalling')}
-                        isChecked={formData.supports_parallel_function_calling}
-                        onChange={(_event, checked) =>
-                          setFormData({ ...formData, supports_parallel_function_calling: checked })
-                        }
-                        isDisabled={isViewModalOpen}
-                      />
-                      <Checkbox
-                        id="supports-tool-choice"
-                        label={t('models.admin.supportsToolChoice')}
-                        isChecked={formData.supports_tool_choice}
-                        onChange={(_event, checked) =>
-                          setFormData({ ...formData, supports_tool_choice: checked })
-                        }
-                        isDisabled={isViewModalOpen}
-                      />
-                    </Stack>
-                  </FormGroup>
-                </GridItem>
+                  <GridItem span={12}>
+                    <FormGroup label={t('common.features')} fieldId="features">
+                      <Stack hasGutter>
+                        <Checkbox
+                          id="supports-tokenize"
+                          label={t('models.admin.supportsTokenize')}
+                          isChecked={formData.supports_tokenize}
+                          onChange={(_event, checked) =>
+                            setFormData({ ...formData, supports_tokenize: checked })
+                          }
+                          isDisabled={isViewModalOpen}
+                        />
+                        <Checkbox
+                          id="supports-vision"
+                          label={t('models.admin.supportsVision')}
+                          isChecked={formData.supports_vision}
+                          onChange={(_event, checked) =>
+                            setFormData({ ...formData, supports_vision: checked })
+                          }
+                          isDisabled={isViewModalOpen}
+                        />
+                        <Checkbox
+                          id="supports-function-calling"
+                          label={t('models.admin.supportsFunctionCalling')}
+                          isChecked={formData.supports_function_calling}
+                          onChange={(_event, checked) =>
+                            setFormData({ ...formData, supports_function_calling: checked })
+                          }
+                          isDisabled={isViewModalOpen}
+                        />
+                        <Checkbox
+                          id="supports-parallel-function-calling"
+                          label={t('models.admin.supportsParallelFunctionCalling')}
+                          isChecked={formData.supports_parallel_function_calling}
+                          onChange={(_event, checked) =>
+                            setFormData({
+                              ...formData,
+                              supports_parallel_function_calling: checked,
+                            })
+                          }
+                          isDisabled={isViewModalOpen}
+                        />
+                        <Checkbox
+                          id="supports-tool-choice"
+                          label={t('models.admin.supportsToolChoice')}
+                          isChecked={formData.supports_tool_choice}
+                          onChange={(_event, checked) =>
+                            setFormData({ ...formData, supports_tool_choice: checked })
+                          }
+                          isDisabled={isViewModalOpen}
+                        />
+                      </Stack>
+                    </FormGroup>
+                  </GridItem>
                 )}
                 <GridItem span={12}>
                   <FormGroup label={t('common.accessRestrictions')} fieldId="access-restrictions">

--- a/frontend/src/pages/ApiKeysPage.tsx
+++ b/frontend/src/pages/ApiKeysPage.tsx
@@ -1919,11 +1919,20 @@ const ApiKeysPage: React.FC = () => {
                                   <Th scope="row">
                                     <strong>{t('pages.apiKeys.labels.apiUrl')}</strong>
                                   </Th>
-                                  <Td>{litellmApiUrl}/{(() => {
-                                    const detail = selectedApiKey.modelDetails?.find((m) => m.id === selectedModelForExample);
-                                    const fromList = models.find((m) => m.id === selectedModelForExample);
-                                    return (detail?.supportsConvert || fromList?.supportsConvert) ? 'docling/v1' : 'v1';
-                                  })()}</Td>
+                                  <Td>
+                                    {litellmApiUrl}/
+                                    {(() => {
+                                      const detail = selectedApiKey.modelDetails?.find(
+                                        (m) => m.id === selectedModelForExample,
+                                      );
+                                      const fromList = models.find(
+                                        (m) => m.id === selectedModelForExample,
+                                      );
+                                      return detail?.supportsConvert || fromList?.supportsConvert
+                                        ? 'docling/v1'
+                                        : 'v1';
+                                    })()}
+                                  </Td>
                                 </Tr>
                                 <Tr>
                                   <Th scope="row">
@@ -2007,13 +2016,24 @@ const ApiKeysPage: React.FC = () => {
                 <CodeBlock>
                   <CodeBlockCode>
                     {(() => {
-                      const bearerToken = visibleKeys.has(selectedApiKey.id) && selectedApiKey.fullKey ? selectedApiKey.fullKey : '<click-show-key-to-reveal>';
+                      const bearerToken =
+                        visibleKeys.has(selectedApiKey.id) && selectedApiKey.fullKey
+                          ? selectedApiKey.fullKey
+                          : '<click-show-key-to-reveal>';
                       const modelName = selectedModelForExample || 'gpt-4';
                       // Check model type from both API key modelDetails and loaded models array
-                      const selectedModelDetail = selectedApiKey.modelDetails?.find((m) => m.id === selectedModelForExample);
-                      const selectedModelFromList = models.find((m) => m.id === selectedModelForExample);
-                      const isEmbeddingsModel = selectedModelDetail?.supportsEmbeddings || selectedModelFromList?.supportsEmbeddings;
-                      const isConvertModel = selectedModelDetail?.supportsConvert || selectedModelFromList?.supportsConvert;
+                      const selectedModelDetail = selectedApiKey.modelDetails?.find(
+                        (m) => m.id === selectedModelForExample,
+                      );
+                      const selectedModelFromList = models.find(
+                        (m) => m.id === selectedModelForExample,
+                      );
+                      const isEmbeddingsModel =
+                        selectedModelDetail?.supportsEmbeddings ||
+                        selectedModelFromList?.supportsEmbeddings;
+                      const isConvertModel =
+                        selectedModelDetail?.supportsConvert ||
+                        selectedModelFromList?.supportsConvert;
 
                       if (isEmbeddingsModel) {
                         return `# ${t('pages.apiKeys.codeExample.commentEmbeddings')}

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -146,9 +146,7 @@ const LoginPage: React.FC = () => {
               variant="danger"
               title={t('pages.login.authError')}
               isInline
-              actionClose={
-                <AlertActionCloseButton onClose={() => setShowAuthError(false)} />
-              }
+              actionClose={<AlertActionCloseButton onClose={() => setShowAuthError(false)} />}
             />
           </StackItem>
         )}

--- a/frontend/src/services/apiKeys.service.ts
+++ b/frontend/src/services/apiKeys.service.ts
@@ -145,9 +145,15 @@ class ApiKeysService {
         id: md.id,
         name: md.name,
         provider: md.provider,
-        contextLength: md.contextLength ?? (md as Record<string, unknown>).context_length as number | undefined,
-        supportsEmbeddings: md.supports_embeddings ?? (md as Record<string, unknown>).supportsEmbeddings as boolean | undefined,
-        supportsConvert: md.supports_convert ?? (md as Record<string, unknown>).supportsConvert as boolean | undefined,
+        contextLength:
+          md.contextLength ??
+          ((md as Record<string, unknown>).context_length as number | undefined),
+        supportsEmbeddings:
+          md.supports_embeddings ??
+          ((md as Record<string, unknown>).supportsEmbeddings as boolean | undefined),
+        supportsConvert:
+          md.supports_convert ??
+          ((md as Record<string, unknown>).supportsConvert as boolean | undefined),
       })),
       maxBudget: backend.maxBudget,
       currentSpend: backend.currentSpend,

--- a/frontend/src/services/models.service.ts
+++ b/frontend/src/services/models.service.ts
@@ -164,10 +164,16 @@ class ModelsService {
       supportsFunctionCalling: backendModel.supportsFunctionCalling,
       supportsParallelFunctionCalling: backendModel.supportsParallelFunctionCalling,
       supportsToolChoice: backendModel.supportsToolChoice,
-      supportsChat: backendModel.supportsChat ?? backendModel.capabilities?.includes('chat') ?? false,
-      supportsEmbeddings: backendModel.supportsEmbeddings ?? backendModel.capabilities?.includes('embeddings') ?? false,
-      supportsTokenize: backendModel.supportsTokenize ?? backendModel.capabilities?.includes('tokenize') ?? false,
-      supportsConvert: backendModel.supportsConvert ?? backendModel.capabilities?.includes('convert') ?? false,
+      supportsChat:
+        backendModel.supportsChat ?? backendModel.capabilities?.includes('chat') ?? false,
+      supportsEmbeddings:
+        backendModel.supportsEmbeddings ??
+        backendModel.capabilities?.includes('embeddings') ??
+        false,
+      supportsTokenize:
+        backendModel.supportsTokenize ?? backendModel.capabilities?.includes('tokenize') ?? false,
+      supportsConvert:
+        backendModel.supportsConvert ?? backendModel.capabilities?.includes('convert') ?? false,
       litellmModelId: backendModel.litellmModelId,
     };
   }

--- a/frontend/src/test/components/AuthCallbackPage.test.tsx
+++ b/frontend/src/test/components/AuthCallbackPage.test.tsx
@@ -171,7 +171,7 @@ describe('AuthCallbackPage', () => {
 
       await waitFor(() => {
         expect(consoleSpy).toHaveBeenCalledWith('No token found in callback');
-        expect(mockNavigate).toHaveBeenCalledWith('/login');
+        expect(mockNavigate).toHaveBeenCalledWith('/login?error=auth_failed');
       });
 
       expect(mockAuthService.setTokens).not.toHaveBeenCalled();
@@ -188,7 +188,7 @@ describe('AuthCallbackPage', () => {
 
       await waitFor(() => {
         expect(consoleSpy).toHaveBeenCalledWith('No token found in callback');
-        expect(mockNavigate).toHaveBeenCalledWith('/login');
+        expect(mockNavigate).toHaveBeenCalledWith('/login?error=auth_failed');
       });
 
       consoleSpy.mockRestore();
@@ -202,7 +202,7 @@ describe('AuthCallbackPage', () => {
 
       await waitFor(() => {
         expect(consoleSpy).toHaveBeenCalledWith('No token found in callback');
-        expect(mockNavigate).toHaveBeenCalledWith('/login');
+        expect(mockNavigate).toHaveBeenCalledWith('/login?error=auth_failed');
       });
 
       consoleSpy.mockRestore();
@@ -219,7 +219,7 @@ describe('AuthCallbackPage', () => {
         expect(mockAuthService.setTokens).toHaveBeenCalledWith('valid-token', 'valid-token');
         expect(mockRefreshUser).toHaveBeenCalledTimes(1);
         expect(consoleSpy).toHaveBeenCalledWith('Error handling auth callback:', expect.any(Error));
-        expect(mockNavigate).toHaveBeenCalledWith('/login');
+        expect(mockNavigate).toHaveBeenCalledWith('/login?error=auth_failed');
       });
 
       consoleSpy.mockRestore();
@@ -236,7 +236,7 @@ describe('AuthCallbackPage', () => {
 
       await waitFor(() => {
         expect(consoleSpy).toHaveBeenCalledWith('Error handling auth callback:', expect.any(Error));
-        expect(mockNavigate).toHaveBeenCalledWith('/login');
+        expect(mockNavigate).toHaveBeenCalledWith('/login?error=auth_failed');
       });
 
       expect(mockRefreshUser).not.toHaveBeenCalled();
@@ -298,7 +298,7 @@ describe('AuthCallbackPage', () => {
 
       await waitFor(() => {
         expect(consoleSpy).toHaveBeenCalledWith('No token found in callback');
-        expect(mockNavigate).toHaveBeenCalledWith('/login');
+        expect(mockNavigate).toHaveBeenCalledWith('/login?error=auth_failed');
       });
 
       consoleSpy.mockRestore();
@@ -461,7 +461,7 @@ describe('AuthCallbackPage', () => {
 
       await waitFor(() => {
         expect(consoleSpy).toHaveBeenCalledWith('Error handling auth callback:', expect.any(Error));
-        expect(mockNavigate).toHaveBeenCalledWith('/login');
+        expect(mockNavigate).toHaveBeenCalledWith('/login?error=auth_failed');
       });
 
       consoleSpy.mockRestore();
@@ -499,7 +499,7 @@ describe('AuthCallbackPage', () => {
 
       await waitFor(() => {
         expect(consoleSpy).toHaveBeenCalledWith('No token found in callback');
-        expect(mockNavigate).toHaveBeenCalledWith('/login');
+        expect(mockNavigate).toHaveBeenCalledWith('/login?error=auth_failed');
       });
 
       consoleSpy.mockRestore();
@@ -513,7 +513,7 @@ describe('AuthCallbackPage', () => {
 
       await waitFor(() => {
         expect(consoleSpy).toHaveBeenCalledWith('No token found in callback');
-        expect(mockNavigate).toHaveBeenCalledWith('/login');
+        expect(mockNavigate).toHaveBeenCalledWith('/login?error=auth_failed');
       });
 
       consoleSpy.mockRestore();
@@ -527,7 +527,7 @@ describe('AuthCallbackPage', () => {
 
       await waitFor(() => {
         expect(consoleSpy).toHaveBeenCalledWith('No token found in callback');
-        expect(mockNavigate).toHaveBeenCalledWith('/login');
+        expect(mockNavigate).toHaveBeenCalledWith('/login?error=auth_failed');
       });
 
       consoleSpy.mockRestore();

--- a/frontend/src/test/components/UserEditModal.test.tsx
+++ b/frontend/src/test/components/UserEditModal.test.tsx
@@ -132,8 +132,15 @@ describe('UserEditModal', () => {
         { user: mockAdminUser },
       );
 
-      // Date should be formatted as locale string
-      const formattedDate = new Date('2024-01-15T10:30:00Z').toLocaleString();
+      // Date should be formatted using formatDateTime (YYYY-MM-DD HH:mm:ss in local timezone)
+      const date = new Date('2024-01-15T10:30:00Z');
+      const year = date.getFullYear();
+      const month = String(date.getMonth() + 1).padStart(2, '0');
+      const day = String(date.getDate()).padStart(2, '0');
+      const hours = String(date.getHours()).padStart(2, '0');
+      const minutes = String(date.getMinutes()).padStart(2, '0');
+      const seconds = String(date.getSeconds()).padStart(2, '0');
+      const formattedDate = `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`;
       expect(screen.getByText(formattedDate)).toBeInTheDocument();
     });
 


### PR DESCRIPTION
## Summary
- **LiteLLM schema creation**: Set `DISABLE_SCHEMA_UPDATE` to `false` in Helm and Kustomize templates, fixing fresh deployments where LiteLLM could not create its database schema
- **Usage analytics enrichment**: Include revoked/inactive API keys in user mapping, fixing undercounted requests and spend
- **Usage cache staleness**: Permanently cache yesterday's completed usage data instead of re-fetching on every request
- **Notification timer cleanup**: Properly clear auto-dismiss timers on unmount, fixing intermittent test errors

## Test plan
- [x] Fresh deployment with empty `litellm_db` — verify LiteLLM creates its schema on startup
- [x] Existing deployment upgrade — verify no regressions
- [ ] Usage analytics report with revoked API keys — verify correct spend attribution
- [x] Notification dismiss behavior — verify no timer errors