### PR TITLE
feat: show loading dots in chatbot while waiting for first token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Chatbot thinking indicator**: Animated loading dots in the assistant message bubble while waiting for the first token, providing visual feedback during the thinking phase of reasoning models
 - **Model Popularity Rating**: Usage-based 1–5 star rating displayed on model cards, computed from the last 30 days of usage data with logarithmic min-max scaling
   - Backend: `ModelPopularityService` with 1-hour in-memory cache, `GET /api/v1/models/popularity` endpoint (any authenticated role)
   - Frontend: reusable `StarRating` component with PatternFly icons, tooltip, and ARIA support integrated into ModelsPage via React Query

--- a/frontend/src/pages/ChatbotPage.tsx
+++ b/frontend/src/pages/ChatbotPage.tsx
@@ -871,6 +871,11 @@ const ChatbotPage: React.FC = () => {
                                     : message.role
                               }
                               content={message.content}
+                              isLoading={
+                                streamingState.isStreaming &&
+                                message.id === streamingState.streamingMessageId &&
+                                !message.content
+                              }
                               timestamp={message.timestamp.toLocaleTimeString()}
                               avatar={message.role === 'assistant' ? orb : userAvatar}
                             />


### PR DESCRIPTION
## Summary
- Adds animated loading dots in the assistant message bubble while waiting for the first token during streaming, providing visual feedback during the thinking phase of reasoning models
- Uses PatternFly Chatbot's built-in `isLoading` prop on the `Message` component, conditioned on streaming being active with no content received yet

## Test plan
- [x] Send a message to a thinking/reasoning model and verify animated dots appear before the first token
- [x] Verify dots disappear once the first token streams in
- [x] Verify normal (non-thinking) models still work correctly
- [x] Verify non-streaming mode still shows its existing loading indicator