### PR TITLE
Fix session invalidation IDOR — enforce ownership check

### DIFF
--- a/backend/src/plugins/session.ts
+++ b/backend/src/plugins/session.ts
@@ -129,6 +129,18 @@ const sessionPlugin: FastifyPluginAsync = async (fastify) => {
                 message: { type: 'string' },
               },
             },
+            404: {
+              type: 'object',
+              properties: {
+                error: {
+                  type: 'object',
+                  properties: {
+                    code: { type: 'string' },
+                    message: { type: 'string' },
+                  },
+                },
+              },
+            },
           },
         },
         preHandler: fastify.authenticate,

--- a/backend/src/plugins/session.ts
+++ b/backend/src/plugins/session.ts
@@ -133,8 +133,12 @@ const sessionPlugin: FastifyPluginAsync = async (fastify) => {
         },
         preHandler: fastify.authenticate,
         handler: async (request, _reply) => {
+          const user = (request as AuthenticatedRequest).user;
           const { sessionId } = request.params as { sessionId: string };
-          await sessionService.invalidateSession(sessionId);
+          const result = await sessionService.invalidateSession(sessionId, user.userId);
+          if (!result) {
+            throw fastify.createNotFoundError('Session');
+          }
           return { success: true };
         },
       });

--- a/backend/src/services/session.service.ts
+++ b/backend/src/services/session.service.ts
@@ -181,10 +181,16 @@ export class SessionService {
     return session;
   }
 
-  async invalidateSession(sessionId: string): Promise<boolean> {
+  async invalidateSession(sessionId: string, userId?: string): Promise<boolean> {
     const session = this.sessionStore.get(sessionId);
 
     if (!session) {
+      return false;
+    }
+
+    // Ownership check: when userId is provided (user-facing endpoint),
+    // verify the session belongs to the requesting user
+    if (userId && session.userId !== userId) {
       return false;
     }
 
@@ -199,11 +205,18 @@ export class SessionService {
       await this.fastify.tokenService.revokeRefreshToken(session.refreshToken);
     }
 
-    // Update database
-    await this.fastify.dbUtils.query(
-      'UPDATE user_sessions SET is_active = false, ended_at = NOW() WHERE id = $1',
-      [sessionId],
-    );
+    // Update database — include user_id filter when ownership is being enforced
+    if (userId) {
+      await this.fastify.dbUtils.query(
+        'UPDATE user_sessions SET is_active = false, ended_at = NOW() WHERE id = $1 AND user_id = $2',
+        [sessionId, userId],
+      );
+    } else {
+      await this.fastify.dbUtils.query(
+        'UPDATE user_sessions SET is_active = false, ended_at = NOW() WHERE id = $1',
+        [sessionId],
+      );
+    }
 
     this.fastify.log.info(
       {

--- a/backend/tests/security/security.test.ts
+++ b/backend/tests/security/security.test.ts
@@ -123,6 +123,30 @@ describe('Security Tests', () => {
       }
     });
 
+    it('should prevent cross-user session invalidation (IDOR)', async () => {
+      const user1Token = generateTestToken('user-1', ['user']);
+      const user2Token = generateTestToken('user-2', ['user']);
+
+      // User2 attempts to invalidate a session belonging to user1
+      // Even with a valid session ID, it should be rejected because user2 doesn't own it
+      const response = await app.inject({
+        method: 'DELETE',
+        url: '/api/auth/sessions/fake-session-id-belonging-to-user1',
+        headers: { authorization: `Bearer ${user2Token}` },
+      });
+
+      // Should return 404 (session not found or not owned by requesting user)
+      expect(response.statusCode).toBe(404);
+
+      // Verify own session invalidation attempt with non-existent ID also returns 404
+      const ownResponse = await app.inject({
+        method: 'DELETE',
+        url: '/api/auth/sessions/nonexistent-session-id',
+        headers: { authorization: `Bearer ${user1Token}` },
+      });
+      expect(ownResponse.statusCode).toBe(404);
+    });
+
     it('should validate API key authentication alongside JWT', async () => {
       // Test that API key authentication works properly
       const response = await app.inject({

--- a/backend/tests/security/security.test.ts
+++ b/backend/tests/security/security.test.ts
@@ -124,27 +124,39 @@ describe('Security Tests', () => {
     });
 
     it('should prevent cross-user session invalidation (IDOR)', async () => {
-      const user1Token = generateTestToken('user-1', ['user']);
-      const user2Token = generateTestToken('user-2', ['user']);
+      const user1Id = 'idor-user-1';
+      const user2Token = generateTestToken('idor-user-2', ['user']);
+      const sessionId = 'idor-test-session';
 
-      // User2 attempts to invalidate a session belonging to user1
-      // Even with a valid session ID, it should be rejected because user2 doesn't own it
+      // Inject a session owned by user1 directly into the in-memory store
+      const sessionStore = (app.sessionService as any).sessionStore as Map<string, any>;
+      sessionStore.set(sessionId, {
+        id: sessionId,
+        userId: user1Id,
+        token: 'dummy',
+        ipAddress: '127.0.0.1',
+        userAgent: 'vitest',
+        createdAt: new Date(),
+        lastActivityAt: new Date(),
+        expiresAt: new Date(Date.now() + 3600_000),
+        isActive: true,
+      });
+
+      // User2 attempts to invalidate user1's session — should be rejected
       const response = await app.inject({
         method: 'DELETE',
-        url: '/api/auth/sessions/fake-session-id-belonging-to-user1',
+        url: `/api/auth/sessions/${sessionId}`,
         headers: { authorization: `Bearer ${user2Token}` },
       });
-
-      // Should return 404 (session not found or not owned by requesting user)
       expect(response.statusCode).toBe(404);
 
-      // Verify own session invalidation attempt with non-existent ID also returns 404
-      const ownResponse = await app.inject({
-        method: 'DELETE',
-        url: '/api/auth/sessions/nonexistent-session-id',
-        headers: { authorization: `Bearer ${user1Token}` },
-      });
-      expect(ownResponse.statusCode).toBe(404);
+      // Verify user1's session is still active after the failed attempt
+      const session = sessionStore.get(sessionId);
+      expect(session).toBeDefined();
+      expect(session.isActive).toBe(true);
+
+      // Clean up
+      sessionStore.delete(sessionId);
     });
 
     it('should validate API key authentication alongside JWT', async () => {


### PR DESCRIPTION
## Summary

- Adds userId ownership validation to `DELETE /api/auth/sessions/:sessionId`
- Service method checks in-memory session ownership + SQL `WHERE user_id` filter
- Returns 404 for non-existent or unowned sessions (matches project pattern)
- Internal callers (cleanup, validation) unaffected — userId parameter is optional

Closes #145

## Files Changed

| File | Change |
|------|--------|
| `backend/src/plugins/session.ts` | Extract `request.user.userId`, pass to service, return 404 on failure |
| `backend/src/services/session.service.ts` | Add optional `userId` param to `invalidateSession()`, ownership check + SQL filter |
| `backend/tests/security/security.test.ts` | Add cross-user session invalidation IDOR test |

## Test plan

- [ ] `npm run build` — TypeScript compiles cleanly
- [ ] Unit tests pass (no new failures)
- [ ] Security test verifies cross-user session invalidation returns 404
- [ ] Internal callers (`validateSession`, `cleanupExpiredSessions`, `invalidateAllUserSessions`) continue to work without userId

🤖 Generated with [Claude Code](https://claude.com/claude-code)