### PR TITLE
Fix review issues on PR #131

### DIFF
--- a/frontend/src/components/admin/MetricsOverview.tsx
+++ b/frontend/src/components/admin/MetricsOverview.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   Grid,
@@ -153,6 +153,12 @@ const MetricsOverview: React.FC<MetricsOverviewProps> = ({ data, loading }) => {
 
   const roles = user?.roles || [];
   const isAdmin = roles.includes('admin') || roles.includes('admin-readonly');
+
+  useEffect(() => {
+    if (!isAdmin) {
+      setIsTopUsersExpanded(false);
+    }
+  }, [isAdmin]);
 
   const getSuccessRateVariant = (rate: number): 'default' | 'success' | 'warning' | 'danger' => {
     if (rate >= 95) return 'success';

--- a/frontend/src/test/components/admin/MetricsOverview.test.tsx
+++ b/frontend/src/test/components/admin/MetricsOverview.test.tsx
@@ -6,6 +6,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import i18n from '../../../i18n';
 import MetricsOverview, { type GlobalMetrics } from '../../../components/admin/MetricsOverview';
 import { AuthContext } from '../../../contexts/AuthContext';
+import { type User } from '../../../services/auth.service';
 
 // Mock chart components to simplify testing
 vi.mock('../../../components/charts', () => ({
@@ -265,7 +266,7 @@ describe('MetricsOverview', () => {
 
   const renderComponent = (
     props: Partial<Parameters<typeof MetricsOverview>[0]> = {},
-    userOverrides?: { roles?: string[] } | null,
+    userOverrides?: Partial<User> | null,
   ) => {
     const defaultProps = {
       data: createMockData(),

--- a/frontend/src/test/services/api.integration.test.ts
+++ b/frontend/src/test/services/api.integration.test.ts
@@ -182,6 +182,7 @@ describe('API Client Integration Tests', () => {
   });
 
   afterEach(() => {
+    vi.unstubAllGlobals();
     vi.unstubAllEnvs();
   });
 


### PR DESCRIPTION
- Reset isTopUsersExpanded state when user loses admin role
- Use Partial<User> typing in test helper instead of ad-hoc type
- Restore vi.unstubAllGlobals() removed by mistake in api.integration.test.ts

---
Signed-off-by: Guillaume Moutier <guimou@users.noreply.github.com>
Co-Authored-By: Claude <noreply@anthropic.com>
