### PR TITLE
docs: document dev branch as PR target in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,6 +157,14 @@ docker compose up -d  # Local development with containers (using compose.yaml)
 
 _See `docs/development/` for detailed setup, `docs/deployment/helm-deployment.md` for Helm deployment, and `docs/deployment/configuration.md` for environment variables_
 
+## 🔀 Git Workflow
+
+**⚠️ IMPORTANT**: The `dev` branch is the integration branch. All feature branches and pull requests MUST target `dev`, NOT `main`. The `main` branch is reserved for stable releases only.
+
+- **Create feature branches from**: `dev`
+- **Target PRs at**: `dev`
+- **Never push directly to**: `main` or `dev`
+
 ## 🚨 CRITICAL DEVELOPMENT NOTES
 
 ### Development Server and Logging Setup

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,10 +44,12 @@ We are committed to providing a welcoming and inclusive environment. Please:
 
 ### 1. Create a Feature Branch
 
+> **Important**: The `dev` branch is the integration branch. All feature branches and pull requests must target `dev`, not `main`. The `main` branch is reserved for stable releases only.
+
 ```bash
-# Update your main branch
-git checkout main
-git pull upstream main
+# Update your dev branch
+git checkout dev
+git pull upstream dev
 
 # Create a new branch
 git checkout -b feature/your-feature-name
@@ -84,7 +86,7 @@ Commit types:
 
 ```bash
 git fetch upstream
-git rebase upstream/main
+git rebase upstream/dev
 ```
 
 ## Code Style and Conventions

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -19,6 +19,8 @@ git clone https://github.com/rh-aiservices-bu/litemaas.git
 cd litemaas
 ```
 
+> **Note**: The `dev` branch is the integration branch — create feature branches from `dev` and target PRs at `dev`. See the [Contributing Guide](../../CONTRIBUTING.md#1-create-a-feature-branch) for the full development workflow.
+
 ### 2. Install Dependencies
 
 ```bash


### PR DESCRIPTION
## Summary

- Adds a "Git Workflow" section to root `CLAUDE.md` instructing AI coding agents to target `dev` (not `main`) for all feature branches and PRs
- `main` is reserved for stable releases; `dev` is the integration branch

## Test plan

- [ ] Verify AI agents reading `CLAUDE.md` create branches from `dev` and target PRs at `dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)