### PR TITLE
fix: remove authenticateWithDevBypass production auth bypass

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -106,10 +106,6 @@ CORS_ORIGIN=http://localhost:3000
 # Admin API Keys (comma-separated list)
 ADMIN_API_KEYS=ltm_admin_dev123,ltm_admin_prod456
 
-# Allowed frontend origins for bypass (development and testing)
-# In production, implement proper JWT authentication instead
-ALLOWED_FRONTEND_ORIGINS=localhost:3000,localhost:3001,127.0.0.1:3000,127.0.0.1:3001
-
 # Default User Values Configuration (for LLM requests via LiteLLM)
 # These values are applied to new users when they first log in
 # They control LLM usage limits, NOT backend API access

--- a/backend/src/plugins/auth.ts
+++ b/backend/src/plugins/auth.ts
@@ -15,128 +15,7 @@ const authPlugin: FastifyPluginAsync = async (fastify) => {
   const tokenService = new TokenService(fastify);
   fastify.decorate('tokenService', tokenService);
 
-  // Frontend-friendly authentication with fallback
-  fastify.decorate(
-    'authenticateWithDevBypass',
-    async (request: FastifyRequest, reply: FastifyReply) => {
-      try {
-        const origin = request.headers.origin;
-        const referer = request.headers.referer;
-        const token = request.headers.authorization;
-
-        // Debug logging
-        fastify.log.debug(
-          {
-            url: request.url,
-            method: request.method,
-            origin,
-            referer,
-            hasToken: !!token,
-            userAgent: request.headers['user-agent'],
-          },
-          'Authentication request details',
-        );
-
-        // First, try normal authentication if token is provided
-        if (token) {
-          try {
-            await fastify.authenticate(request, reply);
-            return; // Authentication successful
-          } catch (error) {
-            // If token authentication fails, continue to frontend bypass logic
-            fastify.log.debug('Token authentication failed, checking frontend bypass');
-          }
-        }
-
-        // Frontend bypass for localhost origins (both dev and production for testing)
-        const allowedOrigins = process.env.ALLOWED_FRONTEND_ORIGINS?.split(',') || [
-          'localhost:3000',
-          'localhost:3001',
-          '127.0.0.1:3000',
-          '127.0.0.1:3001',
-        ];
-
-        // Check if request is from allowed frontend
-        const isFromAllowedFrontend = allowedOrigins.some(
-          (allowedOrigin) =>
-            (origin && origin.includes(allowedOrigin)) ||
-            (referer && referer.includes(allowedOrigin)),
-        );
-
-        // Also allow requests that look like they're from a browser/frontend
-        // This handles proxied requests from Vite dev server
-        const userAgent = request.headers['user-agent'] || '';
-        const acceptHeader = request.headers.accept || '';
-
-        const isLikelyFrontendRequest =
-          // Requests with browser user agents
-          (userAgent.includes('Mozilla') ||
-            userAgent.includes('Chrome') ||
-            userAgent.includes('Safari') ||
-            userAgent.includes('Firefox')) &&
-          // Requests that accept JSON (typical for API calls)
-          (acceptHeader.includes('application/json') || acceptHeader.includes('*/*')) &&
-          // Not curl or other CLI tools
-          !userAgent.includes('curl') &&
-          !userAgent.includes('wget') &&
-          !userAgent.includes('Postman');
-
-        if (isFromAllowedFrontend || isLikelyFrontendRequest) {
-          const mockUser = {
-            userId: '550e8400-e29b-41d4-a716-446655440001',
-            username: 'frontend',
-            email: 'frontend@litemaas.local',
-            name: 'Frontend User',
-            roles: ['admin', 'user'],
-            iat: Math.floor(Date.now() / 1000),
-            exp: Math.floor(Date.now() / 1000) + 24 * 60 * 60, // 24 hours
-          };
-
-          (request as AuthenticatedRequest).user = mockUser;
-
-          const bypassReason = isFromAllowedFrontend ? 'allowed-origin' : 'browser-pattern';
-
-          if (process.env.NODE_ENV === 'production') {
-            fastify.log.warn(
-              {
-                ip: request.ip,
-                origin,
-                referer,
-                userAgent,
-                url: request.url,
-                method: request.method,
-                bypassReason,
-              },
-              'Frontend bypass used in production mode - consider implementing proper authentication',
-            );
-          } else {
-            fastify.log.debug({ bypassReason, userAgent }, 'Frontend request bypass');
-          }
-          return;
-        }
-
-        // If no bypass applies, require strict authentication
-        return reply.status(401).send({
-          error: {
-            code: 'UNAUTHORIZED',
-            message: 'Authentication required',
-          },
-          requestId: request.id,
-        });
-      } catch (error) {
-        fastify.log.error(error, 'Authentication with dev bypass failed');
-        return reply.status(401).send({
-          error: {
-            code: 'UNAUTHORIZED',
-            message: 'Authentication required',
-          },
-          requestId: request.id,
-        });
-      }
-    },
-  );
-
-  // Enhanced authentication decorator
+  // Authentication decorator
   fastify.decorate('authenticate', async (request: FastifyRequest, reply: FastifyReply) => {
     try {
       // Try to get token from Authorization header
@@ -385,7 +264,6 @@ declare module 'fastify' {
   interface FastifyInstance {
     tokenService: TokenService;
     authenticate: (request: FastifyRequest, reply: FastifyReply) => Promise<void>;
-    authenticateWithDevBypass: (request: FastifyRequest, reply: FastifyReply) => Promise<void>;
     optionalAuth: (request: FastifyRequest, reply: FastifyReply) => Promise<void>;
     requireRole: (
       roles: string[],

--- a/backend/src/plugins/swagger.ts
+++ b/backend/src/plugins/swagger.ts
@@ -126,7 +126,7 @@ const swaggerPlugin: FastifyPluginAsync = async (fastify) => {
     schema: {
       hide: true,
     },
-    preHandler: fastify.authenticateWithDevBypass,
+    preHandler: fastify.authenticate,
     handler: (_request, reply) => {
       reply.send(fastify.swagger());
     },

--- a/backend/src/routes/api-keys.ts
+++ b/backend/src/routes/api-keys.ts
@@ -57,7 +57,7 @@ const apiKeysRoutes: FastifyPluginAsync = async (fastify) => {
         200: ApiKeyResponseSchema,
       },
     },
-    preHandler: fastify.authenticateWithDevBypass,
+    preHandler: fastify.authenticate,
     handler: async (request, _reply) => {
       const user = (request as AuthenticatedRequest).user;
       const { page = 1, limit = 20, subscriptionId, modelIds, isActive } = request.query;
@@ -143,7 +143,7 @@ const apiKeysRoutes: FastifyPluginAsync = async (fastify) => {
         200: SingleApiKeyResponseSchema,
       },
     },
-    preHandler: fastify.authenticateWithDevBypass,
+    preHandler: fastify.authenticate,
     handler: async (request, _reply) => {
       const user = (request as AuthenticatedRequest).user;
       const { id } = request.params;
@@ -190,7 +190,7 @@ const apiKeysRoutes: FastifyPluginAsync = async (fastify) => {
         201: SingleApiKeyResponseSchema,
       },
     },
-    preHandler: fastify.authenticateWithDevBypass,
+    preHandler: fastify.authenticate,
     handler: async (request, reply) => {
       const user = (request as AuthenticatedRequest).user;
       const body = request.body;
@@ -348,7 +348,7 @@ const apiKeysRoutes: FastifyPluginAsync = async (fastify) => {
         },
       },
     },
-    preHandler: fastify.authenticateWithDevBypass,
+    preHandler: fastify.authenticate,
     handler: async (request, _reply) => {
       const user = (request as AuthenticatedRequest).user;
       const { id } = request.params;
@@ -407,7 +407,7 @@ const apiKeysRoutes: FastifyPluginAsync = async (fastify) => {
         },
       },
     },
-    preHandler: fastify.authenticateWithDevBypass,
+    preHandler: fastify.authenticate,
     handler: async (request, _reply) => {
       const user = (request as AuthenticatedRequest).user;
       const { id } = request.params;
@@ -537,7 +537,7 @@ const apiKeysRoutes: FastifyPluginAsync = async (fastify) => {
         },
       },
     },
-    preHandler: fastify.authenticateWithDevBypass,
+    preHandler: fastify.authenticate,
     handler: async (request, _reply) => {
       const user = (request as AuthenticatedRequest).user;
       const { id } = request.params;
@@ -715,7 +715,7 @@ const apiKeysRoutes: FastifyPluginAsync = async (fastify) => {
         },
       },
     },
-    preHandler: fastify.authenticateWithDevBypass,
+    preHandler: fastify.authenticate,
     handler: async (request, _reply) => {
       const user = (request as AuthenticatedRequest).user;
       const { id } = request.params;
@@ -762,7 +762,7 @@ const apiKeysRoutes: FastifyPluginAsync = async (fastify) => {
         },
       },
     },
-    preHandler: fastify.authenticateWithDevBypass,
+    preHandler: fastify.authenticate,
     handler: async (request, _reply) => {
       const user = (request as AuthenticatedRequest).user;
 
@@ -985,11 +985,7 @@ const apiKeysRoutes: FastifyPluginAsync = async (fastify) => {
         },
       },
     },
-    preHandler: [
-      fastify.authenticateWithDevBypass,
-      fastify.requireRecentAuth,
-      fastify.keyOperationRateLimit,
-    ],
+    preHandler: [fastify.authenticate, fastify.requireRecentAuth, fastify.keyOperationRateLimit],
     handler: async (request, reply) => {
       const user = (request as AuthenticatedRequest).user;
       const { id } = request.params;

--- a/backend/src/routes/subscriptions.ts
+++ b/backend/src/routes/subscriptions.ts
@@ -97,7 +97,7 @@ const subscriptionsRoutes: FastifyPluginAsync = async (fastify) => {
         },
       },
     },
-    preHandler: fastify.authenticateWithDevBypass,
+    preHandler: fastify.authenticate,
     handler: async (request, _reply) => {
       const user = (request as AuthenticatedRequest).user;
       const { page = 1, limit = 20, status, modelId } = request.query;
@@ -186,7 +186,7 @@ const subscriptionsRoutes: FastifyPluginAsync = async (fastify) => {
         },
       },
     },
-    preHandler: fastify.authenticateWithDevBypass,
+    preHandler: fastify.authenticate,
     handler: async (request, _reply) => {
       const user = (request as AuthenticatedRequest).user;
       const { id } = request.params;
@@ -269,7 +269,7 @@ const subscriptionsRoutes: FastifyPluginAsync = async (fastify) => {
         },
       },
     },
-    preHandler: fastify.authenticateWithDevBypass,
+    preHandler: fastify.authenticate,
     handler: async (request, reply) => {
       const user = (request as AuthenticatedRequest).user;
       const { modelId, quotaRequests, quotaTokens, expiresAt, metadata } = request.body;
@@ -387,7 +387,7 @@ const subscriptionsRoutes: FastifyPluginAsync = async (fastify) => {
         },
       },
     },
-    preHandler: fastify.authenticateWithDevBypass,
+    preHandler: fastify.authenticate,
     handler: async (request, _reply) => {
       const user = (request as AuthenticatedRequest).user;
       const { id } = request.params;
@@ -443,7 +443,7 @@ const subscriptionsRoutes: FastifyPluginAsync = async (fastify) => {
         },
       },
     },
-    preHandler: fastify.authenticateWithDevBypass,
+    preHandler: fastify.authenticate,
     handler: async (request, _reply) => {
       const user = (request as AuthenticatedRequest).user;
       const { id } = request.params;
@@ -518,7 +518,7 @@ const subscriptionsRoutes: FastifyPluginAsync = async (fastify) => {
         },
       },
     },
-    preHandler: fastify.authenticateWithDevBypass,
+    preHandler: fastify.authenticate,
     handler: async (request, _reply) => {
       const user = (request as AuthenticatedRequest).user;
       const { id } = request.params;
@@ -594,7 +594,7 @@ const subscriptionsRoutes: FastifyPluginAsync = async (fastify) => {
         },
       },
     },
-    preHandler: fastify.authenticateWithDevBypass,
+    preHandler: fastify.authenticate,
     handler: async (request, _reply) => {
       const user = (request as AuthenticatedRequest).user;
 
@@ -658,7 +658,7 @@ const subscriptionsRoutes: FastifyPluginAsync = async (fastify) => {
         },
       },
     },
-    preHandler: fastify.authenticateWithDevBypass,
+    preHandler: fastify.authenticate,
     handler: async (request, _reply) => {
       try {
         const user = (request as AuthenticatedRequest).user;

--- a/backend/src/routes/usage.ts
+++ b/backend/src/routes/usage.ts
@@ -125,7 +125,7 @@ const usageRoutes: FastifyPluginAsync = async (fastify) => {
         },
       },
     },
-    preHandler: [fastify.authenticateWithDevBypass, validateUsageMetricsQuery],
+    preHandler: [fastify.authenticate, validateUsageMetricsQuery],
     handler: async (request, _reply) => {
       const user = (request as AuthenticatedRequest).user;
       const { startDate, endDate, modelId, apiKeyId } = request.query;
@@ -454,7 +454,7 @@ const usageRoutes: FastifyPluginAsync = async (fastify) => {
         },
       },
     },
-    preHandler: [fastify.authenticateWithDevBypass, validateUsageSummaryQuery],
+    preHandler: [fastify.authenticate, validateUsageSummaryQuery],
     handler: async (request, _reply) => {
       const user = (request as AuthenticatedRequest).user;
       const { startDate, endDate, modelId, subscriptionId, granularity } = request.query;
@@ -547,7 +547,7 @@ const usageRoutes: FastifyPluginAsync = async (fastify) => {
         },
       },
     },
-    preHandler: fastify.authenticateWithDevBypass,
+    preHandler: fastify.authenticate,
     handler: async (request, _reply) => {
       const user = (request as AuthenticatedRequest).user;
       const { startDate, endDate, interval = 'day', modelId, subscriptionId } = request.query;
@@ -625,7 +625,7 @@ const usageRoutes: FastifyPluginAsync = async (fastify) => {
         },
       },
     },
-    preHandler: fastify.authenticateWithDevBypass,
+    preHandler: fastify.authenticate,
     handler: async (_request, _reply) => {
       // TODO: This endpoint should fetch from LiteLLM API
       // For now, returning empty data since local logging is not implemented
@@ -714,7 +714,7 @@ const usageRoutes: FastifyPluginAsync = async (fastify) => {
         },
       },
     },
-    preHandler: fastify.authenticateWithDevBypass,
+    preHandler: fastify.authenticate,
     handler: async (_request, _reply) => {
       // TODO: This endpoint should fetch from LiteLLM API
       // For now, returning empty data since local logging is not implemented
@@ -751,7 +751,7 @@ const usageRoutes: FastifyPluginAsync = async (fastify) => {
         },
       },
     },
-    preHandler: [fastify.authenticateWithDevBypass, validateUsageExportQuery],
+    preHandler: [fastify.authenticate, validateUsageExportQuery],
     handler: async (request, reply) => {
       const user = (request as AuthenticatedRequest).user;
       const {

--- a/backend/tests/helpers/test-app.ts
+++ b/backend/tests/helpers/test-app.ts
@@ -1,55 +1,14 @@
-import { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
+import { FastifyInstance } from 'fastify';
 import { createApp } from '../../src/app';
 
 export interface TestAppOptions {
-  strictAuth?: boolean;
   logger?: boolean;
 }
 
 export async function createTestApp(options: TestAppOptions = {}): Promise<FastifyInstance> {
-  const { strictAuth = false, logger = false } = options;
+  const { logger = false } = options;
 
-  // Set environment variables for test mode
-  const originalNodeEnv = process.env.NODE_ENV;
-  const originalFrontendOrigins = process.env.ALLOWED_FRONTEND_ORIGINS;
-
-  if (strictAuth) {
-    // Disable dev bypass for strict authentication testing
-    process.env.NODE_ENV = 'test-strict';
-    process.env.ALLOWED_FRONTEND_ORIGINS = '';
-  } else {
-    process.env.NODE_ENV = 'test';
-  }
-
-  try {
-    const app = await createApp({ logger });
-
-    if (strictAuth) {
-      // Override the authenticateWithDevBypass function to force strict auth
-      const originalAuthenticate = app.authenticate;
-      (app as any).authenticateWithDevBypass = async (
-        request: FastifyRequest,
-        reply: FastifyReply,
-      ) => {
-        // Force strict authentication - no dev bypass
-        return originalAuthenticate(request, reply);
-      };
-    }
-
-    await app.ready();
-    return app;
-  } finally {
-    // Restore original environment variables
-    if (originalNodeEnv !== undefined) {
-      process.env.NODE_ENV = originalNodeEnv;
-    } else {
-      delete process.env.NODE_ENV;
-    }
-
-    if (originalFrontendOrigins !== undefined) {
-      process.env.ALLOWED_FRONTEND_ORIGINS = originalFrontendOrigins;
-    } else {
-      delete process.env.ALLOWED_FRONTEND_ORIGINS;
-    }
-  }
+  const app = await createApp({ logger });
+  await app.ready();
+  return app;
 }

--- a/backend/tests/integration/admin-api-keys.test.ts
+++ b/backend/tests/integration/admin-api-keys.test.ts
@@ -17,7 +17,6 @@ describe('Admin API Keys Endpoint', () => {
   beforeAll(async () => {
     // Set test environment
     process.env.NODE_ENV = 'test';
-    process.env.ALLOWED_FRONTEND_ORIGINS = ''; // Disable frontend bypass
 
     app = await createApp({ logger: false });
     await app.ready();

--- a/backend/tests/integration/admin-usage-pagination.test.ts
+++ b/backend/tests/integration/admin-usage-pagination.test.ts
@@ -18,7 +18,6 @@ describe('Admin Usage Pagination', () => {
   beforeAll(async () => {
     // Set test environment
     process.env.NODE_ENV = 'test';
-    process.env.ALLOWED_FRONTEND_ORIGINS = ''; // Disable frontend bypass
 
     app = await createApp({ logger: false });
     await app.ready();

--- a/backend/tests/integration/admin-usage-rate-limit.test.ts
+++ b/backend/tests/integration/admin-usage-rate-limit.test.ts
@@ -17,7 +17,6 @@ describe('Admin Usage Analytics - Rate Limiting', () => {
   beforeAll(async () => {
     // Set test environment
     process.env.NODE_ENV = 'test';
-    process.env.ALLOWED_FRONTEND_ORIGINS = ''; // Disable frontend bypass
 
     app = await createApp({ logger: false });
     await app.ready();

--- a/backend/tests/integration/admin-usage.test.ts
+++ b/backend/tests/integration/admin-usage.test.ts
@@ -17,7 +17,6 @@ describe('Admin Usage Analytics Routes', () => {
   beforeAll(async () => {
     // Set test environment
     process.env.NODE_ENV = 'test';
-    process.env.ALLOWED_FRONTEND_ORIGINS = ''; // Disable frontend bypass
 
     app = await createApp({ logger: false });
     await app.ready();

--- a/backend/tests/integration/date-range-validation.test.ts
+++ b/backend/tests/integration/date-range-validation.test.ts
@@ -12,7 +12,6 @@ describe('Date Range Validation', () => {
   beforeAll(async () => {
     // Set test environment
     process.env.NODE_ENV = 'test';
-    process.env.ALLOWED_FRONTEND_ORIGINS = ''; // Disable frontend bypass
 
     app = await createApp({ logger: false });
     await app.ready();

--- a/backend/tests/integration/error-flows.test.ts
+++ b/backend/tests/integration/error-flows.test.ts
@@ -62,7 +62,6 @@ describe('Error Flows Integration', () => {
   beforeAll(async () => {
     // Set test environment to prevent dev bypass authentication
     process.env.NODE_ENV = 'test';
-    process.env.ALLOWED_FRONTEND_ORIGINS = ''; // Disable frontend bypass
 
     app = await createApp({ logger: false });
     await app.ready();
@@ -78,7 +77,6 @@ describe('Error Flows Integration', () => {
     vi.clearAllMocks();
     // Ensure test environment settings
     process.env.NODE_ENV = 'test';
-    process.env.ALLOWED_FRONTEND_ORIGINS = '';
   });
 
   describe('Authentication and Authorization Error Flows', () => {

--- a/backend/tests/integration/routes/admin-users.test.ts
+++ b/backend/tests/integration/routes/admin-users.test.ts
@@ -16,7 +16,6 @@ describe('Admin Users Routes Integration', () => {
 
   beforeAll(async () => {
     process.env.NODE_ENV = 'test';
-    process.env.ALLOWED_FRONTEND_ORIGINS = '';
 
     app = await createApp({ logger: false });
     await app.ready();

--- a/backend/tests/integration/routes/auth-user.test.ts
+++ b/backend/tests/integration/routes/auth-user.test.ts
@@ -16,7 +16,6 @@ describe('Auth User Routes Integration', () => {
   beforeAll(async () => {
     // Set test environment
     process.env.NODE_ENV = 'test';
-    process.env.ALLOWED_FRONTEND_ORIGINS = ''; // Disable frontend bypass
 
     app = await createApp({ logger: false });
     await app.ready();

--- a/backend/tests/integration/routes/auth.test.ts
+++ b/backend/tests/integration/routes/auth.test.ts
@@ -18,7 +18,6 @@ describe('Auth Routes Integration', () => {
     process.env.NODE_ENV = 'test';
     process.env.ALLOW_DEV_TOKENS = 'true';
     process.env.OAUTH_MOCK_ENABLED = 'true'; // Enable mock OAuth for testing
-    process.env.ALLOWED_FRONTEND_ORIGINS = ''; // Disable frontend bypass
 
     app = await createApp({ logger: false });
     await app.ready();

--- a/backend/tests/integration/routes/config.test.ts
+++ b/backend/tests/integration/routes/config.test.ts
@@ -14,7 +14,6 @@ describe('Config Routes Integration', () => {
     // Set test environment
     process.env.NODE_ENV = 'test';
     process.env.OAUTH_MOCK_ENABLED = 'true'; // Enable mock OAuth for testing
-    process.env.ALLOWED_FRONTEND_ORIGINS = ''; // Disable frontend bypass
 
     app = await createApp({ logger: false });
     await app.ready();

--- a/backend/tests/integration/routes/health.test.ts
+++ b/backend/tests/integration/routes/health.test.ts
@@ -16,7 +16,6 @@ describe('Health Routes Integration', () => {
   beforeAll(async () => {
     // Set test environment
     process.env.NODE_ENV = 'test';
-    process.env.ALLOWED_FRONTEND_ORIGINS = ''; // Disable frontend bypass
 
     app = await createApp({ logger: false });
     await app.ready();

--- a/backend/tests/integration/routes/models.test.ts
+++ b/backend/tests/integration/routes/models.test.ts
@@ -17,7 +17,6 @@ describe('Models Routes Integration', () => {
   beforeAll(async () => {
     // Set test environment
     process.env.NODE_ENV = 'test';
-    process.env.ALLOWED_FRONTEND_ORIGINS = ''; // Disable frontend bypass
 
     app = await createApp({ logger: false });
     await app.ready();

--- a/backend/tests/integration/routes/usage.test.ts
+++ b/backend/tests/integration/routes/usage.test.ts
@@ -15,7 +15,6 @@ describe('Usage Routes Integration', () => {
   beforeAll(async () => {
     // Set test environment
     process.env.NODE_ENV = 'test';
-    process.env.ALLOWED_FRONTEND_ORIGINS = ''; // Disable frontend bypass
 
     app = await createApp({ logger: false });
     await app.ready();

--- a/backend/tests/integration/routes/users.test.ts
+++ b/backend/tests/integration/routes/users.test.ts
@@ -17,7 +17,6 @@ describe('Users Routes Integration', () => {
   beforeAll(async () => {
     // Set test environment
     process.env.NODE_ENV = 'test';
-    process.env.ALLOWED_FRONTEND_ORIGINS = ''; // Disable frontend bypass
 
     app = await createApp({ logger: false });
     await app.ready();

--- a/backend/tests/security/security.test.ts
+++ b/backend/tests/security/security.test.ts
@@ -57,6 +57,35 @@ describe('Security Tests', () => {
       expect([200, 500]).toContain(modelsResponse.statusCode);
     });
 
+    it('should reject unauthenticated requests with browser-like User-Agent (CWE-287 regression)', async () => {
+      const browserUserAgents = [
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15',
+        'Mozilla/5.0 (X11; Linux x86_64; rv:121.0) Gecko/20100101 Firefox/121.0',
+      ];
+
+      const protectedEndpoints = [
+        { method: 'GET' as const, url: '/api/v1/api-keys' },
+        { method: 'GET' as const, url: '/api/v1/subscriptions' },
+        { method: 'GET' as const, url: '/api/v1/usage/dashboard' },
+      ];
+
+      for (const ua of browserUserAgents) {
+        for (const endpoint of protectedEndpoints) {
+          const response = await app.inject({
+            method: endpoint.method,
+            url: endpoint.url,
+            headers: {
+              'user-agent': ua,
+              accept: 'application/json',
+            },
+          });
+
+          expect(response.statusCode).toBe(401);
+        }
+      }
+    });
+
     it('should reject requests with invalid tokens', async () => {
       const response = await app.inject({
         method: 'GET',

--- a/backend/tests/security/security.test.ts
+++ b/backend/tests/security/security.test.ts
@@ -8,7 +8,7 @@ describe('Security Tests', () => {
 
   beforeAll(async () => {
     // Use strict authentication mode for security tests
-    app = await createTestApp({ strictAuth: true, logger: false });
+    app = await createTestApp({ logger: false });
   });
 
   afterAll(async () => {

--- a/backend/tests/setup.ts
+++ b/backend/tests/setup.ts
@@ -17,14 +17,6 @@ beforeAll(async () => {
   // Register test-specific plugins or overrides
   await global.testApp.register(async function (fastify) {
     // Override authentication for testing
-    fastify.decorate(
-      'authenticateWithDevBypass',
-      async (request: FastifyRequest, _reply: FastifyReply) => {
-        // Mock user for testing
-        request.user = mockUser;
-      },
-    );
-
     fastify.decorate('authenticate', async (request: FastifyRequest, _reply: FastifyReply) => {
       // Mock user for testing
       request.user = mockUser;


### PR DESCRIPTION
## Summary

- Remove the `authenticateWithDevBypass` decorator which granted full admin access to any request with a browser-like User-Agent — active in all environments including production (CWE-287, CRITICAL)
- Replace all 23 usages across 4 route files with `fastify.authenticate` (strict JWT/API-key validation)
- Remove `ALLOWED_FRONTEND_ORIGINS` env var and clean up test helpers

Fixes #137

## Changes

| File | Change |
|---|---|
| `backend/src/plugins/auth.ts` | Remove decorator definition (120 lines) and type declaration |
| `backend/src/routes/api-keys.ts` | 9 routes: `authenticateWithDevBypass` → `authenticate` |
| `backend/src/routes/subscriptions.ts` | 8 routes: `authenticateWithDevBypass` → `authenticate` |
| `backend/src/routes/usage.ts` | 6 routes: `authenticateWithDevBypass` → `authenticate` |
| `backend/src/plugins/swagger.ts` | 1 route: `authenticateWithDevBypass` → `authenticate` |
| `backend/tests/helpers/test-app.ts` | Remove `strictAuth` option (no longer needed) |
| `backend/tests/setup.ts` | Remove `authenticateWithDevBypass` mock |
| `backend/tests/security/security.test.ts` | Remove `strictAuth: true` |
| `backend/.env.example` | Remove `ALLOWED_FRONTEND_ORIGINS` |
| 14 integration test files | Remove `ALLOWED_FRONTEND_ORIGINS = ''` overrides |

## Why this is safe

All 23 affected routes are **user-scoped** — they pass `request.user.userId` to service methods, so authenticated users can only access their own data. No RBAC permission middleware needs to be added. The `fastify.authenticate` decorator enforces strict JWT token or API key validation with no bypass path.

## Test plan

- [x] `npm run build` — clean TypeScript compilation
- [x] `npm run lint` — no lint errors
- [x] `npm run test:unit` — 991 passed (9 pre-existing failures unchanged)
- [x] `grep -rn "authenticateWithDevBypass" backend/` — zero hits
- [x] `grep -rn "ALLOWED_FRONTEND_ORIGINS" backend/` — zero hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)