### PR TITLE
Add NetworkPolicy resources for network segmentation

### DIFF
--- a/deployment/helm/litemaas/templates/networkpolicy.yaml
+++ b/deployment/helm/litemaas/templates/networkpolicy.yaml
@@ -14,12 +14,11 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name }}
   policyTypes:
     - Ingress
-
+{{- if .Values.postgresql.enabled }}
 ---
 # =============================================================================
 # PostgreSQL: allow ingress from backend and litellm only
 # =============================================================================
-{{- if .Values.postgresql.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -50,12 +49,11 @@ spec:
           port: 5432
     {{- end }}
 {{- end }}
-
+{{- if .Values.redis.enabled }}
 ---
 # =============================================================================
 # Redis: allow ingress from backend and litellm only
 # =============================================================================
-{{- if .Values.redis.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -86,12 +84,11 @@ spec:
           port: 6379
     {{- end }}
 {{- end }}
-
+{{- if .Values.litellm.enabled }}
 ---
 # =============================================================================
 # LiteLLM: allow ingress from backend (and ingress controller when exposed)
 # =============================================================================
-{{- if .Values.litellm.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -113,15 +110,20 @@ spec:
         - protocol: TCP
           port: 4000
     {{- if or (and .Values.ingress.enabled .Values.ingress.litellm.enabled) (and .Values.route.enabled .Values.route.litellm.enabled) }}
-    # Allow ingress controller traffic when LiteLLM is externally exposed
     - from:
-        - namespaceSelector: {}
+        - namespaceSelector:
+            matchLabels:
+              {{- toYaml .Values.networkPolicy.ingressController.namespaceSelector | nindent 14 }}
+          {{- with .Values.networkPolicy.ingressController.podSelector }}
+          podSelector:
+            matchLabels:
+              {{- toYaml . | nindent 14 }}
+          {{- end }}
       ports:
         - protocol: TCP
           port: 4000
     {{- end }}
 {{- end }}
-
 ---
 # =============================================================================
 # Backend: allow ingress from frontend and ingress controller
@@ -146,13 +148,20 @@ spec:
       ports:
         - protocol: TCP
           port: 8080
-    # Allow ingress controller traffic (frontend proxies API requests to backend)
+    {{- if or .Values.ingress.enabled .Values.route.enabled }}
     - from:
-        - namespaceSelector: {}
+        - namespaceSelector:
+            matchLabels:
+              {{- toYaml .Values.networkPolicy.ingressController.namespaceSelector | nindent 14 }}
+          {{- with .Values.networkPolicy.ingressController.podSelector }}
+          podSelector:
+            matchLabels:
+              {{- toYaml . | nindent 14 }}
+          {{- end }}
       ports:
         - protocol: TCP
           port: 8080
-
+    {{- end }}
 ---
 # =============================================================================
 # Frontend: allow ingress from ingress controller
@@ -169,11 +178,19 @@ spec:
       {{- include "litemaas.componentSelectorLabels" (dict "context" . "component" "web") | nindent 6 }}
   policyTypes:
     - Ingress
+  {{- if or .Values.ingress.enabled .Values.route.enabled }}
   ingress:
-    # Allow ingress controller / OpenShift router traffic
     - from:
-        - namespaceSelector: {}
+        - namespaceSelector:
+            matchLabels:
+              {{- toYaml .Values.networkPolicy.ingressController.namespaceSelector | nindent 14 }}
+          {{- with .Values.networkPolicy.ingressController.podSelector }}
+          podSelector:
+            matchLabels:
+              {{- toYaml . | nindent 14 }}
+          {{- end }}
       ports:
         - protocol: TCP
           port: 8080
+  {{- end }}
 {{- end }}

--- a/deployment/helm/litemaas/templates/networkpolicy.yaml
+++ b/deployment/helm/litemaas/templates/networkpolicy.yaml
@@ -1,4 +1,9 @@
 {{- if .Values.networkPolicy.enabled }}
+{{- if or .Values.ingress.enabled .Values.route.enabled }}
+{{- if not .Values.networkPolicy.ingressController.namespaceSelector }}
+{{- fail "networkPolicy.ingressController.namespaceSelector is required when networkPolicy and ingress/route are both enabled. Set it to your ingress controller's namespace labels (e.g. kubernetes.io/metadata.name: ingress-nginx)." }}
+{{- end }}
+{{- end }}
 # =============================================================================
 # Default deny-all ingress for LiteMaaS pods
 # =============================================================================

--- a/deployment/helm/litemaas/templates/networkpolicy.yaml
+++ b/deployment/helm/litemaas/templates/networkpolicy.yaml
@@ -1,0 +1,179 @@
+{{- if .Values.networkPolicy.enabled }}
+# =============================================================================
+# Default deny-all ingress for LiteMaaS pods
+# =============================================================================
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "litemaas.fullname" . }}-deny-all
+  labels:
+    {{- include "litemaas.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  policyTypes:
+    - Ingress
+
+---
+# =============================================================================
+# PostgreSQL: allow ingress from backend and litellm only
+# =============================================================================
+{{- if .Values.postgresql.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "litemaas.fullname" . }}-postgresql
+  labels:
+    {{- include "litemaas.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "litemaas.componentSelectorLabels" (dict "context" . "component" "database") | nindent 6 }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              {{- include "litemaas.componentSelectorLabels" (dict "context" . "component" "api") | nindent 14 }}
+      ports:
+        - protocol: TCP
+          port: 5432
+    {{- if .Values.litellm.enabled }}
+    - from:
+        - podSelector:
+            matchLabels:
+              {{- include "litemaas.componentSelectorLabels" (dict "context" . "component" "ai-proxy") | nindent 14 }}
+      ports:
+        - protocol: TCP
+          port: 5432
+    {{- end }}
+{{- end }}
+
+---
+# =============================================================================
+# Redis: allow ingress from backend and litellm only
+# =============================================================================
+{{- if .Values.redis.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "litemaas.fullname" . }}-redis
+  labels:
+    {{- include "litemaas.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "litemaas.componentSelectorLabels" (dict "context" . "component" "cache") | nindent 6 }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              {{- include "litemaas.componentSelectorLabels" (dict "context" . "component" "api") | nindent 14 }}
+      ports:
+        - protocol: TCP
+          port: 6379
+    {{- if .Values.litellm.enabled }}
+    - from:
+        - podSelector:
+            matchLabels:
+              {{- include "litemaas.componentSelectorLabels" (dict "context" . "component" "ai-proxy") | nindent 14 }}
+      ports:
+        - protocol: TCP
+          port: 6379
+    {{- end }}
+{{- end }}
+
+---
+# =============================================================================
+# LiteLLM: allow ingress from backend (and ingress controller when exposed)
+# =============================================================================
+{{- if .Values.litellm.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "litemaas.fullname" . }}-litellm
+  labels:
+    {{- include "litemaas.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "litemaas.componentSelectorLabels" (dict "context" . "component" "ai-proxy") | nindent 6 }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              {{- include "litemaas.componentSelectorLabels" (dict "context" . "component" "api") | nindent 14 }}
+      ports:
+        - protocol: TCP
+          port: 4000
+    {{- if or (and .Values.ingress.enabled .Values.ingress.litellm.enabled) (and .Values.route.enabled .Values.route.litellm.enabled) }}
+    # Allow ingress controller traffic when LiteLLM is externally exposed
+    - from:
+        - namespaceSelector: {}
+      ports:
+        - protocol: TCP
+          port: 4000
+    {{- end }}
+{{- end }}
+
+---
+# =============================================================================
+# Backend: allow ingress from frontend and ingress controller
+# =============================================================================
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "litemaas.fullname" . }}-backend
+  labels:
+    {{- include "litemaas.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "litemaas.componentSelectorLabels" (dict "context" . "component" "api") | nindent 6 }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              {{- include "litemaas.componentSelectorLabels" (dict "context" . "component" "web") | nindent 14 }}
+      ports:
+        - protocol: TCP
+          port: 8080
+    # Allow ingress controller traffic (frontend proxies API requests to backend)
+    - from:
+        - namespaceSelector: {}
+      ports:
+        - protocol: TCP
+          port: 8080
+
+---
+# =============================================================================
+# Frontend: allow ingress from ingress controller
+# =============================================================================
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "litemaas.fullname" . }}-frontend
+  labels:
+    {{- include "litemaas.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "litemaas.componentSelectorLabels" (dict "context" . "component" "web") | nindent 6 }}
+  policyTypes:
+    - Ingress
+  ingress:
+    # Allow ingress controller / OpenShift router traffic
+    - from:
+        - namespaceSelector: {}
+      ports:
+        - protocol: TCP
+          port: 8080
+{{- end }}

--- a/deployment/helm/litemaas/values.yaml
+++ b/deployment/helm/litemaas/values.yaml
@@ -29,8 +29,8 @@ networkPolicy:
   # so only expected traffic flows are permitted (e.g., only backend can reach PostgreSQL).
   enabled: false
   # -- Selectors to identify ingress controller / OpenShift router pods.
-  # By default namespaceSelector is empty ({}) which matches all namespaces.
-  # Restrict to your controller's namespace and pods for tighter segmentation, e.g.:
+  # Required when networkPolicy and ingress/route are both enabled.
+  # Example:
   #   namespaceSelector:
   #     kubernetes.io/metadata.name: ingress-nginx
   #   podSelector:

--- a/deployment/helm/litemaas/values.yaml
+++ b/deployment/helm/litemaas/values.yaml
@@ -36,8 +36,10 @@ networkPolicy:
   #   podSelector:
   #     app.kubernetes.io/name: ingress-nginx
   ingressController:
-    # -- Namespace labels that identify the ingress controller namespace
-    namespaceSelector: {}
+    # -- Namespace labels that identify the ingress controller namespace.
+    # Required when networkPolicy and ingress/route are both enabled.
+    # Example: { kubernetes.io/metadata.name: ingress-nginx }
+    namespaceSelector: null
     # -- Pod labels that identify the ingress controller pods (omit to allow all pods in matched namespaces)
     # podSelector: {}
 

--- a/deployment/helm/litemaas/values.yaml
+++ b/deployment/helm/litemaas/values.yaml
@@ -28,6 +28,18 @@ networkPolicy:
   # When enabled, deploys deny-all-ingress default and per-component allow rules
   # so only expected traffic flows are permitted (e.g., only backend can reach PostgreSQL).
   enabled: false
+  # -- Selectors to identify ingress controller / OpenShift router pods.
+  # By default namespaceSelector is empty ({}) which matches all namespaces.
+  # Restrict to your controller's namespace and pods for tighter segmentation, e.g.:
+  #   namespaceSelector:
+  #     kubernetes.io/metadata.name: ingress-nginx
+  #   podSelector:
+  #     app.kubernetes.io/name: ingress-nginx
+  ingressController:
+    # -- Namespace labels that identify the ingress controller namespace
+    namespaceSelector: {}
+    # -- Pod labels that identify the ingress controller pods (omit to allow all pods in matched namespaces)
+    # podSelector: {}
 
 # -- ServiceAccount configuration
 serviceAccount:

--- a/deployment/helm/litemaas/values.yaml
+++ b/deployment/helm/litemaas/values.yaml
@@ -22,6 +22,13 @@ nameOverride: ""
 # -- Override fully qualified app name
 fullnameOverride: ""
 
+# -- Network policy configuration
+networkPolicy:
+  # -- Enable NetworkPolicies for network segmentation.
+  # When enabled, deploys deny-all-ingress default and per-component allow rules
+  # so only expected traffic flows are permitted (e.g., only backend can reach PostgreSQL).
+  enabled: false
+
 # -- ServiceAccount configuration
 serviceAccount:
   # -- Create a ServiceAccount


### PR DESCRIPTION
## Summary

- Adds `networkpolicy.yaml` Helm template with deny-all-ingress default and per-component allow rules
- Gated by `networkPolicy.enabled` (default `false`) for backward compatibility
- Adds `networkPolicy` section to `values.yaml`

Closes #141

## Policies Created

| Policy | Target | Allowed Sources | Port |
|--------|--------|-----------------|------|
| deny-all | All LiteMaaS pods | (none) | — |
| postgresql | database | backend, litellm | 5432 |
| redis | cache | backend, litellm | 6379 |
| litellm | ai-proxy | backend, ingress controller (when exposed) | 4000 |
| backend | api | frontend, ingress controller | 8080 |
| frontend | web | ingress controller | 8080 |

## Files Changed

| File | Change |
|------|--------|
| `deployment/helm/litemaas/templates/networkpolicy.yaml` | New — 6 NetworkPolicy resources |
| `deployment/helm/litemaas/values.yaml` | Add `networkPolicy.enabled: false` |

## Test plan

- [x] `helm template` with `networkPolicy.enabled=true` renders all 6 policies
- [x] `helm template` with defaults renders zero NetworkPolicy resources (backward compatible)
- [x] Pod selectors match existing `app.kubernetes.io/component` labels from `_helpers.tpl`
- [x] Conditional policies correctly gate on `redis.enabled`, `litellm.enabled`, `postgresql.enabled`

🤖 Generated with [Claude Code](https://claude.com/claude-code)