### PR TITLE
Add Redis authentication support (requirepass)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -76,6 +76,11 @@ OAUTH_CALLBACK_URL=http://localhost:3000/api/auth/callback
 JWT_SECRET=your-super-secret-jwt-key
 JWT_EXPIRES_IN=24h
 
+# Redis (optional — used to flush LiteLLM's cache after model CRUD)
+# REDIS_HOST=localhost
+# REDIS_PORT=6379
+# REDIS_PASSWORD=                         # Redis authentication password (optional)
+
 # LiteLLM Configuration
 LITELLM_API_URL=http://your-litellm-instance:8000
 LITELLM_API_KEY=your-litellm-api-key

--- a/backend/src/plugins/env.ts
+++ b/backend/src/plugins/env.ts
@@ -36,6 +36,7 @@ const envSchema = Type.Object({
   // Redis (optional — used to flush LiteLLM's cache after model CRUD)
   REDIS_HOST: Type.Optional(Type.String()),
   REDIS_PORT: Type.String({ default: '6379' }),
+  REDIS_PASSWORD: Type.Optional(Type.String()),
 
   // LiteLLM
   LITELLM_API_URL: Type.String({ default: 'http://localhost:4000' }),

--- a/backend/src/plugins/redis.ts
+++ b/backend/src/plugins/redis.ts
@@ -5,6 +5,7 @@ import Redis from 'ioredis';
 const redisPlugin: FastifyPluginAsync = async (fastify) => {
   const redisHost = fastify.config.REDIS_HOST;
   const redisPort = parseInt(fastify.config.REDIS_PORT || '6379');
+  const redisPassword = fastify.config.REDIS_PASSWORD || undefined;
 
   if (!redisHost) {
     fastify.log.info('REDIS_HOST not set — Redis cache flush disabled');
@@ -21,6 +22,7 @@ const redisPlugin: FastifyPluginAsync = async (fastify) => {
     client = new Redis({
       host: redisHost,
       port: redisPort,
+      password: redisPassword,
       maxRetriesPerRequest: 3,
       retryStrategy(times) {
         if (times > 3) return null; // stop retrying

--- a/backend/src/types/fastify.ts
+++ b/backend/src/types/fastify.ts
@@ -35,6 +35,7 @@ declare module 'fastify' {
       // Redis (optional)
       REDIS_HOST?: string;
       REDIS_PORT: string;
+      REDIS_PASSWORD?: string;
 
       // LiteLLM
       LITELLM_API_URL: string;

--- a/deployment/helm/litemaas/templates/_helpers.tpl
+++ b/deployment/helm/litemaas/templates/_helpers.tpl
@@ -106,6 +106,14 @@ app.kubernetes.io/component: {{ .component }}
 
 {{/* ========== Secret name helpers ========== */}}
 
+{{- define "litemaas.redis.secretName" -}}
+{{- if .Values.redis.auth.existingSecret }}
+{{- .Values.redis.auth.existingSecret }}
+{{- else }}
+{{- include "litemaas.redis.fullname" . }}
+{{- end }}
+{{- end }}
+
 {{- define "litemaas.postgresql.secretName" -}}
 {{- if .Values.postgresql.auth.existingSecret }}
 {{- .Values.postgresql.auth.existingSecret }}

--- a/deployment/helm/litemaas/templates/_helpers.tpl
+++ b/deployment/helm/litemaas/templates/_helpers.tpl
@@ -106,6 +106,10 @@ app.kubernetes.io/component: {{ .component }}
 
 {{/* ========== Secret name helpers ========== */}}
 
+{{- define "litemaas.redis.authEnabled" -}}
+{{- if or .Values.redis.auth.password .Values.redis.auth.existingSecret -}}true{{- end -}}
+{{- end -}}
+
 {{- define "litemaas.redis.secretName" -}}
 {{- if .Values.redis.auth.existingSecret }}
 {{- .Values.redis.auth.existingSecret }}

--- a/deployment/helm/litemaas/templates/backend-deployment.yaml
+++ b/deployment/helm/litemaas/templates/backend-deployment.yaml
@@ -99,7 +99,7 @@ spec:
                 secretKeyRef:
                   name: {{ include "litemaas.backend.secretName" . }}
                   key: litellm-database-url
-            {{- if and (include "litemaas.redis.host" .) .Values.redis.auth.password }}
+            {{- if and (include "litemaas.redis.host" .) (include "litemaas.redis.authEnabled" .) }}
             # Redis authentication
             - name: REDIS_PASSWORD
               valueFrom:

--- a/deployment/helm/litemaas/templates/backend-deployment.yaml
+++ b/deployment/helm/litemaas/templates/backend-deployment.yaml
@@ -99,6 +99,14 @@ spec:
                 secretKeyRef:
                   name: {{ include "litemaas.backend.secretName" . }}
                   key: litellm-database-url
+            {{- if and (include "litemaas.redis.host" .) .Values.redis.auth.password }}
+            # Redis authentication
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "litemaas.redis.secretName" . }}
+                  key: password
+            {{- end }}
           volumeMounts:
             - name: backup-storage
               mountPath: {{ .Values.backend.backup.storagePath }}

--- a/deployment/helm/litemaas/templates/litellm-deployment.yaml
+++ b/deployment/helm/litemaas/templates/litellm-deployment.yaml
@@ -69,7 +69,7 @@ spec:
               value: {{ $redisHost | quote }}
             - name: REDIS_PORT
               value: {{ .Values.backend.redis.port | quote }}
-            {{- if .Values.redis.auth.password }}
+            {{- if (include "litemaas.redis.authEnabled" .) }}
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/deployment/helm/litemaas/templates/litellm-deployment.yaml
+++ b/deployment/helm/litemaas/templates/litellm-deployment.yaml
@@ -69,6 +69,13 @@ spec:
               value: {{ $redisHost | quote }}
             - name: REDIS_PORT
               value: {{ .Values.backend.redis.port | quote }}
+            {{- if .Values.redis.auth.password }}
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "litemaas.redis.secretName" . }}
+                  key: password
+            {{- end }}
             {{- end }}
             {{- if not .Values.litellm.sslVerify }}
             # Disable SSL verification for internal services (e.g., KServe with self-signed certs)

--- a/deployment/helm/litemaas/templates/redis-deployment.yaml
+++ b/deployment/helm/litemaas/templates/redis-deployment.yaml
@@ -24,7 +24,7 @@ spec:
         - name: redis
           image: "{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}"
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
-          {{- if .Values.redis.auth.password }}
+          {{- if (include "litemaas.redis.authEnabled" .) }}
           command: ["redis-server", "--requirepass", "$(REDIS_PASSWORD)"]
           env:
             - name: REDIS_PASSWORD
@@ -41,7 +41,7 @@ spec:
           livenessProbe:
             exec:
               command:
-                {{- if .Values.redis.auth.password }}
+                {{- if (include "litemaas.redis.authEnabled" .) }}
                 - sh
                 - -c
                 - redis-cli -a "$REDIS_PASSWORD" --no-auth-warning ping
@@ -56,7 +56,7 @@ spec:
           readinessProbe:
             exec:
               command:
-                {{- if .Values.redis.auth.password }}
+                {{- if (include "litemaas.redis.authEnabled" .) }}
                 - sh
                 - -c
                 - redis-cli -a "$REDIS_PASSWORD" --no-auth-warning ping

--- a/deployment/helm/litemaas/templates/redis-deployment.yaml
+++ b/deployment/helm/litemaas/templates/redis-deployment.yaml
@@ -24,6 +24,15 @@ spec:
         - name: redis
           image: "{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}"
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          {{- if .Values.redis.auth.password }}
+          command: ["redis-server", "--requirepass", "$(REDIS_PASSWORD)"]
+          env:
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "litemaas.redis.secretName" . }}
+                  key: password
+          {{- end }}
           ports:
             - containerPort: 6379
               name: redis
@@ -32,8 +41,14 @@ spec:
           livenessProbe:
             exec:
               command:
+                {{- if .Values.redis.auth.password }}
+                - sh
+                - -c
+                - redis-cli -a "$REDIS_PASSWORD" --no-auth-warning ping
+                {{- else }}
                 - redis-cli
                 - ping
+                {{- end }}
             initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 3
@@ -41,8 +56,14 @@ spec:
           readinessProbe:
             exec:
               command:
+                {{- if .Values.redis.auth.password }}
+                - sh
+                - -c
+                - redis-cli -a "$REDIS_PASSWORD" --no-auth-warning ping
+                {{- else }}
                 - redis-cli
                 - ping
+                {{- end }}
             initialDelaySeconds: 5
             periodSeconds: 5
             timeoutSeconds: 3

--- a/deployment/helm/litemaas/templates/redis-secret.yaml
+++ b/deployment/helm/litemaas/templates/redis-secret.yaml
@@ -1,0 +1,11 @@
+{{- if and .Values.redis.enabled (not .Values.redis.auth.existingSecret) .Values.redis.auth.password }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "litemaas.redis.fullname" . }}
+  labels:
+    {{- include "litemaas.componentLabels" (dict "context" . "component" "cache") | nindent 4 }}
+type: Opaque
+stringData:
+  password: {{ .Values.redis.auth.password | quote }}
+{{- end }}

--- a/deployment/helm/litemaas/templates/redis-secret.yaml
+++ b/deployment/helm/litemaas/templates/redis-secret.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.redis.enabled (not .Values.redis.auth.existingSecret) .Values.redis.auth.password }}
+{{- if and (include "litemaas.redis.host" .) (not .Values.redis.auth.existingSecret) .Values.redis.auth.password }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/deployment/helm/litemaas/values.yaml
+++ b/deployment/helm/litemaas/values.yaml
@@ -121,6 +121,13 @@ redis:
     repository: redis
     tag: "7-alpine"
 
+  auth:
+    # -- Redis password (CHANGE THIS). Set to "" to disable authentication.
+    password: changeme
+    # -- Use an existing Secret instead of creating one.
+    # Must contain key: password
+    existingSecret: ""
+
   resources:
     requests:
       memory: "64Mi"

--- a/deployment/kustomize/backend-deployment.yaml.template
+++ b/deployment/kustomize/backend-deployment.yaml.template
@@ -140,6 +140,12 @@ spec:
               value: 'litellm-redis'
             - name: REDIS_PORT
               value: '6379'
+            # Uncomment to enable Redis authentication (requires redis-auth Secret):
+            # - name: REDIS_PASSWORD
+            #   valueFrom:
+            #     secretKeyRef:
+            #       name: redis-auth
+            #       key: password
 
             # Backend API Rate Limiting (NOT for LLM requests)
             - name: RATE_LIMIT_MAX

--- a/deployment/kustomize/litellm-deployment.yaml
+++ b/deployment/kustomize/litellm-deployment.yaml
@@ -75,6 +75,12 @@ spec:
               value: 'litellm-redis'
             - name: REDIS_PORT
               value: '6379'
+            # Uncomment to enable Redis authentication (requires redis-auth Secret):
+            # - name: REDIS_PASSWORD
+            #   valueFrom:
+            #     secretKeyRef:
+            #       name: redis-auth
+            #       key: password
             # Uncomment to disable SSL verification for internal services with self-signed certs
             # ⚠️ Security Warning: Only use in development/testing or with trusted internal services
             # - name: SSL_VERIFY

--- a/deployment/kustomize/redis-deployment.yaml
+++ b/deployment/kustomize/redis-deployment.yaml
@@ -17,8 +17,12 @@ spec:
       containers:
         - name: redis
           image: redis:7-alpine
-          # To enable authentication, uncomment the command and env below,
-          # and create a Secret named 'redis-auth' with key 'password'.
+          # To enable authentication:
+          # 1. Create a Secret: oc create secret generic redis-auth --from-literal=password=<your-password>
+          # 2. Uncomment the command and env below.
+          # 3. Uncomment the authenticated probe variants below (and remove the unauthenticated ones).
+          # 4. Add REDIS_PASSWORD to backend-deployment.yaml.template and litellm-deployment.yaml
+          #    (see commented blocks in those files).
           # command: ["redis-server", "--requirepass", "$(REDIS_PASSWORD)"]
           # env:
           #   - name: REDIS_PASSWORD
@@ -39,6 +43,11 @@ spec:
           livenessProbe:
             exec:
               command:
+                # Authenticated variant (uncomment when auth is enabled):
+                # - sh
+                # - -c
+                # - redis-cli -a "$REDIS_PASSWORD" --no-auth-warning ping
+                # Unauthenticated (remove when auth is enabled):
                 - redis-cli
                 - ping
             initialDelaySeconds: 10
@@ -48,6 +57,11 @@ spec:
           readinessProbe:
             exec:
               command:
+                # Authenticated variant (uncomment when auth is enabled):
+                # - sh
+                # - -c
+                # - redis-cli -a "$REDIS_PASSWORD" --no-auth-warning ping
+                # Unauthenticated (remove when auth is enabled):
                 - redis-cli
                 - ping
             initialDelaySeconds: 5

--- a/deployment/kustomize/redis-deployment.yaml
+++ b/deployment/kustomize/redis-deployment.yaml
@@ -17,6 +17,15 @@ spec:
       containers:
         - name: redis
           image: redis:7-alpine
+          # To enable authentication, uncomment the command and env below,
+          # and create a Secret named 'redis-auth' with key 'password'.
+          # command: ["redis-server", "--requirepass", "$(REDIS_PASSWORD)"]
+          # env:
+          #   - name: REDIS_PASSWORD
+          #     valueFrom:
+          #       secretKeyRef:
+          #         name: redis-auth
+          #         key: password
           ports:
             - containerPort: 6379
               name: redis


### PR DESCRIPTION
## Summary

- Adds `redis.auth.password` to Helm values (default `changeme`, with `existingSecret` support)
- Redis runs with `--requirepass` when password is configured
- `REDIS_PASSWORD` injected into backend and LiteLLM deployments via Secret reference
- Backend ioredis client passes `password` to Redis constructor
- Backward compatible: `redis.auth.password: ""` disables authentication

Closes #147

## Files Changed

| File | Change |
|------|--------|
| `backend/src/plugins/env.ts` | Add optional `REDIS_PASSWORD` env var |
| `backend/src/plugins/redis.ts` | Pass password to ioredis constructor |
| `backend/src/types/fastify.ts` | Add `REDIS_PASSWORD` to config type |
| `backend/.env.example` | Document Redis config vars |
| `deployment/helm/litemaas/values.yaml` | Add `redis.auth` section |
| `deployment/helm/litemaas/templates/_helpers.tpl` | Add `litemaas.redis.secretName` helper |
| `deployment/helm/litemaas/templates/redis-secret.yaml` | New — Redis password Secret |
| `deployment/helm/litemaas/templates/redis-deployment.yaml` | Add requirepass command, authenticated probes |
| `deployment/helm/litemaas/templates/backend-deployment.yaml` | Inject `REDIS_PASSWORD` env var |
| `deployment/helm/litemaas/templates/litellm-deployment.yaml` | Inject `REDIS_PASSWORD` env var |
| `deployment/kustomize/redis-deployment.yaml` | Add commented auth instructions |

## Upgrade Path

| Scenario | Behaviour |
|----------|-----------|
| New install (default) | Redis password `changeme` — user should override |
| Existing deployment upgrading | All pods restart with password; transition is seamless |
| External Redis (`existingSecret`) | References user-provided Secret |
| No auth wanted (`password: ""`) | No secret created, no requirepass — current behaviour |

## Test plan

- [x] `helm template` default: Redis secret created, requirepass enabled, all pods get REDIS_PASSWORD
- [x] `helm template` with `redis.auth.password=""`: no secret, no requirepass, no REDIS_PASSWORD
- [x] `helm template` with `redis.auth.existingSecret=my-secret`: references external secret
- [x] `npm run build` — TypeScript compiles cleanly
- [x] Unit tests pass (no new failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)