### PR TITLE
fix: add missing jsonwebtoken dev dependency for backend tests

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -57,6 +57,7 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
+    "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "^20.11.19",
     "@types/pg": "^8.10.9",
     "@typescript-eslint/eslint-plugin": "^7.0.1",
@@ -66,6 +67,7 @@
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.1.3",
+    "jsonwebtoken": "^9.0.3",
     "pino-pretty": "^10.3.1",
     "prettier": "^3.2.5",
     "rimraf": "^5.0.5",

--- a/backend/tests/integration/error-flows.test.ts
+++ b/backend/tests/integration/error-flows.test.ts
@@ -91,7 +91,7 @@ describe('Error Flows Integration', () => {
 
       const result = JSON.parse(response.body);
       expect(result.error.code).toBe('UNAUTHORIZED');
-      expect(result.error.message).toBe('Authentication required');
+      expect(result.error.message).toBe('Invalid or missing authentication token');
       expect(result.requestId).toBeDefined();
       // Note: Basic auth responses don't include statusCode, timestamp fields
     });

--- a/backend/tests/integration/routes/auth.test.ts
+++ b/backend/tests/integration/routes/auth.test.ts
@@ -126,7 +126,7 @@ describe('Auth Routes Integration', () => {
       expect(response.statusCode).toBe(200);
       const result = JSON.parse(response.body);
       expect(result.user.username).toBe('testuser');
-      expect(result.user.email).toBe('testuser@litemaas.local');
+      expect(result.user.email).toBe('test@example.com');
     });
 
     it('should generate development token with custom roles', async () => {

--- a/backend/tests/unit/services/oauth.service.test.ts
+++ b/backend/tests/unit/services/oauth.service.test.ts
@@ -37,6 +37,8 @@ describe('OAuthService', () => {
     };
     mockDefaultTeamService = {
       ensureUserMembership: vi.fn(),
+      ensureDefaultTeamExists: vi.fn().mockResolvedValue(undefined),
+      assignUserToDefaultTeam: vi.fn().mockResolvedValue(undefined),
     };
 
     service = new OAuthService(mockFastify, mockLiteLLMService, mockDefaultTeamService);
@@ -291,7 +293,8 @@ describe('OAuthService', () => {
     it('should query database for existing user', async () => {
       mockFastify.dbUtils.queryOne = vi
         .fn()
-        .mockResolvedValueOnce(null) // Check for existing user
+        .mockResolvedValueOnce(null) // Check for existing user by oauth_id
+        .mockResolvedValueOnce(null) // Email migration check by email
         .mockResolvedValueOnce(null) // system_settings query (user_defaults)
         .mockResolvedValueOnce(mockUserDbRow); // INSERT RETURNING
       mockFastify.dbUtils.query = vi.fn().mockResolvedValue({ rowCount: 1 });
@@ -308,7 +311,8 @@ describe('OAuthService', () => {
     it('should create new user with INSERT RETURNING', async () => {
       mockFastify.dbUtils.queryOne = vi
         .fn()
-        .mockResolvedValueOnce(null) // Check for existing user
+        .mockResolvedValueOnce(null) // Check for existing user by oauth_id
+        .mockResolvedValueOnce(null) // Email migration check by email
         .mockResolvedValueOnce(null) // system_settings query (user_defaults)
         .mockResolvedValueOnce(mockUserDbRow); // INSERT RETURNING
       mockFastify.dbUtils.query = vi.fn().mockResolvedValue({ rowCount: 1 });
@@ -346,7 +350,8 @@ describe('OAuthService', () => {
     it('should handle LiteLLM sync errors gracefully', async () => {
       mockFastify.dbUtils.queryOne = vi
         .fn()
-        .mockResolvedValueOnce(null) // Check for existing user
+        .mockResolvedValueOnce(null) // Check for existing user by oauth_id
+        .mockResolvedValueOnce(null) // Email migration check by email
         .mockResolvedValueOnce(null) // system_settings query (user_defaults)
         .mockResolvedValueOnce(mockUserDbRow); // INSERT RETURNING
       mockFastify.dbUtils.query = vi.fn().mockResolvedValue({ rowCount: 1 });
@@ -363,7 +368,8 @@ describe('OAuthService', () => {
     it('should log info on successful user creation', async () => {
       mockFastify.dbUtils.queryOne = vi
         .fn()
-        .mockResolvedValueOnce(null) // Check for existing user
+        .mockResolvedValueOnce(null) // Check for existing user by oauth_id
+        .mockResolvedValueOnce(null) // Email migration check by email
         .mockResolvedValueOnce(null) // system_settings query (user_defaults)
         .mockResolvedValueOnce(mockUserDbRow); // INSERT RETURNING
       mockFastify.dbUtils.query = vi.fn().mockResolvedValue({ rowCount: 1 });
@@ -387,7 +393,8 @@ describe('OAuthService', () => {
     it('should map admin groups correctly', async () => {
       mockFastify.dbUtils.queryOne = vi
         .fn()
-        .mockResolvedValueOnce(null) // Check for existing user
+        .mockResolvedValueOnce(null) // Check for existing user by oauth_id
+        .mockResolvedValueOnce(null) // Email migration check by email
         .mockResolvedValueOnce(null) // system_settings query (user_defaults)
         .mockResolvedValueOnce({ ...mockUserDbRow, roles: ['user', 'admin'] }); // INSERT RETURNING
       mockFastify.dbUtils.query = vi.fn().mockResolvedValue({ rowCount: 1 });
@@ -403,7 +410,8 @@ describe('OAuthService', () => {
     it('should map readonly groups correctly', async () => {
       mockFastify.dbUtils.queryOne = vi
         .fn()
-        .mockResolvedValueOnce(null) // Check for existing user
+        .mockResolvedValueOnce(null) // Check for existing user by oauth_id
+        .mockResolvedValueOnce(null) // Email migration check by email
         .mockResolvedValueOnce(null) // system_settings query (user_defaults)
         .mockResolvedValueOnce({ ...mockUserDbRow, roles: ['user', 'admin-readonly'] }); // INSERT RETURNING
       mockFastify.dbUtils.query = vi.fn().mockResolvedValue({ rowCount: 1 });
@@ -419,7 +427,8 @@ describe('OAuthService', () => {
     it('should default to user role for unknown groups', async () => {
       mockFastify.dbUtils.queryOne = vi
         .fn()
-        .mockResolvedValueOnce(null) // Check for existing user
+        .mockResolvedValueOnce(null) // Check for existing user by oauth_id
+        .mockResolvedValueOnce(null) // Email migration check by email
         .mockResolvedValueOnce(null) // system_settings query (user_defaults)
         .mockResolvedValueOnce(mockUserDbRow); // INSERT RETURNING
       mockFastify.dbUtils.query = vi.fn().mockResolvedValue({ rowCount: 1 });
@@ -434,7 +443,8 @@ describe('OAuthService', () => {
     it('should handle empty groups array', async () => {
       mockFastify.dbUtils.queryOne = vi
         .fn()
-        .mockResolvedValueOnce(null) // Check for existing user
+        .mockResolvedValueOnce(null) // Check for existing user by oauth_id
+        .mockResolvedValueOnce(null) // Email migration check by email
         .mockResolvedValueOnce(null) // system_settings query (user_defaults)
         .mockResolvedValueOnce(mockUserDbRow); // INSERT RETURNING
       mockFastify.dbUtils.query = vi.fn().mockResolvedValue({ rowCount: 1 });
@@ -449,7 +459,8 @@ describe('OAuthService', () => {
     it('should throw error if user creation fails', async () => {
       mockFastify.dbUtils.queryOne = vi
         .fn()
-        .mockResolvedValueOnce(null) // Check for existing user
+        .mockResolvedValueOnce(null) // Check for existing user by oauth_id
+        .mockResolvedValueOnce(null) // Email migration check by email
         .mockResolvedValueOnce(null) // system_settings query (user_defaults)
         .mockResolvedValueOnce(null); // INSERT RETURNING returns null
       mockFastify.dbUtils.query = vi.fn().mockResolvedValue({ rowCount: 1 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "zod": "^3.23.8"
       },
       "devDependencies": {
+        "@types/jsonwebtoken": "^9.0.10",
         "@types/node": "^20.11.19",
         "@types/pg": "^8.10.9",
         "@typescript-eslint/eslint-plugin": "^7.0.1",
@@ -59,6 +60,7 @@
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.1.3",
+        "jsonwebtoken": "^9.0.3",
         "pino-pretty": "^10.3.1",
         "prettier": "^3.2.5",
         "rimraf": "^5.0.5",
@@ -3084,6 +3086,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
+      "integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/mdast": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
@@ -4113,6 +4126,13 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/cac": {
       "version": "6.7.14",
@@ -8246,6 +8266,29 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
@@ -8259,6 +8302,29 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/keyv": {
@@ -8335,10 +8401,52 @@
       "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
       "license": "MIT"
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
       "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.merge": {
@@ -8346,6 +8454,13 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/longest-streak": {
       "version": "3.1.0",


### PR DESCRIPTION
## Summary

- Adds `jsonwebtoken` and `@types/jsonwebtoken` as dev dependencies in `backend/package.json` (fixes import resolution failure that prevented all integration/security test suites from loading)
- Fixes 10 broken test expectations across 3 test files:
  - **error-flows.test.ts**: Updated auth error message to match current `authenticate()` decorator
  - **auth.test.ts**: Updated dev-token email expectation to match DB-seeded user (endpoint now does DB lookups)
  - **oauth.service.test.ts**: Added missing email migration `queryOne` mock to all new-user-path tests, and added `ensureDefaultTeamExists`/`assignUserToDefaultTeam` to mock `defaultTeamService`

Closes #152

## Test plan

- [x] All 20 integration test files load (no import resolution errors)
- [x] Security tests pass (18/18)
- [x] OAuth service unit tests pass (35/35)
- [x] Error flows auth error expectation matches source
- [x] `jsonwebtoken` and `@types/jsonwebtoken` present in devDependencies