### PR TITLE
Fix subscription quota reset: require userId and tighten permission

### DIFF
--- a/backend/src/routes/subscriptions.ts
+++ b/backend/src/routes/subscriptions.ts
@@ -725,6 +725,7 @@ const subscriptionsRoutes: FastifyPluginAsync = async (fastify) => {
         properties: {
           userId: { type: 'string' },
         },
+        required: ['userId'],
       },
       response: {
         200: {
@@ -736,10 +737,10 @@ const subscriptionsRoutes: FastifyPluginAsync = async (fastify) => {
         },
       },
     },
-    preHandler: [fastify.authenticate, fastify.requirePermission('subscriptions:write')],
+    preHandler: [fastify.authenticate, fastify.requirePermission('admin:subscriptions:write')],
     handler: async (request, _reply) => {
       const user = (request as AuthenticatedRequest).user;
-      const { userId } = request.body as { userId?: string };
+      const { userId } = request.body as { userId: string };
 
       try {
         const resetCount = await subscriptionService.resetQuotas(userId);


### PR DESCRIPTION
## Summary

- Mark `userId` as **required** in the `POST /subscriptions/admin/reset-quotas` request body schema — previously optional, which allowed callers to omit it and trigger undefined behaviour in the service layer
- Tighten the TypeScript type from `userId?: string` to `userId: string` to match the schema
- Upgrade the required permission from `subscriptions:write` to `admin:subscriptions:write`, aligning this admin-only endpoint with the project's granular RBAC convention for admin subscription operations

## Motivation

Without `userId` being required in the schema, Fastify/Ajv would not reject requests that omit the field, and the service call `subscriptionService.resetQuotas(undefined)` could silently operate on an unintended target. The permission upgrade closes a privilege-escalation gap where any user holding the broader `subscriptions:write` permission could invoke this admin-only endpoint.

## Test plan

- [ ] `POST /subscriptions/admin/reset-quotas` without `userId` returns `400 Bad Request`
- [ ] Endpoint is inaccessible to users with only `subscriptions:write` permission
- [ ] Endpoint succeeds for admin users with `admin:subscriptions:write` and a valid `userId`
- [ ] Audit log entry is created with the correct `targetUserId` and `resetCount`

🤖 Generated with [Claude Code](https://claude.com/claude-code)