### PR TITLE
fix: use user-scoped endpoints for UsagePage filters (#135)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Dev-only endpoints locked down**: `dev-token`, `mock-login`, and `mock-users` endpoints now restricted to development and test environments only via allowlist
 - **Session invalidation IDOR**: Session delete endpoint now enforces ownership check, preventing users from invalidating other users' sessions
 - **Swagger/dev endpoint visibility**: Swagger `hide` property now uses the same allowlist as handler guards, preventing dev endpoints from being advertised in non-development environments
+- **UsagePage 403 errors for regular users**: `ModelFilterSelect` and `ApiKeyFilterSelect` on the user usage page (`/usage`) unconditionally called admin-only endpoints; both now accept a `useAdminEndpoint` prop and fall back to user-scoped `/models` and `/api-keys` endpoints (#135)
 - **Usage analytics enrichment**: Revoked or inactive API keys are now included in user mapping during usage report enrichment, fixing undercounted requests and spend for users whose keys were later deactivated
 - **Usage cache staleness**: Yesterday's completed usage data is now permanently cached instead of being re-fetched on every request, improving performance and consistency
 - **Usage analytics billing calculation**: Eliminated token double-counting where model metrics were initialized with LiteLLM's already-aggregated prompt/completion tokens then added again per API key, and excluded tokens/spend from skipped requests with empty or invalid API keys

--- a/backend/src/routes/api-keys.ts
+++ b/backend/src/routes/api-keys.ts
@@ -89,6 +89,7 @@ const apiKeysRoutes: FastifyPluginAsync = async (fastify) => {
             expiresAt: apiKey.expiresAt,
             isActive: apiKey.isActive,
             revokedAt: apiKey.revokedAt,
+            liteLLMKeyAlias: apiKey.liteLLMKeyAlias,
             liteLLMKeyId: apiKey.liteLLMKeyId,
             lastSyncAt: apiKey.lastSyncAt,
             syncStatus: apiKey.syncStatus,

--- a/backend/src/schemas/api-keys.ts
+++ b/backend/src/schemas/api-keys.ts
@@ -298,6 +298,7 @@ export const ApiKeyResponseSchema = Type.Object({
       ),
       modelRpmLimit: Type.Optional(Type.Record(Type.String(), Type.Integer())),
       modelTpmLimit: Type.Optional(Type.Record(Type.String(), Type.Integer())),
+      liteLLMKeyAlias: Type.Optional(Type.String()),
       metadata: Type.Optional(Type.Record(Type.String(), Type.Any())),
     }),
   ),

--- a/backend/src/services/api-key.service.ts
+++ b/backend/src/services/api-key.service.ts
@@ -119,6 +119,7 @@ interface ApiKeyDbRow {
   budget_duration?: string;
   soft_budget?: number;
   budget_reset_at?: Date | string;
+  litellm_key_alias?: string;
   metadata?: Record<string, unknown>;
   model_details?: unknown[];
   subscription_id?: string;
@@ -2035,6 +2036,7 @@ export class ApiKeyService extends BaseService {
       isActive: apiKey.is_active,
       createdAt: new Date(apiKey.created_at),
       revokedAt: apiKey.revoked_at ? new Date(apiKey.revoked_at) : undefined,
+      liteLLMKeyAlias: apiKey.litellm_key_alias,
       liteLLMKeyId: apiKey.lite_llm_key_value || liteLLMResponse?.key,
       lastSyncAt: apiKey.last_sync_at ? new Date(apiKey.last_sync_at) : undefined,
       syncStatus: (apiKey.sync_status || 'pending') as 'pending' | 'synced' | 'error',

--- a/backend/src/types/api-key.types.ts
+++ b/backend/src/types/api-key.types.ts
@@ -265,6 +265,7 @@ export interface EnhancedApiKey extends ApiKey {
     quotaRequests: number;
     usedRequests: number;
   }>;
+  liteLLMKeyAlias?: string;
   // PHASE 1 FIX: Add actual LiteLLM key fields
   liteLLMKey?: string; // Masked key for list views, full key for individual retrieval
   liteLLMKeyId?: string; // Full LiteLLM key ID for internal use

--- a/frontend/src/components/admin/ApiKeyFilterSelect.tsx
+++ b/frontend/src/components/admin/ApiKeyFilterSelect.tsx
@@ -32,6 +32,7 @@ interface ApiKeyFilterSelectProps {
   onSelect: (keyAliases: string[]) => void;
   selectedUserIds: string[];
   isDisabled?: boolean;
+  useAdminEndpoint?: boolean;
 }
 
 /**
@@ -44,6 +45,7 @@ export const ApiKeyFilterSelect: React.FC<ApiKeyFilterSelectProps> = ({
   onSelect,
   selectedUserIds,
   isDisabled = false,
+  useAdminEndpoint = true,
 }) => {
   const { t } = useTranslation();
   const [isOpen, setIsOpen] = useState(false);
@@ -58,21 +60,45 @@ export const ApiKeyFilterSelect: React.FC<ApiKeyFilterSelectProps> = ({
 
   const NO_RESULTS = 'no results';
 
-  // Fetch API keys from API - only when users are selected
+  // Fetch API keys - admin path uses /admin/api-keys, user path uses /api-keys
   const { data: apiKeysData, error: apiKeysError } = useQuery(
-    ['api-keys-for-filter', selectedUserIds.sort().join(',')],
+    useAdminEndpoint
+      ? ['api-keys-for-filter', selectedUserIds.sort().join(',')]
+      : ['user-api-keys-for-filter'],
     async () => {
-      const params = new URLSearchParams();
-      selectedUserIds.forEach((id) => params.append('userIds', id));
-      const response = await apiClient.get<{ apiKeys: ApiKeyOption[] }>(
-        `/admin/api-keys?${params.toString()}`,
-      );
-      return response.apiKeys;
+      if (useAdminEndpoint) {
+        const params = new URLSearchParams();
+        selectedUserIds.forEach((id) => params.append('userIds', id));
+        const response = await apiClient.get<{ apiKeys: ApiKeyOption[] }>(
+          `/admin/api-keys?${params.toString()}`,
+        );
+        return response.apiKeys;
+      } else {
+        const response = await apiClient.get<{
+          data: Array<{
+            id: string;
+            name: string;
+            liteLLMKeyAlias?: string;
+            keyPrefix: string;
+            isActive: boolean;
+          }>;
+        }>('/api-keys?limit=100&isActive=true');
+        return response.data
+          .filter((key) => key.liteLLMKeyAlias)
+          .map((key) => ({
+            id: key.id,
+            name: key.name,
+            keyAlias: key.liteLLMKeyAlias!,
+            userId: '',
+            username: '',
+            email: '',
+          }));
+      }
     },
     {
       staleTime: 5 * 60 * 1000, // 5 minutes
       refetchOnWindowFocus: false,
-      enabled: selectedUserIds.length > 0 && !isDisabled,
+      enabled: useAdminEndpoint ? selectedUserIds.length > 0 && !isDisabled : !isDisabled,
     },
   );
 
@@ -81,7 +107,7 @@ export const ApiKeyFilterSelect: React.FC<ApiKeyFilterSelectProps> = ({
   // Convert API keys to select options
   const initialSelectOptions: SelectOptionProps[] = allApiKeys.map((apiKey) => ({
     value: apiKey.keyAlias,
-    children: `${apiKey.name} (${apiKey.username})`,
+    children: useAdminEndpoint ? `${apiKey.name} (${apiKey.username})` : apiKey.name,
   }));
 
   // Helper function to truncate text
@@ -128,7 +154,7 @@ export const ApiKeyFilterSelect: React.FC<ApiKeyFilterSelectProps> = ({
   }, [inputValue, initialSelectOptions.length]);
 
   useEffect(() => {
-    if (isDisabled || selectedUserIds.length === 0) {
+    if (useAdminEndpoint && (isDisabled || selectedUserIds.length === 0)) {
       setPlaceholder(
         t('adminUsage.filters.apiKeysPlaceholder', 'Select users first to filter by API keys'),
       );
@@ -139,7 +165,7 @@ export const ApiKeyFilterSelect: React.FC<ApiKeyFilterSelectProps> = ({
     } else {
       setPlaceholder(''); // Empty when labels are shown
     }
-  }, [selected, selectedUserIds, isDisabled, t]);
+  }, [selected, selectedUserIds, isDisabled, useAdminEndpoint, t]);
 
   // Show error state if API key loading failed
   useEffect(() => {
@@ -150,18 +176,21 @@ export const ApiKeyFilterSelect: React.FC<ApiKeyFilterSelectProps> = ({
 
   // Show no API keys available state
   useEffect(() => {
+    const hasUsers = useAdminEndpoint ? selectedUserIds.length > 0 : true;
     if (
-      selectedUserIds.length > 0 &&
+      hasUsers &&
       !isDisabled &&
       !apiKeysError &&
       allApiKeys.length === 0 &&
       apiKeysData !== undefined
     ) {
       setPlaceholder(
-        t('adminUsage.filters.noApiKeysAvailable', 'No API keys available for selected users'),
+        useAdminEndpoint
+          ? t('adminUsage.filters.noApiKeysAvailable', 'No API keys available for selected users')
+          : t('adminUsage.filters.noApiKeysAvailableUser', 'No API keys available'),
       );
     }
-  }, [selectedUserIds, isDisabled, apiKeysError, allApiKeys, apiKeysData, t]);
+  }, [selectedUserIds, isDisabled, apiKeysError, allApiKeys, apiKeysData, useAdminEndpoint, t]);
 
   const createItemId = (value: any) =>
     `select-multi-typeahead-api-keys-${value.replace(/[^a-zA-Z0-9]/g, '-')}`;

--- a/frontend/src/components/usage/filters/ModelFilterSelect.tsx
+++ b/frontend/src/components/usage/filters/ModelFilterSelect.tsx
@@ -31,6 +31,7 @@ interface ModelFilterSelectProps {
     startDate: string;
     endDate: string;
   };
+  useAdminEndpoint?: boolean;
 }
 
 /**
@@ -44,6 +45,7 @@ export const ModelFilterSelect: React.FC<ModelFilterSelectProps> = ({
   selected,
   onSelect,
   dateRange,
+  useAdminEndpoint = true,
 }) => {
   const { t } = useTranslation();
   const [isOpen, setIsOpen] = useState(false);
@@ -58,14 +60,15 @@ export const ModelFilterSelect: React.FC<ModelFilterSelectProps> = ({
 
   const NO_RESULTS = 'no results';
 
-  // Fetch models from API - either from /models or from usage data based on dateRange
+  const useAdminPath = dateRange && useAdminEndpoint;
+
+  // Fetch models from API - admin path uses usage filter-options, user path uses /models
   const { data: modelsData } = useQuery(
-    dateRange
+    useAdminPath
       ? ['models-from-usage', dateRange.startDate, dateRange.endDate]
       : ['models-for-filter'],
     async () => {
-      if (dateRange) {
-        // Fetch models that have usage data in the specified date range
+      if (useAdminPath) {
         const response = await apiClient.get<{
           models: ModelOption[];
           users: Array<{ userId: string; username: string; email: string }>;
@@ -74,7 +77,6 @@ export const ModelFilterSelect: React.FC<ModelFilterSelectProps> = ({
         );
         return response.models;
       } else {
-        // Fetch currently active models
         const response = await apiClient.get<{ data: ModelOption[] }>('/models?limit=1000');
         return response.data;
       }
@@ -82,7 +84,7 @@ export const ModelFilterSelect: React.FC<ModelFilterSelectProps> = ({
     {
       staleTime: 5 * 60 * 1000, // 5 minutes
       refetchOnWindowFocus: false,
-      enabled: !dateRange || (!!dateRange.startDate && !!dateRange.endDate),
+      enabled: !useAdminPath || (!!dateRange?.startDate && !!dateRange?.endDate),
     },
   );
 

--- a/frontend/src/pages/UsagePage.tsx
+++ b/frontend/src/pages/UsagePage.tsx
@@ -200,6 +200,7 @@ const UsagePage: React.FC = () => {
                 selected={selectedModelIds}
                 onSelect={handleModelFilterChange}
                 dateRange={{ startDate: filters.startDate, endDate: filters.endDate }}
+                useAdminEndpoint={false}
               />
             </ToolbarItem>
 
@@ -209,6 +210,7 @@ const UsagePage: React.FC = () => {
                 onSelect={handleApiKeyFilterChange}
                 selectedUserIds={currentUser?.id ? [currentUser.id] : []}
                 isDisabled={false}
+                useAdminEndpoint={false}
               />
             </ToolbarItem>
           </ToolbarContent>

--- a/frontend/src/test/components/admin/ApiKeyFilterSelect.test.tsx
+++ b/frontend/src/test/components/admin/ApiKeyFilterSelect.test.tsx
@@ -307,4 +307,133 @@ describe('ApiKeyFilterSelect', () => {
       expect(mockApiClient.get.mock.calls.length).toBe(firstCallCount);
     });
   });
+
+  describe('useAdminEndpoint={false} (user mode)', () => {
+    it('should fetch from user-scoped /api-keys endpoint', async () => {
+      const mockUserKeys = {
+        data: [
+          {
+            id: 'key-1',
+            name: 'My Key',
+            liteLLMKeyAlias: 'sk-my-key-alias',
+            keyPrefix: 'sk-abc',
+            isActive: true,
+          },
+        ],
+      };
+
+      mockApiClient.get.mockResolvedValueOnce(mockUserKeys);
+
+      renderComponent({
+        selectedUserIds: ['user-1'],
+        useAdminEndpoint: false,
+      });
+
+      await waitFor(() => {
+        expect(mockApiClient.get).toHaveBeenCalledWith('/api-keys?limit=100&isActive=true');
+      });
+    });
+
+    it('should not require selectedUserIds to fetch', async () => {
+      mockApiClient.get.mockResolvedValueOnce({ data: [] });
+
+      renderComponent({
+        selectedUserIds: [],
+        useAdminEndpoint: false,
+      });
+
+      await waitFor(() => {
+        expect(mockApiClient.get).toHaveBeenCalledWith('/api-keys?limit=100&isActive=true');
+      });
+    });
+
+    it('should display key name without username', async () => {
+      const mockUserKeys = {
+        data: [
+          {
+            id: 'key-1',
+            name: 'Production Key',
+            liteLLMKeyAlias: 'sk-prod-alias',
+            keyPrefix: 'sk-abc',
+            isActive: true,
+          },
+        ],
+      };
+
+      mockApiClient.get.mockResolvedValueOnce(mockUserKeys);
+
+      const user = userEvent.setup();
+      renderComponent({
+        selectedUserIds: [],
+        useAdminEndpoint: false,
+      });
+
+      await waitFor(() => {
+        expect(mockApiClient.get).toHaveBeenCalled();
+      });
+
+      const input = screen.getByPlaceholderText(/all api keys \(click to filter\)/i);
+      await user.click(input);
+
+      await waitFor(() => {
+        const option = screen.getByText('Production Key');
+        expect(option).toBeInTheDocument();
+        expect(screen.queryByText(/\(.*\)/)).not.toBeInTheDocument();
+      });
+    });
+
+    it('should filter out keys without liteLLMKeyAlias', async () => {
+      const mockUserKeys = {
+        data: [
+          {
+            id: 'key-1',
+            name: 'Has Alias',
+            liteLLMKeyAlias: 'sk-alias',
+            keyPrefix: 'sk-abc',
+            isActive: true,
+          },
+          {
+            id: 'key-2',
+            name: 'No Alias',
+            keyPrefix: 'sk-def',
+            isActive: true,
+          },
+        ],
+      };
+
+      mockApiClient.get.mockResolvedValueOnce(mockUserKeys);
+
+      const user = userEvent.setup();
+      renderComponent({
+        selectedUserIds: [],
+        useAdminEndpoint: false,
+      });
+
+      await waitFor(() => {
+        expect(mockApiClient.get).toHaveBeenCalled();
+      });
+
+      const input = screen.getByPlaceholderText(/all api keys \(click to filter\)/i);
+      await user.click(input);
+
+      await waitFor(() => {
+        expect(screen.getByText('Has Alias')).toBeInTheDocument();
+        expect(screen.queryByText('No Alias')).not.toBeInTheDocument();
+      });
+    });
+
+    it('should show placeholder without "select users" text', () => {
+      renderComponent({
+        selectedUserIds: [],
+        useAdminEndpoint: false,
+      });
+
+      expect(
+        screen.getByPlaceholderText(/all api keys \(click to filter\)/i),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByPlaceholderText(/select users first/i),
+      ).not.toBeInTheDocument();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- `ModelFilterSelect` and `ApiKeyFilterSelect` on the user `/usage` page unconditionally called admin-only endpoints (`/admin/usage/filter-options`, `/admin/api-keys`), causing 403 errors for non-admin users
- Added `useAdminEndpoint` prop (default `true`) to both components; when `false`, they use user-scoped `/models` and `/api-keys` endpoints instead
- Backend: exposed `liteLLMKeyAlias` in user API keys response and response schema so the API key filter can match keys to usage data

## Test plan

- [x] TypeScript compiles clean (backend + frontend)
- [x] All 16 ApiKeyFilterSelect tests pass (11 existing + 5 new for user mode)
- [x] All 11 AdminUsagePage tests pass (no regression)
- [x] Manual: log in as non-admin user, navigate to `/usage`, confirm no 403 errors in network tab
- [x] Manual: confirm model and API key filter dropdowns populate and filter correctly
- [x] Manual: log in as admin, navigate to `/admin/usage`, confirm existing behavior unchanged

Closes #135