### PR TITLE
feat: add model popularity rating (1-5 stars) on model cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Model Popularity Rating**: Usage-based 1–5 star rating displayed on model cards, computed from the last 30 days of usage data with logarithmic min-max scaling
+  - Backend: `ModelPopularityService` with 1-hour in-memory cache, `GET /api/v1/models/popularity` endpoint (any authenticated role)
+  - Frontend: reusable `StarRating` component with PatternFly icons, tooltip, and ARIA support integrated into ModelsPage via React Query
+  - Cross-references `daily_usage_cache` model keys against the `models` table with case-insensitive matching and provider-prefix stripping
+  - i18n: Translations across all 9 locales
 - **Usage Data Sync tool**: Admin tool in Settings and Tools to re-import usage data from LiteLLM for a selected date range, useful after migrations or when cached data needs recalculation with current enrichment logic (token reconciliation, user mapping)
   - Backend: `resyncDateRange()` on AdminUsageStatsService, `deleteDateRange()` on DailyUsageCacheManager, new `POST /api/v1/admin/usage/resync` endpoint
   - Frontend: UsageDataSyncTab with date range pickers and sync button

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,13 @@ See [`docs/architecture/project-structure.md`](docs/architecture/project-structu
 - **Redis Cache Flush**: Optional Redis integration (`REDIS_HOST`/`REDIS_PORT`) to flush LiteLLM's cache after model CRUD, ensuring all proxy pods pick up changes immediately
 - **Deployment**: Redis deployment included in Helm (`redis.enabled: true`) and Kustomize charts
 
+**Model Popularity Rating**: Usage-based 1–5 star rating on model cards, giving users a quick visual indicator of which models are most actively used:
+
+- **Computation**: Last 30 days of usage data with logarithmic min-max scaling (1–5 stars)
+- **Backend**: `ModelPopularityService` with 1-hour in-memory cache, `GET /api/v1/models/popularity`
+- **Frontend**: Reusable `StarRating` component with PatternFly icons, tooltip, and ARIA support
+- **Key Resolution**: Cross-references `daily_usage_cache` model keys against the `models` table with case-insensitive matching and provider-prefix stripping
+
 **Restricted Model Subscription Approval** (Major feature - 2025 Q4): Admin-controlled access to sensitive/costly models with comprehensive approval workflow:
 
 - **Restricted Model Flagging**: Administrators mark models requiring approval

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -138,6 +138,7 @@ For details, see [`docs/features/user-roles-administration.md`](../docs/features
   - `UsageStatsService` - User-level usage analytics
   - `AdminUsageStatsService` - **System-wide analytics** with trend analysis and multi-dimensional filtering
   - `DailyUsageCacheManager` - **Day-by-day incremental caching** (permanent historical cache, 5-min TTL for current day)
+- **Popularity**: `ModelPopularityService` - 1–5 star ratings from 30-day usage data (1-hour in-memory cache, log-scaled)
 - **Integration**: LiteLLMService, LiteLLMIntegrationService
 - **Admin**: AdminService, admin-users route (user details, budget/limits, API keys, subscriptions)
 - **Settings**: SettingsService (API key quota defaults and maximums via `system_settings` table)

--- a/backend/src/routes/models.ts
+++ b/backend/src/routes/models.ts
@@ -9,12 +9,14 @@ import {
 import { LiteLLMModel } from '../types/model.types';
 import { LiteLLMService } from '../services/litellm.service';
 import { ModelSyncService } from '../services/model-sync.service';
+import { ModelPopularityService } from '../services/model-popularity.service';
 import { ApplicationError } from '../utils/errors';
 
 const modelsRoutes: FastifyPluginAsync = async (fastify) => {
   // Initialize services
   const liteLLMService = new LiteLLMService(fastify);
   const modelSyncService = new ModelSyncService(fastify);
+  const modelPopularityService = new ModelPopularityService(fastify);
 
   // Helper function to convert LiteLLM model to our Model format
   const convertLiteLLMModel = (model: LiteLLMModel): Model => {
@@ -721,6 +723,31 @@ const modelsRoutes: FastifyPluginAsync = async (fastify) => {
         fastify.log.error(error, 'Failed to retrieve capabilities');
         throw fastify.createError(500, 'Failed to retrieve capabilities');
       }
+    },
+  });
+
+  // Get model popularity ratings (1-5 stars based on last 30 days of usage)
+  fastify.get('/popularity', {
+    schema: {
+      tags: ['Models'],
+      description: 'Get model popularity ratings based on monthly usage',
+      security: [{ bearerAuth: [] }],
+      response: {
+        200: {
+          type: 'object',
+          properties: {
+            popularity: {
+              type: 'object',
+              additionalProperties: { type: 'number' },
+            },
+          },
+        },
+      },
+    },
+    preHandler: [fastify.authenticate],
+    handler: async (_request, _reply) => {
+      const popularity = await modelPopularityService.getPopularityRatings();
+      return { popularity };
     },
   });
 

--- a/backend/src/services/model-popularity.service.ts
+++ b/backend/src/services/model-popularity.service.ts
@@ -1,0 +1,159 @@
+import type { FastifyInstance } from 'fastify';
+import { BaseService } from './base.service';
+import { getTodayUTC, subDaysUTC } from './admin-usage/admin-usage.utils.js';
+
+interface CachedModelEntry {
+  metrics: {
+    api_requests: number;
+    total_tokens: number;
+    prompt_tokens: number;
+    completion_tokens: number;
+    spend: number;
+    successful_requests: number;
+    failed_requests: number;
+  };
+  users: Record<string, unknown>;
+}
+
+interface PopularityCache {
+  data: Record<string, number>;
+  expiresAt: number;
+}
+
+export class ModelPopularityService extends BaseService {
+  private cache: PopularityCache | null = null;
+  private static readonly CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+  private static readonly ROLLING_WINDOW_DAYS = 29;
+  private static readonly MAX_STARS = 5;
+  private static readonly MIN_STARS = 1;
+
+  constructor(fastify: FastifyInstance) {
+    super(fastify);
+  }
+
+  async getPopularityRatings(): Promise<Record<string, number>> {
+    if (this.cache && Date.now() < this.cache.expiresAt) {
+      this.fastify.log.debug('Model popularity cache hit');
+      return this.cache.data;
+    }
+
+    const today = getTodayUTC();
+    const startDate = subDaysUTC(today, ModelPopularityService.ROLLING_WINDOW_DAYS);
+
+    const modelsResult = await this.executeQuery<{
+      rows: Array<{ id: string }>;
+    }>(`SELECT id FROM models`, [], 'fetching model IDs');
+
+    const modelIds = modelsResult.rows.map((r) => r.id);
+    const modelIdLookup = new Map<string, string>();
+    for (const id of modelIds) {
+      modelIdLookup.set(id.toLowerCase(), id);
+    }
+
+    const result = await this.executeQuery<{
+      rows: Array<{ aggregated_by_model: Record<string, CachedModelEntry> | null }>;
+    }>(
+      `SELECT aggregated_by_model
+       FROM daily_usage_cache
+       WHERE date BETWEEN $1 AND $2`,
+      [startDate, today],
+      'fetching model popularity data',
+    );
+
+    const requestCounts = this.aggregateRequestCounts(result.rows, modelIdLookup);
+    const ratings = this.calculateRatings(requestCounts);
+
+    this.cache = {
+      data: ratings,
+      expiresAt: Date.now() + ModelPopularityService.CACHE_TTL_MS,
+    };
+
+    this.fastify.log.info(
+      { modelCount: Object.keys(ratings).length, startDate, endDate: today },
+      'Computed model popularity ratings',
+    );
+
+    return ratings;
+  }
+
+  private resolveModelId(cacheKey: string, modelIdLookup: Map<string, string>): string | null {
+    const directMatch = modelIdLookup.get(cacheKey.toLowerCase());
+    if (directMatch) return directMatch;
+
+    const slashIndex = cacheKey.indexOf('/');
+    if (slashIndex !== -1) {
+      const stripped = cacheKey.substring(slashIndex + 1);
+      const strippedMatch = modelIdLookup.get(stripped.toLowerCase());
+      if (strippedMatch) return strippedMatch;
+    }
+
+    return null;
+  }
+
+  private aggregateRequestCounts(
+    rows: Array<{ aggregated_by_model: Record<string, CachedModelEntry> | null }>,
+    modelIdLookup: Map<string, string>,
+  ): Map<string, number> {
+    const totals = new Map<string, number>();
+
+    for (const row of rows) {
+      const byModel = row.aggregated_by_model;
+      if (!byModel) continue;
+
+      for (const [cacheKey, entry] of Object.entries(byModel)) {
+        const modelId = this.resolveModelId(cacheKey, modelIdLookup);
+        if (!modelId) continue;
+
+        const current = totals.get(modelId) || 0;
+        totals.set(modelId, current + (entry.metrics?.api_requests || 0));
+      }
+    }
+
+    return totals;
+  }
+
+  private calculateRatings(requestCounts: Map<string, number>): Record<string, number> {
+    const modelsWithUsage = Array.from(requestCounts.entries()).filter(([, count]) => count > 0);
+
+    if (modelsWithUsage.length === 0) {
+      return {};
+    }
+
+    if (modelsWithUsage.length === 1) {
+      return { [modelsWithUsage[0][0]]: ModelPopularityService.MAX_STARS };
+    }
+
+    const logValues = modelsWithUsage.map(([id, count]) => ({
+      id,
+      logValue: Math.log(count),
+    }));
+
+    const logMin = Math.min(...logValues.map((v) => v.logValue));
+    const logMax = Math.max(...logValues.map((v) => v.logValue));
+
+    if (logMin === logMax) {
+      const ratings: Record<string, number> = {};
+      for (const { id } of logValues) {
+        ratings[id] = 3;
+      }
+      return ratings;
+    }
+
+    const ratings: Record<string, number> = {};
+    const range = logMax - logMin;
+
+    for (const { id, logValue } of logValues) {
+      const normalized = (logValue - logMin) / range;
+      ratings[id] = Math.round(
+        ModelPopularityService.MIN_STARS +
+          (ModelPopularityService.MAX_STARS - ModelPopularityService.MIN_STARS) * normalized,
+      );
+    }
+
+    return ratings;
+  }
+
+  invalidateCache(): void {
+    this.cache = null;
+  }
+}

--- a/backend/tests/integration/routes/models.test.ts
+++ b/backend/tests/integration/routes/models.test.ts
@@ -626,6 +626,100 @@ describe('Models Routes Integration', () => {
     });
   });
 
+  describe('GET /api/v1/models/popularity', () => {
+    it('should require authentication', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/v1/models/popularity',
+      });
+
+      expect(response.statusCode).toBe(401);
+    });
+
+    it('should allow access for regular users', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/v1/models/popularity',
+        headers: {
+          Authorization: `Bearer ${userToken}`,
+        },
+      });
+
+      expect([200, 500]).toContain(response.statusCode);
+
+      if (response.statusCode === 200) {
+        const result = JSON.parse(response.body);
+        expect(result).toHaveProperty('popularity');
+        expect(typeof result.popularity).toBe('object');
+      }
+    });
+
+    it('should allow access for admin users', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/v1/models/popularity',
+        headers: {
+          Authorization: `Bearer ${adminToken}`,
+        },
+      });
+
+      expect([200, 500]).toContain(response.statusCode);
+
+      if (response.statusCode === 200) {
+        const result = JSON.parse(response.body);
+        expect(result).toHaveProperty('popularity');
+      }
+    });
+
+    it('should allow access for admin readonly users', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/v1/models/popularity',
+        headers: {
+          Authorization: `Bearer ${adminReadonlyToken}`,
+        },
+      });
+
+      expect([200, 500]).toContain(response.statusCode);
+
+      if (response.statusCode === 200) {
+        const result = JSON.parse(response.body);
+        expect(result).toHaveProperty('popularity');
+      }
+    });
+
+    it('should return star ratings between 1 and 5', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/v1/models/popularity',
+        headers: {
+          Authorization: `Bearer ${userToken}`,
+        },
+      });
+
+      if (response.statusCode === 200) {
+        const result = JSON.parse(response.body);
+        for (const [, rating] of Object.entries(result.popularity)) {
+          expect(rating).toBeGreaterThanOrEqual(1);
+          expect(rating).toBeLessThanOrEqual(5);
+          expect(Number.isInteger(rating)).toBe(true);
+        }
+      }
+    });
+
+    it('should reject requests with invalid tokens', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/v1/models/popularity',
+        headers: {
+          Authorization: 'Bearer invalid-token-value',
+        },
+      });
+
+      expect(response.statusCode).toBe(401);
+    });
+  });
+
   describe('Error Handling', () => {
     it('should handle invalid pagination values gracefully', async () => {
       const response = await app.inject({

--- a/backend/tests/security/security.test.ts
+++ b/backend/tests/security/security.test.ts
@@ -25,6 +25,7 @@ describe('Security Tests', () => {
         '/api/v1/api-keys',
         '/api/v1/usage/dashboard',
         '/api/v1/users/me/activity',
+        '/api/v1/models/popularity',
       ];
 
       for (const endpoint of protectedEndpoints) {

--- a/backend/tests/unit/services/model-popularity.service.test.ts
+++ b/backend/tests/unit/services/model-popularity.service.test.ts
@@ -1,0 +1,309 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ModelPopularityService } from '../../../src/services/model-popularity.service';
+import type { FastifyInstance } from 'fastify';
+
+function modelEntry(apiRequests: number) {
+  return {
+    metrics: {
+      api_requests: apiRequests,
+      total_tokens: 0,
+      prompt_tokens: 0,
+      completion_tokens: 0,
+      spend: 0,
+      successful_requests: 0,
+      failed_requests: 0,
+    },
+    users: {},
+  };
+}
+
+function modelRows(...ids: string[]) {
+  return { rows: ids.map((id) => ({ id })) };
+}
+
+function cacheRows(
+  ...entries: Array<Record<string, ReturnType<typeof modelEntry>> | null>
+) {
+  return {
+    rows: entries.map((e) => ({ aggregated_by_model: e })),
+  };
+}
+
+describe('ModelPopularityService', () => {
+  let service: ModelPopularityService;
+  let mockFastify: any;
+
+  beforeEach(() => {
+    mockFastify = {
+      pg: {
+        query: vi.fn(),
+      },
+      log: {
+        info: vi.fn(),
+        error: vi.fn(),
+        warn: vi.fn(),
+        debug: vi.fn(),
+      },
+    };
+
+    service = new ModelPopularityService(mockFastify as FastifyInstance);
+  });
+
+  describe('getPopularityRatings', () => {
+    it('should return empty map when no usage data exists', async () => {
+      mockFastify.pg.query
+        .mockResolvedValueOnce(modelRows('model-a'))
+        .mockResolvedValueOnce(cacheRows());
+
+      const result = await service.getPopularityRatings();
+
+      expect(result).toEqual({});
+    });
+
+    it('should return empty map when all models have zero requests', async () => {
+      mockFastify.pg.query
+        .mockResolvedValueOnce(modelRows('model-a', 'model-b'))
+        .mockResolvedValueOnce(
+          cacheRows({
+            'model-a': modelEntry(0),
+            'model-b': modelEntry(0),
+          }),
+        );
+
+      const result = await service.getPopularityRatings();
+
+      expect(result).toEqual({});
+    });
+
+    it('should give 5 stars to the only model with usage', async () => {
+      mockFastify.pg.query
+        .mockResolvedValueOnce(modelRows('model-a'))
+        .mockResolvedValueOnce(
+          cacheRows({
+            'model-a': modelEntry(100),
+          }),
+        );
+
+      const result = await service.getPopularityRatings();
+
+      expect(result).toEqual({ 'model-a': 5 });
+    });
+
+    it('should give 3 stars to all models with equal usage', async () => {
+      mockFastify.pg.query
+        .mockResolvedValueOnce(modelRows('model-a', 'model-b', 'model-c'))
+        .mockResolvedValueOnce(
+          cacheRows({
+            'model-a': modelEntry(500),
+            'model-b': modelEntry(500),
+            'model-c': modelEntry(500),
+          }),
+        );
+
+      const result = await service.getPopularityRatings();
+
+      expect(result).toEqual({ 'model-a': 3, 'model-b': 3, 'model-c': 3 });
+    });
+
+    it('should apply logarithmic scaling for large disparity', async () => {
+      mockFastify.pg.query
+        .mockResolvedValueOnce(modelRows('model-low', 'model-high'))
+        .mockResolvedValueOnce(
+          cacheRows({
+            'model-low': modelEntry(1),
+            'model-high': modelEntry(1000000),
+          }),
+        );
+
+      const result = await service.getPopularityRatings();
+
+      expect(result['model-low']).toBe(1);
+      expect(result['model-high']).toBe(5);
+    });
+
+    it('should produce a spread of ratings with varied usage', async () => {
+      mockFastify.pg.query
+        .mockResolvedValueOnce(
+          modelRows('model-a', 'model-b', 'model-c', 'model-d', 'model-e'),
+        )
+        .mockResolvedValueOnce(
+          cacheRows({
+            'model-a': modelEntry(10),
+            'model-b': modelEntry(100),
+            'model-c': modelEntry(1000),
+            'model-d': modelEntry(10000),
+            'model-e': modelEntry(100000),
+          }),
+        );
+
+      const result = await service.getPopularityRatings();
+
+      expect(result['model-a']).toBe(1);
+      expect(result['model-e']).toBe(5);
+      for (const rating of Object.values(result)) {
+        expect(rating).toBeGreaterThanOrEqual(1);
+        expect(rating).toBeLessThanOrEqual(5);
+      }
+    });
+
+    it('should aggregate requests across multiple days', async () => {
+      mockFastify.pg.query
+        .mockResolvedValueOnce(modelRows('model-a', 'model-b'))
+        .mockResolvedValueOnce(
+          cacheRows(
+            {
+              'model-a': modelEntry(50),
+              'model-b': modelEntry(100),
+            },
+            {
+              'model-a': modelEntry(50),
+              'model-b': modelEntry(100),
+            },
+          ),
+        );
+
+      const result = await service.getPopularityRatings();
+
+      expect(result['model-b']).toBeGreaterThanOrEqual(result['model-a']);
+    });
+
+    it('should exclude zero-usage models from ratings', async () => {
+      mockFastify.pg.query
+        .mockResolvedValueOnce(modelRows('model-used', 'model-unused'))
+        .mockResolvedValueOnce(
+          cacheRows({
+            'model-used': modelEntry(500),
+            'model-unused': modelEntry(0),
+          }),
+        );
+
+      const result = await service.getPopularityRatings();
+
+      expect(result['model-used']).toBe(5);
+      expect(result['model-unused']).toBeUndefined();
+    });
+
+    it('should handle null aggregated_by_model gracefully', async () => {
+      mockFastify.pg.query
+        .mockResolvedValueOnce(modelRows('model-a'))
+        .mockResolvedValueOnce(cacheRows(null));
+
+      const result = await service.getPopularityRatings();
+
+      expect(result).toEqual({});
+    });
+
+    it('should use cached data on subsequent calls', async () => {
+      mockFastify.pg.query
+        .mockResolvedValueOnce(modelRows('model-a'))
+        .mockResolvedValueOnce(
+          cacheRows({
+            'model-a': modelEntry(100),
+          }),
+        );
+
+      const result1 = await service.getPopularityRatings();
+      const result2 = await service.getPopularityRatings();
+
+      expect(result1).toEqual(result2);
+      expect(mockFastify.pg.query).toHaveBeenCalledTimes(2);
+    });
+
+    it('should refresh cache after invalidation', async () => {
+      mockFastify.pg.query
+        .mockResolvedValueOnce(modelRows('model-a'))
+        .mockResolvedValueOnce(
+          cacheRows({
+            'model-a': modelEntry(100),
+          }),
+        )
+        .mockResolvedValueOnce(modelRows('model-a'))
+        .mockResolvedValueOnce(
+          cacheRows({
+            'model-a': modelEntry(100),
+          }),
+        );
+
+      await service.getPopularityRatings();
+      service.invalidateCache();
+      await service.getPopularityRatings();
+
+      expect(mockFastify.pg.query).toHaveBeenCalledTimes(4);
+    });
+
+    it('should produce ratings between 1 and 5 inclusive', async () => {
+      mockFastify.pg.query
+        .mockResolvedValueOnce(modelRows('a', 'b', 'c', 'd', 'e', 'f', 'g'))
+        .mockResolvedValueOnce(
+          cacheRows({
+            a: modelEntry(1),
+            b: modelEntry(5),
+            c: modelEntry(25),
+            d: modelEntry(125),
+            e: modelEntry(625),
+            f: modelEntry(3125),
+            g: modelEntry(15625),
+          }),
+        );
+
+      const result = await service.getPopularityRatings();
+
+      for (const [, rating] of Object.entries(result)) {
+        expect(rating).toBeGreaterThanOrEqual(1);
+        expect(rating).toBeLessThanOrEqual(5);
+        expect(Number.isInteger(rating)).toBe(true);
+      }
+    });
+
+    it('should resolve cache keys with provider prefix to model IDs', async () => {
+      mockFastify.pg.query
+        .mockResolvedValueOnce(modelRows('Qwen3.6-35B-A3B', 'DeepSeek-R1'))
+        .mockResolvedValueOnce(
+          cacheRows({
+            'openai/Qwen3.6-35B-A3B': modelEntry(100),
+            'openai/deepseek-r1': modelEntry(50),
+          }),
+        );
+
+      const result = await service.getPopularityRatings();
+
+      expect(result['Qwen3.6-35B-A3B']).toBeDefined();
+      expect(result['DeepSeek-R1']).toBeDefined();
+      expect(result['openai/Qwen3.6-35B-A3B']).toBeUndefined();
+    });
+
+    it('should aggregate counts across prefixed and unprefixed keys for same model', async () => {
+      mockFastify.pg.query
+        .mockResolvedValueOnce(modelRows('MyModel'))
+        .mockResolvedValueOnce(
+          cacheRows({
+            MyModel: modelEntry(100),
+            'openai/MyModel': modelEntry(50),
+            'openai/mymodel': modelEntry(25),
+          }),
+        );
+
+      const result = await service.getPopularityRatings();
+
+      expect(result['MyModel']).toBe(5);
+      expect(Object.keys(result)).toHaveLength(1);
+    });
+
+    it('should skip cache keys that do not match any known model', async () => {
+      mockFastify.pg.query
+        .mockResolvedValueOnce(modelRows('RealModel'))
+        .mockResolvedValueOnce(
+          cacheRows({
+            RealModel: modelEntry(100),
+            'openai/none': modelEntry(50),
+            'openai/your-model-name': modelEntry(30),
+          }),
+        );
+
+      const result = await service.getPopularityRatings();
+
+      expect(result['RealModel']).toBe(5);
+      expect(Object.keys(result)).toHaveLength(1);
+    });
+  });
+});

--- a/docs/api/rest-api.md
+++ b/docs/api/rest-api.md
@@ -210,6 +210,25 @@ Response:
 }
 ```
 
+#### GET /api/v1/models/popularity
+
+**Authorization**: Requires valid JWT token (any role)
+
+Get popularity ratings for all models based on the last 30 days of usage data. Ratings are computed using logarithmic min-max scaling and cached for 1 hour.
+
+```json
+Response:
+{
+  "popularity": {
+    "model-id-1": 5,
+    "model-id-2": 3,
+    "model-id-3": 1
+  }
+}
+```
+
+Each value is an integer from 1 (least popular) to 5 (most popular). Models with zero usage in the window are omitted.
+
 ### Subscriptions
 
 #### GET /api/v1/subscriptions

--- a/docs/architecture/project-structure.md
+++ b/docs/architecture/project-structure.md
@@ -86,6 +86,7 @@ litemaas/
 │   │   │   ├── default-team.service.ts # Default team management
 │   │   │   ├── litellm.service.ts # LiteLLM API client
 │   │   │   ├── litellm-integration.service.ts # LiteLLM integration layer
+│   │   │   ├── model-popularity.service.ts # Model popularity ratings (1-5 stars from usage data)
 │   │   │   ├── model-sync.service.ts # Model synchronization
 │   │   │   ├── notification.service.ts # Notification management
 │   │   │   ├── oauth.service.ts # OAuth/OIDC provider integration (discovery, PKCE, token exchange)
@@ -154,6 +155,7 @@ litemaas/
 │   │   │   ├── charts/       # Chart components (AccessibleChart, etc.)
 │   │   │   ├── branding/      # Branding customization components
 │   │   │   │   └── BrandingTab.tsx # Branding settings tab
+│   │   │   ├── StarRating.tsx  # Reusable 1-5 star rating (popularity)
 │   │   │   ├── AlertToastGroup.tsx # Toast notifications
 │   │   │   ├── ComponentErrorBoundary.tsx # Component-level error handling
 │   │   │   ├── ErrorBoundary.tsx # Global error handling

--- a/docs/architecture/services.md
+++ b/docs/architecture/services.md
@@ -95,6 +95,31 @@ The LiteMaaS backend service layer implements the business logic and core functi
 
 ---
 
+### ModelPopularityService
+
+**Purpose**: Compute 1–5 star popularity ratings for models based on recent usage data
+
+**Extends**: BaseService
+
+**Responsibilities**:
+
+- Aggregate API request counts from `daily_usage_cache` over a 30-day rolling window
+- Resolve cache model keys (which may include provider prefixes like `openai/`) to `models` table IDs using case-insensitive matching
+- Apply logarithmic min-max scaling to produce 1–5 star ratings
+- Maintain a 1-hour in-memory cache of computed ratings
+
+**Dependencies**:
+
+- Database connection for `daily_usage_cache` and `models` tables
+- Utility functions from `admin-usage.utils.ts` (`getTodayUTC`, `subDaysUTC`)
+
+**Key Operations**:
+
+- `getPopularityRatings()` - Return `Record<modelId, rating>` (cached, recomputed hourly)
+- `invalidateCache()` - Force recomputation on next call
+
+---
+
 ### LiteLLMService ✅ **UPDATED 2025-08-06**
 
 **Purpose**: Core integration with LiteLLM instances

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -30,6 +30,7 @@ This directory contains documentation for key features and functionality in Lite
 
 - Model synchronization with LiteLLM
 - Model configuration and testing
+- Model popularity rating (1–5 stars based on 30-day usage, displayed on model cards)
 - API key management (multi-model support)
 - Self-service API key quotas with admin-controlled defaults and maximums
 

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -131,6 +131,7 @@ See [`docs/architecture/project-structure.md`](../docs/architecture/project-stru
   - `UserSubscriptionsTab.tsx` - Read-only subscription list with status display
 - `components/admin/` - Admin settings & tools components
   - `UsageDataSyncTab.tsx` - Usage data re-import tool for selected date ranges
+- `components/StarRating.tsx` - Reusable 1–5 star rating with PatternFly icons, tooltip, and ARIA (used on model cards for popularity)
 - `components/charts/` - Shared chart components
   - `UsageTrends.tsx`, `ModelDistributionChart.tsx`, `ModelUsageTrends.tsx`
   - `UsageHeatmap.tsx` - Weekly heatmap (component ready, integration pending)

--- a/frontend/src/components/StarRating.tsx
+++ b/frontend/src/components/StarRating.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { Tooltip } from '@patternfly/react-core';
+import { StarIcon, OutlinedStarIcon } from '@patternfly/react-icons';
+
+interface StarRatingProps {
+  rating: number;
+  tooltip: string;
+  ariaLabel: string;
+}
+
+const TOTAL_STARS = 5;
+const FILLED_COLOR = 'var(--pf-t--global--color--status--warning--default)';
+const EMPTY_COLOR = 'var(--pf-t--global--color--nonstatus--gray--default)';
+
+const StarRating: React.FC<StarRatingProps> = ({ rating, tooltip, ariaLabel }) => {
+  return (
+    <Tooltip content={tooltip}>
+      <span
+        role="img"
+        aria-label={ariaLabel}
+        style={{ display: 'inline-flex', gap: '2px', alignItems: 'center', cursor: 'default' }}
+      >
+        {Array.from({ length: TOTAL_STARS }, (_, i) =>
+          i < rating ? (
+            <StarIcon key={i} color={FILLED_COLOR} />
+          ) : (
+            <OutlinedStarIcon key={i} color={EMPTY_COLOR} />
+          ),
+        )}
+      </span>
+    </Tooltip>
+  );
+};
+
+export default StarRating;

--- a/frontend/src/i18n/locales/de/translation.json
+++ b/frontend/src/i18n/locales/de/translation.json
@@ -1133,6 +1133,10 @@
         "output": "Ausgabe",
         "separator": "•"
       },
+      "popularity": {
+        "tooltip": "Monatliche Beliebtheit",
+        "ariaLabel": "Beliebtheitsbewertung: {{rating}} von 5 Sternen"
+      },
       "pricingLabel": "Preisgestaltung: N/A",
       "restrictedAccess": "Restricted Access",
       "searchPlaceholder": "Modelle suchen...",

--- a/frontend/src/i18n/locales/elv/translation.json
+++ b/frontend/src/i18n/locales/elv/translation.json
@@ -1133,6 +1133,10 @@
         "output": "Toltha",
         "separator": "•"
       },
+      "popularity": {
+        "tooltip": "Iastadh astarennen",
+        "ariaLabel": "Iastadh: {{rating}} o 5 elenath"
+      },
       "pricingLabel": "Vuin: Ú-úir",
       "restrictedAccess": "Restricted Access",
       "searchPlaceholder": "Drego echuin...",

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -1133,6 +1133,10 @@
         "output": "Output",
         "separator": "•"
       },
+      "popularity": {
+        "tooltip": "Monthly popularity",
+        "ariaLabel": "Popularity rating: {{rating}} out of 5 stars"
+      },
       "pricingLabel": "Pricing: N/A",
       "restrictedAccess": "Restricted Access",
       "searchPlaceholder": "Search models...",

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -1133,6 +1133,10 @@
         "output": "Salida",
         "separator": "•"
       },
+      "popularity": {
+        "tooltip": "Popularidad mensual",
+        "ariaLabel": "Valoración de popularidad: {{rating}} de 5 estrellas"
+      },
       "pricingLabel": "Precios: N/D",
       "restrictedAccess": "Acceso Restringido",
       "searchPlaceholder": "Buscar modelos...",

--- a/frontend/src/i18n/locales/fr/translation.json
+++ b/frontend/src/i18n/locales/fr/translation.json
@@ -1133,6 +1133,10 @@
         "output": "Sortie",
         "separator": "•"
       },
+      "popularity": {
+        "tooltip": "Popularité mensuelle",
+        "ariaLabel": "Note de popularité : {{rating}} sur 5 étoiles"
+      },
       "pricingLabel": "Tarification : N/A",
       "restrictedAccess": "Restricted Access",
       "searchPlaceholder": "Rechercher des modèles...",

--- a/frontend/src/i18n/locales/it/translation.json
+++ b/frontend/src/i18n/locales/it/translation.json
@@ -1133,6 +1133,10 @@
         "output": "Output",
         "separator": "•"
       },
+      "popularity": {
+        "tooltip": "Popolarità mensile",
+        "ariaLabel": "Valutazione di popolarità: {{rating}} su 5 stelle"
+      },
       "pricingLabel": "Prezzi: N/D",
       "restrictedAccess": "Restricted Access",
       "searchPlaceholder": "Cerca modelli...",

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -1133,6 +1133,10 @@
         "output": "出力",
         "separator": "•"
       },
+      "popularity": {
+        "tooltip": "月間人気度",
+        "ariaLabel": "人気度評価：5つ星中{{rating}}つ星"
+      },
       "pricingLabel": "価格：N/A",
       "restrictedAccess": "Restricted Access",
       "searchPlaceholder": "モデルを検索...",

--- a/frontend/src/i18n/locales/ko/translation.json
+++ b/frontend/src/i18n/locales/ko/translation.json
@@ -1133,6 +1133,10 @@
         "output": "출력",
         "separator": "•"
       },
+      "popularity": {
+        "tooltip": "월간 인기도",
+        "ariaLabel": "인기도 평가: 별 5개 중 {{rating}}개"
+      },
       "pricingLabel": "가격: N/A",
       "restrictedAccess": "제한된 액세스",
       "searchPlaceholder": "모델 검색...",

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -1133,6 +1133,10 @@
         "output": "输出",
         "separator": "•"
       },
+      "popularity": {
+        "tooltip": "月度热度",
+        "ariaLabel": "热度评分：{{rating}}/5 星"
+      },
       "pricingLabel": "价格：不适用",
       "restrictedAccess": "Restricted Access",
       "searchPlaceholder": "搜索模型...",

--- a/frontend/src/pages/ModelsPage.tsx
+++ b/frontend/src/pages/ModelsPage.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
+import { useQuery } from 'react-query';
 import { useTranslation } from 'react-i18next';
 import {
   PageSection,
@@ -52,8 +53,9 @@ import {
 import { useNotifications } from '../contexts/NotificationContext';
 import { useCurrency } from '../contexts/ConfigContext';
 import { useErrorHandler } from '../hooks/useErrorHandler';
-import { modelsService, Model } from '../services/models.service';
+import { modelsService, Model, ModelPopularityResponse } from '../services/models.service';
 import { subscriptionsService, Subscription } from '../services/subscriptions.service';
+import StarRating from '../components/StarRating';
 import {
   ScreenReaderAnnouncement,
   useScreenReaderAnnouncement,
@@ -123,6 +125,16 @@ const ModelsPage: React.FC = () => {
   const [perPage, setPerPage] = useState(12);
   const [total, setTotal] = useState(0);
   const [error, setError] = useState<string | null>(null);
+
+  const { data: popularityData } = useQuery<ModelPopularityResponse>(
+    ['modelPopularity'],
+    () => modelsService.getModelPopularity(),
+    {
+      staleTime: 30 * 60 * 1000,
+      refetchOnWindowFocus: false,
+      retry: 1,
+    },
+  );
 
   // Load subscriptions from API
   const loadSubscriptions = async (): Promise<void> => {
@@ -587,6 +599,17 @@ const ModelsPage: React.FC = () => {
                               : t('pages.models.pricingLabel')}
                           </Content>
                         </FlexItem>
+                        {popularityData?.popularity[model.id] && (
+                          <FlexItem>
+                            <StarRating
+                              rating={popularityData.popularity[model.id]}
+                              tooltip={t('pages.models.popularity.tooltip')}
+                              ariaLabel={t('pages.models.popularity.ariaLabel', {
+                                rating: popularityData.popularity[model.id],
+                              })}
+                            />
+                          </FlexItem>
+                        )}
                       </Flex>
                     </CardBody>
                     <CardFooter>

--- a/frontend/src/services/models.service.ts
+++ b/frontend/src/services/models.service.ts
@@ -99,6 +99,10 @@ export interface CapabilitiesResponse {
   }[];
 }
 
+export interface ModelPopularityResponse {
+  popularity: Record<string, number>;
+}
+
 class ModelsService {
   // Helper function to convert backend model to frontend model
   private convertBackendModel(backendModel: BackendModel): Model {
@@ -228,6 +232,10 @@ class ModelsService {
   async refreshModels(): Promise<any> {
     const response = await apiClient.post('/models/sync', {});
     return response;
+  }
+
+  async getModelPopularity(): Promise<ModelPopularityResponse> {
+    return apiClient.get<ModelPopularityResponse>('/models/popularity');
   }
 }
 

--- a/frontend/src/test/components/StarRating.test.tsx
+++ b/frontend/src/test/components/StarRating.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '../test-utils';
+import StarRating from '../../components/StarRating';
+
+describe('StarRating', () => {
+  it('renders the correct number of filled stars for rating 3', () => {
+    render(
+      <StarRating rating={3} tooltip="Monthly popularity" ariaLabel="3 out of 5 stars" />,
+    );
+
+    const container = screen.getByRole('img', { name: '3 out of 5 stars' });
+    expect(container).toBeInTheDocument();
+
+    const svgs = container.querySelectorAll('svg');
+    expect(svgs).toHaveLength(5);
+  });
+
+  it('renders 5 filled stars for rating 5', () => {
+    render(
+      <StarRating rating={5} tooltip="Monthly popularity" ariaLabel="5 out of 5 stars" />,
+    );
+
+    const container = screen.getByRole('img', { name: '5 out of 5 stars' });
+    expect(container).toBeInTheDocument();
+  });
+
+  it('renders 1 filled star for rating 1', () => {
+    render(
+      <StarRating rating={1} tooltip="Monthly popularity" ariaLabel="1 out of 5 stars" />,
+    );
+
+    const container = screen.getByRole('img', { name: '1 out of 5 stars' });
+    expect(container).toBeInTheDocument();
+  });
+
+  it('has correct aria-label', () => {
+    render(
+      <StarRating
+        rating={4}
+        tooltip="Monthly popularity"
+        ariaLabel="Popularity rating: 4 out of 5 stars"
+      />,
+    );
+
+    expect(
+      screen.getByRole('img', { name: 'Popularity rating: 4 out of 5 stars' }),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- Add a monthly popularity rating (1–5 stars) to each model card, computed from the last 30 days of usage data using logarithmic min-max scaling
- Backend: new `ModelPopularityService` with 1-hour in-memory cache, `GET /api/v1/models/popularity` endpoint accessible to all authenticated users
- Frontend: reusable `StarRating` component with PatternFly icons, tooltip, and ARIA support integrated into ModelsPage via React Query
- Cross-references `daily_usage_cache` model keys against the `models` table with case-insensitive matching and provider-prefix stripping
- i18n translations added for all 9 locales
- Documentation updated across CHANGELOG, CLAUDE.md files, API reference, architecture, and feature index

Closes #158

## Test plan

- [x] Integration tests: auth (unauthenticated rejected), response shape, all roles return 200
- [x] Unit tests: logarithmic scaling, single-model edge case, equal-usage edge case, provider-prefix resolution, cache hit/invalidation
- [x] Security test: endpoint included in authenticated routes coverage
- [x] Visual: star ratings appear on model cards with correct tooltip and ARIA labels
- [x] Verify models with zero usage show no stars