### PR TITLE
fix: resolve broken translation keys and hardcoded strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Usage page incomplete and missing translations**: Fixed broken translation keys and hardcoded strings across the frontend (#163)
 - **Usage analytics token reconciliation**: `total_tokens` is now consistently computed as `prompt_tokens + completion_tokens` at every breakdown level (model, user, provider, API key, daily), fixing dashboard mismatches where total tokens did not equal prompt + completion tokens
 - **User usage export migrated to admin pipeline**: User export endpoint now returns per-day rows with reconciled token totals instead of a single aggregated record, with date range validation, API key ownership checks, and currency-aware cost headers
 - **Date picker popover clipping**: DatePicker calendar in Usage Data Sync tab now renders at `document.body` to prevent clipping by tab panel overflow

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -80,7 +80,7 @@ class ErrorBoundaryComponent extends Component<Props, State> {
               {t('ui.errors.somethingWentWrongDesc')}
               {process.env.NODE_ENV === 'development' && this.state.error && (
                 <details style={{ marginTop: '20px', textAlign: 'left' }}>
-                  <summary>Error details</summary>
+                  <summary>{t('ui.errors.errorDetails', 'Error details')}</summary>
                   <pre
                     style={{
                       fontSize: 'var(--pf-t--global--font--size--xs)',

--- a/frontend/src/components/NotificationDrawer.tsx
+++ b/frontend/src/components/NotificationDrawer.tsx
@@ -147,7 +147,11 @@ export const NotificationDrawer: React.FC<NotificationDrawerProps> = (_props) =>
                   >
                     <Button
                       variant="plain"
-                      aria-label={`Remove notification: ${notification.title}`}
+                      aria-label={t(
+                        'ui.notifications.removeNotification',
+                        'Remove notification: {{title}}',
+                        { title: notification.title },
+                      )}
                       onClick={(e) => {
                         e.stopPropagation();
                         removeNotification(notification.id);

--- a/frontend/src/components/backup/BackupTab.tsx
+++ b/frontend/src/components/backup/BackupTab.tsx
@@ -454,7 +454,10 @@ const BackupTab: React.FC<BackupTabProps> = ({ canManage }) => {
                 <EmptyStateBody>{t('pages.tools.backup.table.emptyDescription')}</EmptyStateBody>
               </EmptyState>
             ) : (
-              <Table aria-label="Backups table" variant="compact">
+              <Table
+                aria-label={t('pages.tools.backup.table.ariaLabel', 'Backups table')}
+                variant="compact"
+              >
                 <Thead>
                   <Tr>
                     <Th screenReaderText={t('pages.tools.backup.table.database')}>

--- a/frontend/src/components/usage/UserBudgetSummary.tsx
+++ b/frontend/src/components/usage/UserBudgetSummary.tsx
@@ -133,7 +133,7 @@ export const UserBudgetSummary: React.FC<UserBudgetSummaryProps> = ({
                   <WalletIcon />
                 </Icon>
               </FlexItem>
-              <FlexItem>{t('usage.budgetSummary.title', 'Budget (User)')}</FlexItem>
+              <FlexItem>{t('adminUsage.budgetSummary.title', 'Budget (User)')}</FlexItem>
             </Flex>
           </CardTitle>
           <CardBody>
@@ -168,10 +168,10 @@ export const UserBudgetSummary: React.FC<UserBudgetSummaryProps> = ({
   const spendText = `${formatCurrency(currentSpend)} / ${maxBudget != null ? formatCurrency(maxBudget) : t('users.budget.unlimited', 'Unlimited')}`;
 
   const cardTitle = displayName
-    ? t('usage.budgetSummary.titleForUser', 'Budget (User) — {{username}}', {
+    ? t('adminUsage.budgetSummary.titleForUser', 'Budget (User) — {{username}}', {
         username: displayName,
       })
-    : t('usage.budgetSummary.title', 'Budget (User)');
+    : t('adminUsage.budgetSummary.title', 'Budget (User)');
 
   return (
     <Card
@@ -209,7 +209,9 @@ export const UserBudgetSummary: React.FC<UserBudgetSummaryProps> = ({
               {periodLabel && (
                 <FlexItem>
                   <Content component={ContentVariants.small}>
-                    {t('usage.budgetSummary.period', 'Period: {{period}}', { period: periodLabel })}
+                    {t('adminUsage.budgetSummary.period', 'Period: {{period}}', {
+                      period: periodLabel,
+                    })}
                   </Content>
                 </FlexItem>
               )}

--- a/frontend/src/i18n/locales/de/translation.json
+++ b/frontend/src/i18n/locales/de/translation.json
@@ -84,6 +84,7 @@
   "adminUsage": {
     "accessDenied": "Zugriff verweigert",
     "activeUsers": "Aktive Benutzer",
+    "apiKeyFilterChanged": "Filtern nach {{count}} API-Schlüssel(n)",
     "apiKeysCleared": "API-Schlüssel-Filter deaktiviert - wählen Sie zuerst Benutzer aus",
     "apiKeysFilterAdjusted": "API-Schlüssel-Filter wurde möglicherweise geändert - bitte überprüfen Sie Ihre Auswahl",
     "apiKeysFilterAvailable": "API-Schlüssel-Filter ist jetzt verfügbar",
@@ -363,6 +364,9 @@
     "yearly": "Yearly",
     "yes": "Ja"
   },
+  "errors": {
+    "maxRetriesExceeded": "Maximale Anzahl an Wiederholungen überschritten"
+  },
   "models": {
     "admin": {
       "apiBaseUrl": "API-Basis-URL",
@@ -619,6 +623,8 @@
         "description": "Beschreibung",
         "expires": "Läuft ab",
         "keyDetails": "Schlüssel-Details",
+        "keyDetailsAriaLabel": "Schlüsseldetails",
+        "keyLimitsAriaLabel": "Schlüssel-Limits",
         "lastUsed": "Zuletzt verwendet",
         "rateLimit": "Ratenlimit",
         "rateLimitLabel": "Ratenlimit (Anfragen pro Minute)",
@@ -1358,6 +1364,7 @@
         "createBackup": "Sicherung erstellen",
         "creating": "Wird erstellt...",
         "table": {
+          "ariaLabel": "Sicherungstabelle",
           "database": "Datenbank",
           "timestamp": "Zeitstempel",
           "size": "Größe",
@@ -1525,6 +1532,7 @@
       "variantInfo": "Info (Blau)",
       "variantSuccess": "Erfolg (Grün)",
       "variantWarning": "Warnung (Orange)",
+      "viewBanner": "Banner ansehen",
       "visibility": "Sichtbarkeit",
       "visible": "Sichtbar",
       "usageSync": {
@@ -1752,6 +1760,7 @@
       "configLoadFailed": "Fehler beim Laden der Anwendungskonfiguration",
       "details": "Details",
       "errorCode": "Fehlercode",
+      "errorDetails": "Fehlerdetails",
       "field": "Feld",
       "general": "Ein Fehler ist aufgetreten",
       "hideDetails": "Details ausblenden",
@@ -1765,7 +1774,6 @@
       "showDetails": "Details anzeigen",
       "somethingWentWrong": "Etwas ist schiefgelaufen",
       "somethingWentWrongDesc": "Es tut uns leid, aber etwas Unerwartetes ist passiert. Bitte versuchen Sie, die Seite zu aktualisieren oder kontaktieren Sie den Support, wenn das Problem weiterhin besteht.",
-      "somethingWrong": "Etwas ist schief gelaufen",
       "statusCode": "Statuscode",
       "title": "Fehler",
       "tryRefresh": "Es tut uns leid, aber etwas Unerwartetes ist passiert. Bitte versuchen Sie, die Seite zu aktualisieren oder kontaktieren Sie den Support, wenn das Problem weiterhin besteht.",
@@ -1821,6 +1829,7 @@
       "noNotificationsFound": "Keine Benachrichtigungen gefunden",
       "notificationSrTitle": "Benachrichtigung",
       "notificationsLabel": "Benachrichtigungen",
+      "removeNotification": "Benachrichtigung entfernen: {{title}}",
       "title": "Benachrichtigungen"
     },
     "pagination": {

--- a/frontend/src/i18n/locales/elv/translation.json
+++ b/frontend/src/i18n/locales/elv/translation.json
@@ -223,6 +223,7 @@
       "totalRequests": "Pedi",
       "totalTokens": "Têw Îl"
     },
+    "apiKeyFilterChanged": "Halad dan {{count}} echui-cair(in)",
     "modelFilterChanged": "Halad dan {{count}} echui(n)",
     "noData": "Úin gwaed úir",
     "noModelData": "Úin echuin-gwaed úir",
@@ -362,6 +363,9 @@
     "weekly": "Weekly",
     "yearly": "Yearly",
     "yes": "Mae"
+  },
+  "errors": {
+    "maxRetriesExceeded": "Adlenn-athrad daen estent"
   },
   "models": {
     "admin": {
@@ -619,6 +623,8 @@
         "description": "Orthael",
         "expires": "Firn",
         "keyDetails": "Anguirel Vuin",
+        "keyDetailsAriaLabel": "Cair teithad",
+        "keyLimitsAriaLabel": "Cair glandath",
         "lastUsed": "Methed Aerlinn",
         "rateLimit": "Rond-Lim",
         "rateLimitLabel": "Rond-lim (pedi hen vuilin)",
@@ -1358,6 +1364,7 @@
         "createBackup": "Caro tirith-gwaed",
         "creating": "Carad...",
         "table": {
+          "ariaLabel": "Adlenn-bord",
           "database": "Gwaed-dagor",
           "timestamp": "Lû-anim",
           "size": "Daer",
@@ -1526,6 +1533,7 @@
       "variantSuccess": "Orthad (Calen)",
       "variantWarning": "Balch (Galadh)",
       "visibility": "Tiruith",
+      "viewBanner": "Tiro Faer",
       "visible": "Tiria",
       "usageSync": {
         "tabTitle": "Sennui Gwanur-Mathon",
@@ -1752,6 +1760,7 @@
       "configLoadFailed": "Lain amloth-orthad fael",
       "details": "En-chinn",
       "errorCode": "Ú-acharn côd",
+      "errorDetails": "Raeg teithad",
       "field": "Talaf",
       "general": "Ohtar túl",
       "hideDetails": "Thuia en-chinn",
@@ -1765,7 +1774,6 @@
       "showDetails": "Tira en-chinn",
       "somethingWentWrong": "Rhein ohtar orthant",
       "somethingWentWrongDesc": "Goheno, nan rhein ú-prestann orthant. Anno orthor dan athra-band pe pado na orthad-uin sui ohtar dartha.",
-      "somethingWrong": "Rhein ohtar orthant",
       "statusCode": "Stat côd",
       "title": "Ohtar",
       "tryRefresh": "Goheno, nan rhein ú-prestann orthant. Anno athra-band i band pe pado na orthad-uin sui ohtar dartha.",
@@ -1821,6 +1829,7 @@
       "noNotificationsFound": "Ú-ennen thúl",
       "notificationSrTitle": "Thúl",
       "notificationsLabel": "Thúl",
+      "removeNotification": "Dago prestannen: {{title}}",
       "title": "Thúl"
     },
     "pagination": {

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -223,6 +223,7 @@
       "totalRequests": "Requests",
       "totalTokens": "Total Tokens"
     },
+    "apiKeyFilterChanged": "Filtering by {{count}} API key(s)",
     "modelFilterChanged": "Filtering by {{count}} model(s)",
     "noData": "No data available",
     "noModelData": "No model data available",
@@ -362,6 +363,9 @@
     "weekly": "Weekly",
     "yearly": "Yearly",
     "yes": "Yes"
+  },
+  "errors": {
+    "maxRetriesExceeded": "Maximum retries exceeded"
   },
   "models": {
     "admin": {
@@ -619,6 +623,8 @@
         "description": "Description",
         "expires": "Expires",
         "keyDetails": "Key Details",
+        "keyDetailsAriaLabel": "Key details",
+        "keyLimitsAriaLabel": "Key limits",
         "lastUsed": "Last Used",
         "rateLimit": "Rate Limit",
         "rateLimitLabel": "Rate Limit (requests per minute)",
@@ -1369,6 +1375,7 @@
           "alreadyRunning": "A backup is already in progress."
         },
         "table": {
+          "ariaLabel": "Backups table",
           "database": "Database",
           "timestamp": "Timestamp",
           "size": "Size",
@@ -1484,6 +1491,7 @@
       "saveBanner": "Save Banner",
       "saving": "Saving...",
       "showBanner": "Show Banner",
+      "viewBanner": "View Banner",
       "successfulUpdates": "Successful",
       "syncError": "Failed to synchronize models",
       "syncErrorGeneric": "An error occurred while synchronizing models. Please try again.",
@@ -1751,6 +1759,7 @@
       "componentLoadingErrorDesc": "Failed to load this component. Please try refreshing the page.",
       "configLoadFailed": "Failed to load application configuration",
       "details": "Details",
+      "errorDetails": "Error details",
       "errorCode": "Error Code",
       "field": "Field",
       "general": "An error occurred",
@@ -1820,6 +1829,7 @@
       "noNotificationsFound": "No notifications found",
       "notificationSrTitle": "Notification",
       "notificationsLabel": "Notifications",
+      "removeNotification": "Remove notification: {{title}}",
       "title": "Notifications"
     },
     "pagination": {

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -84,6 +84,7 @@
   "adminUsage": {
     "accessDenied": "Acceso denegado",
     "activeUsers": "Usuarios activos",
+    "apiKeyFilterChanged": "Filtrando por {{count}} clave(s) API",
     "apiKeysCleared": "Filtro de claves API deshabilitado - seleccione usuarios primero",
     "apiKeysFilterAdjusted": "El filtro de claves API puede haber cambiado - por favor revise las selecciones",
     "apiKeysFilterAvailable": "El filtro de claves API ahora está disponible",
@@ -363,6 +364,9 @@
     "yearly": "Yearly",
     "yes": "Sí"
   },
+  "errors": {
+    "maxRetriesExceeded": "Número máximo de reintentos excedido"
+  },
   "models": {
     "admin": {
       "apiBaseUrl": "URL Base de API",
@@ -619,6 +623,8 @@
         "description": "Descripción",
         "expires": "Expira",
         "keyDetails": "Detalles de Clave",
+        "keyDetailsAriaLabel": "Detalles de la clave",
+        "keyLimitsAriaLabel": "Límites de la clave",
         "lastUsed": "Último Uso",
         "rateLimit": "Límite de Velocidad",
         "rateLimitLabel": "Límite de velocidad (solicitudes por minuto)",
@@ -1358,6 +1364,7 @@
         "createBackup": "Crear copia de seguridad",
         "creating": "Creando...",
         "table": {
+          "ariaLabel": "Tabla de copias de seguridad",
           "database": "Base de datos",
           "timestamp": "Fecha y hora",
           "size": "Tamaño",
@@ -1525,6 +1532,7 @@
       "variantInfo": "Info (Azul)",
       "variantSuccess": "Éxito (Verde)",
       "variantWarning": "Advertencia (Naranja)",
+      "viewBanner": "Ver Banner",
       "visibility": "Visibilidad",
       "visible": "Visible",
       "usageSync": {
@@ -1752,6 +1760,7 @@
       "configLoadFailed": "Error al cargar la configuración de la aplicación",
       "details": "Detalles",
       "errorCode": "Código de error",
+      "errorDetails": "Detalles del error",
       "field": "Campo",
       "general": "Ocurrió un error",
       "hideDetails": "Ocultar detalles",
@@ -1765,7 +1774,6 @@
       "showDetails": "Mostrar detalles",
       "somethingWentWrong": "Algo salió mal",
       "somethingWentWrongDesc": "Lo sentimos, pero algo inesperado ocurrió. Por favor, intenta actualizar la página o contacta con soporte si el problema persiste.",
-      "somethingWrong": "Algo salió mal",
       "statusCode": "Código de estado",
       "title": "Error",
       "tryRefresh": "Lo sentimos, pero algo inesperado ocurrió. Por favor, intenta actualizar la página o contacta con soporte si el problema persiste.",
@@ -1821,6 +1829,7 @@
       "noNotificationsFound": "No se encontraron notificaciones",
       "notificationSrTitle": "Notificación",
       "notificationsLabel": "Notificaciones",
+      "removeNotification": "Eliminar notificación: {{title}}",
       "title": "Notificaciones"
     },
     "pagination": {

--- a/frontend/src/i18n/locales/fr/translation.json
+++ b/frontend/src/i18n/locales/fr/translation.json
@@ -86,6 +86,7 @@
     "activeUsers": "Utilisateurs actifs",
     "apiKeysCleared": "Filtre de clés API désactivé - sélectionnez d'abord des utilisateurs",
     "apiKeysFilterAdjusted": "Le filtre de clés API a peut-être changé - veuillez vérifier les sélections",
+    "apiKeyFilterChanged": "Filtrage par {{count}} clé(s) API",
     "apiKeysFilterAvailable": "Le filtre de clés API est maintenant disponible",
     "budgetSummary": {
       "period": "Période : {{period}}",
@@ -363,6 +364,9 @@
     "yearly": "Yearly",
     "yes": "Oui"
   },
+  "errors": {
+    "maxRetriesExceeded": "Nombre maximum de tentatives dépassé"
+  },
   "models": {
     "admin": {
       "apiBaseUrl": "URL de Base API",
@@ -619,6 +623,8 @@
         "description": "Description",
         "expires": "Expire",
         "keyDetails": "Détails de la Clé",
+        "keyDetailsAriaLabel": "Détails de la clé",
+        "keyLimitsAriaLabel": "Limites de la clé",
         "lastUsed": "Dernière Utilisation",
         "rateLimit": "Limite de Débit",
         "rateLimitLabel": "Limite de Débit (requêtes par minute)",
@@ -1358,12 +1364,13 @@
         "createBackup": "Créer une sauvegarde",
         "creating": "Création en cours...",
         "table": {
-          "database": "Base de données",
-          "timestamp": "Date et heure",
-          "size": "Taille",
           "actions": "Actions",
+          "ariaLabel": "Tableau des sauvegardes",
+          "database": "Base de données",
           "empty": "Aucune sauvegarde trouvée",
-          "emptyDescription": "Créez une sauvegarde pour commencer."
+          "emptyDescription": "Créez une sauvegarde pour commencer.",
+          "size": "Taille",
+          "timestamp": "Date et heure"
         },
         "download": "Télécharger",
         "restore": "Restaurer",
@@ -1525,6 +1532,7 @@
       "variantInfo": "Info (Bleu)",
       "variantSuccess": "Succès (Vert)",
       "variantWarning": "Avertissement (Orange)",
+      "viewBanner": "Voir la Bannière",
       "visibility": "Visibilité",
       "visible": "Visible",
       "usageSync": {
@@ -1752,6 +1760,7 @@
       "configLoadFailed": "Échec du chargement de la configuration de l'application",
       "details": "Détails",
       "errorCode": "Code d'erreur",
+      "errorDetails": "Détails de l'erreur",
       "field": "Champ",
       "general": "Une erreur s'est produite",
       "hideDetails": "Masquer les détails",
@@ -1765,7 +1774,6 @@
       "showDetails": "Afficher les détails",
       "somethingWentWrong": "Une erreur s'est produite",
       "somethingWentWrongDesc": "Nous sommes désolés, mais quelque chose d'inattendu s'est produit. Veuillez essayer d'actualiser la page ou contacter le support si le problème persiste.",
-      "somethingWrong": "Quelque chose s'est mal passé",
       "statusCode": "Code de statut",
       "title": "Erreur",
       "tryRefresh": "Nous sommes désolés, mais quelque chose d'inattendu s'est produit. Veuillez essayer d'actualiser la page ou contacter le support si le problème persiste.",
@@ -1820,6 +1828,7 @@
       "noNotificationsDescription": "Il n'y a actuellement aucune notification.",
       "noNotificationsFound": "Aucune notification trouvée",
       "notificationSrTitle": "Notification",
+      "removeNotification": "Supprimer la notification : {{title}}",
       "notificationsLabel": "Notifications",
       "title": "Notifications"
     },

--- a/frontend/src/i18n/locales/it/translation.json
+++ b/frontend/src/i18n/locales/it/translation.json
@@ -86,6 +86,7 @@
     "activeUsers": "Utenti Attivi",
     "apiKeysCleared": "Filtro chiavi API disabilitato - seleziona prima gli utenti",
     "apiKeysFilterAdjusted": "Il filtro chiavi API potrebbe essere cambiato - controlla le selezioni",
+    "apiKeyFilterChanged": "Filtro per {{count}} chiave/i API",
     "apiKeysFilterAvailable": "Il filtro chiavi API è ora disponibile",
     "budgetSummary": {
       "period": "Periodo: {{period}}",
@@ -363,6 +364,9 @@
     "yearly": "Yearly",
     "yes": "Sì"
   },
+  "errors": {
+    "maxRetriesExceeded": "Numero massimo di tentativi superato"
+  },
   "models": {
     "admin": {
       "apiBaseUrl": "URL Base API",
@@ -619,6 +623,8 @@
         "description": "Descrizione",
         "expires": "Scade",
         "keyDetails": "Dettagli Chiave",
+        "keyDetailsAriaLabel": "Dettagli della chiave",
+        "keyLimitsAriaLabel": "Limiti della chiave",
         "lastUsed": "Ultimo Utilizzo",
         "rateLimit": "Limite di Frequenza",
         "rateLimitLabel": "Limite di frequenza (richieste al minuto)",
@@ -1358,12 +1364,13 @@
         "createBackup": "Crea backup",
         "creating": "Creazione in corso...",
         "table": {
-          "database": "Database",
-          "timestamp": "Data e ora",
-          "size": "Dimensione",
           "actions": "Azioni",
+          "ariaLabel": "Tabella dei backup",
+          "database": "Database",
           "empty": "Nessun backup trovato",
-          "emptyDescription": "Crea un backup per iniziare."
+          "emptyDescription": "Crea un backup per iniziare.",
+          "size": "Dimensione",
+          "timestamp": "Data e ora"
         },
         "download": "Scarica",
         "restore": "Ripristina",
@@ -1525,6 +1532,7 @@
       "variantInfo": "Info (Blu)",
       "variantSuccess": "Successo (Verde)",
       "variantWarning": "Avvertimento (Arancione)",
+      "viewBanner": "Visualizza Banner",
       "visibility": "Visibilità",
       "visible": "Visibile",
       "usageSync": {
@@ -1752,6 +1760,7 @@
       "configLoadFailed": "Impossibile caricare la configurazione dell'applicazione",
       "details": "Dettagli",
       "errorCode": "Codice errore",
+      "errorDetails": "Dettagli dell'errore",
       "field": "Campo",
       "general": "Si è verificato un errore",
       "hideDetails": "Nascondi dettagli",
@@ -1765,7 +1774,6 @@
       "showDetails": "Mostra dettagli",
       "somethingWentWrong": "Qualcosa è andato storto",
       "somethingWentWrongDesc": "Ci dispiace, ma si è verificato qualcosa di inaspettato. Prova ad aggiornare la pagina o contatta il supporto se il problema persiste.",
-      "somethingWrong": "Qualcosa è andato storto",
       "statusCode": "Codice di stato",
       "title": "Errore",
       "tryRefresh": "Ci dispiace, ma si è verificato qualcosa di inaspettato. Prova ad aggiornare la pagina o contatta il supporto se il problema persiste.",
@@ -1820,6 +1828,7 @@
       "noNotificationsDescription": "Al momento non ci sono notifiche.",
       "noNotificationsFound": "Nessuna notifica trovata",
       "notificationSrTitle": "Notifica",
+      "removeNotification": "Rimuovi notifica: {{title}}",
       "notificationsLabel": "Notifiche",
       "title": "Notifiche"
     },

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -86,6 +86,7 @@
     "activeUsers": "アクティブユーザー",
     "apiKeysCleared": "APIキーフィルターが無効化されました - 最初にユーザーを選択してください",
     "apiKeysFilterAdjusted": "APIキーフィルターが変更された可能性があります - 選択内容を確認してください",
+    "apiKeyFilterChanged": "{{count}}個のAPIキーでフィルタリング中",
     "apiKeysFilterAvailable": "APIキーフィルターが利用可能になりました",
     "budgetSummary": {
       "period": "期間: {{period}}",
@@ -363,6 +364,9 @@
     "yearly": "Yearly",
     "yes": "はい"
   },
+  "errors": {
+    "maxRetriesExceeded": "最大リトライ回数を超えました"
+  },
   "models": {
     "admin": {
       "apiBaseUrl": "APIベースURL",
@@ -619,6 +623,8 @@
         "description": "説明",
         "expires": "有効期限",
         "keyDetails": "キー詳細",
+        "keyDetailsAriaLabel": "キーの詳細",
+        "keyLimitsAriaLabel": "キーの制限",
         "lastUsed": "最終使用",
         "rateLimit": "レート制限",
         "rateLimitLabel": "レート制限（リクエスト/分）",
@@ -1358,6 +1364,7 @@
         "createBackup": "バックアップを作成",
         "creating": "作成中...",
         "table": {
+          "ariaLabel": "バックアップテーブル",
           "database": "データベース",
           "timestamp": "日時",
           "size": "サイズ",
@@ -1542,7 +1549,8 @@
           "success": "{{total}}日分のうち{{processed}}日分の使用データを正常に再同期しました。",
           "errorTitle": "使用データの同期に失敗しました"
         }
-      }
+      },
+      "viewBanner": "バナーを閲覧"
     },
     "usage": {
       "ariaLabels": {
@@ -1752,6 +1760,7 @@
       "configLoadFailed": "アプリケーション設定の読み込みに失敗しました",
       "details": "詳細",
       "errorCode": "エラーコード",
+      "errorDetails": "エラーの詳細",
       "field": "フィールド",
       "general": "エラーが発生しました",
       "hideDetails": "詳細を非表示",
@@ -1765,7 +1774,6 @@
       "showDetails": "詳細を表示",
       "somethingWentWrong": "問題が発生しました",
       "somethingWentWrongDesc": "申し訳ございませんが、予期しない問題が発生しました。ページを更新するか、問題が続く場合はサポートにお問い合わせください。",
-      "somethingWrong": "問題が発生しました",
       "statusCode": "ステータスコード",
       "title": "エラー",
       "tryRefresh": "申し訳ございませんが、予期しない問題が発生しました。ページを更新するか、問題が続く場合はサポートにお問い合わせください。",
@@ -1821,6 +1829,7 @@
       "noNotificationsFound": "通知が見つかりません",
       "notificationSrTitle": "通知",
       "notificationsLabel": "通知",
+      "removeNotification": "通知を削除: {{title}}",
       "title": "通知"
     },
     "pagination": {

--- a/frontend/src/i18n/locales/ko/translation.json
+++ b/frontend/src/i18n/locales/ko/translation.json
@@ -86,6 +86,7 @@
     "activeUsers": "활성 사용자",
     "apiKeysCleared": "API 키 필터 비활성화됨 - 먼저 사용자를 선택하세요",
     "apiKeysFilterAdjusted": "API 키 필터가 변경되었을 수 있습니다 - 선택 사항을 확인해 주세요",
+    "apiKeyFilterChanged": "{{count}}개 API 키로 필터링 중",
     "apiKeysFilterAvailable": "이제 API 키 필터를 사용할 수 있습니다",
     "budgetSummary": {
       "period": "기간: {{period}}",
@@ -363,6 +364,9 @@
     "yearly": "Yearly",
     "yes": "예"
   },
+  "errors": {
+    "maxRetriesExceeded": "최대 재시도 횟수 초과"
+  },
   "models": {
     "admin": {
       "apiBaseUrl": "API 기본 URL",
@@ -619,6 +623,8 @@
         "description": "설명",
         "expires": "만료",
         "keyDetails": "키 상세 정보",
+        "keyDetailsAriaLabel": "키 상세 정보",
+        "keyLimitsAriaLabel": "키 제한",
         "lastUsed": "마지막 사용",
         "rateLimit": "속도 제한",
         "rateLimitLabel": "속도 제한 (분당 요청)",
@@ -1358,6 +1364,7 @@
         "createBackup": "백업 생성",
         "creating": "생성 중...",
         "table": {
+          "ariaLabel": "백업 테이블",
           "database": "데이터베이스",
           "timestamp": "날짜 및 시간",
           "size": "크기",
@@ -1542,7 +1549,8 @@
           "success": "{{total}}일 중 {{processed}}일치 사용 데이터를 성공적으로 재동기화했습니다.",
           "errorTitle": "사용 데이터 동기화 실패"
         }
-      }
+      },
+      "viewBanner": "배너 보기"
     },
     "usage": {
       "ariaLabels": {
@@ -1752,6 +1760,7 @@
       "configLoadFailed": "애플리케이션 설정을 로드하는 데 실패했습니다",
       "details": "세부사항",
       "errorCode": "오류 코드",
+      "errorDetails": "오류 상세 정보",
       "field": "필드",
       "general": "오류가 발생했습니다",
       "hideDetails": "세부사항 숨기기",
@@ -1759,19 +1768,12 @@
       "rateLimited": "요청 제한 초과",
       "rateLimitedDescription": "너무 많은 요청입니다. 제한: {{timeWindow}}당 {{limit}}회. {{retryAfter}}초 기다린 후 다시 시도하세요.",
       "requestId": "요청 ID",
-      "restrictedAccessHelp": "사용자는 액세스를 요청해야 하며 관리자의 승인을 받아야 합니다",
-      "restrictedAccessLabel": "관리자 승인 필요",
-      "restrictedAccessWarning": {
-        "message": "이 설정은 이 모델의 모든 활성 구독을 대기 상태로 변경하고 기존 API 키에서 모델을 제거합니다. 사용자는 다시 승인을 받아야 합니다.",
-        "title": "제한된 액세스를 활성화하시겠습니까?"
-      },
       "retry": "다시 시도",
       "retryAction": "실패한 작업을 다시 시도",
       "retryAfter": "{{seconds}}초 후에 다시 시도해 주세요",
       "showDetails": "세부사항 보기",
       "somethingWentWrong": "문제가 발생했습니다",
       "somethingWentWrongDesc": "죄송합니다. 예상치 못한 문제가 발생했습니다. 페이지를 새로고침하거나 문제가 지속되면 지원팀에 문의해 주세요.",
-      "somethingWrong": "문제가 발생했습니다",
       "statusCode": "상태 코드",
       "title": "오류",
       "tryRefresh": "죄송합니다만 예기치 않은 문제가 발생했습니다. 페이지를 새로고침하거나 문제가 지속되면 지원팀에 문의하세요.",
@@ -1827,6 +1829,7 @@
       "noNotificationsFound": "알림을 찾을 수 없습니다",
       "notificationSrTitle": "알림",
       "notificationsLabel": "알림",
+      "removeNotification": "알림 삭제: {{title}}",
       "title": "알림"
     },
     "pagination": {

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -223,6 +223,7 @@
       "totalRequests": "请求数",
       "totalTokens": "总令牌数"
     },
+    "apiKeyFilterChanged": "按 {{count}} 个 API 密钥筛选",
     "modelFilterChanged": "按 {{count}} 个模型筛选",
     "noData": "无可用数据",
     "noModelData": "无可用模型数据",
@@ -362,6 +363,9 @@
     "weekly": "Weekly",
     "yearly": "Yearly",
     "yes": "是"
+  },
+  "errors": {
+    "maxRetriesExceeded": "已超过最大重试次数"
   },
   "models": {
     "admin": {
@@ -619,6 +623,8 @@
         "description": "描述",
         "expires": "过期时间",
         "keyDetails": "密钥详情",
+        "keyDetailsAriaLabel": "密钥详情",
+        "keyLimitsAriaLabel": "密钥限制",
         "lastUsed": "最后使用",
         "rateLimit": "速率限制",
         "rateLimitLabel": "速率限制（每分钟请求数）",
@@ -1358,6 +1364,7 @@
         "createBackup": "创建备份",
         "creating": "创建中...",
         "table": {
+          "ariaLabel": "备份表",
           "database": "数据库",
           "timestamp": "时间",
           "size": "大小",
@@ -1526,6 +1533,7 @@
       "variantSuccess": "成功（绿色）",
       "variantWarning": "警告（橙色）",
       "visibility": "可见性",
+      "viewBanner": "查看横幅",
       "visible": "可见",
       "usageSync": {
         "tabTitle": "使用数据同步",
@@ -1752,6 +1760,7 @@
       "configLoadFailed": "加载应用程序配置失败",
       "details": "详情",
       "errorCode": "错误代码",
+      "errorDetails": "错误详情",
       "field": "字段",
       "general": "发生了错误",
       "hideDetails": "隐藏详情",
@@ -1765,7 +1774,6 @@
       "showDetails": "显示详情",
       "somethingWentWrong": "出现问题",
       "somethingWentWrongDesc": "抱歉，发生了意外情况。请尝试刷新页面，如果问题仍然存在，请联系支持。",
-      "somethingWrong": "出现问题",
       "statusCode": "状态代码",
       "title": "错误",
       "tryRefresh": "抱歉，发生了意外情况。请尝试刷新页面，如果问题仍然存在，请联系支持。",
@@ -1820,6 +1828,7 @@
       "noNotificationsDescription": "当前没有通知。",
       "noNotificationsFound": "未找到通知",
       "notificationSrTitle": "通知",
+      "removeNotification": "删除通知：{{title}}",
       "notificationsLabel": "通知",
       "title": "通知"
     },

--- a/frontend/src/pages/ApiKeysPage.tsx
+++ b/frontend/src/pages/ApiKeysPage.tsx
@@ -1915,7 +1915,14 @@ const ApiKeysPage: React.FC = () => {
                       <Td colSpan={2} style={{ padding: 0 }}>
                         <Split hasGutter>
                           <SplitItem isFilled>
-                            <Table aria-label="Key details left" variant="compact" borders={false}>
+                            <Table
+                              aria-label={t(
+                                'pages.apiKeys.labels.keyDetailsAriaLabel',
+                                'Key details',
+                              )}
+                              variant="compact"
+                              borders={false}
+                            >
                               <Tbody>
                                 <Tr>
                                   <Th scope="row">
@@ -1952,7 +1959,14 @@ const ApiKeysPage: React.FC = () => {
                             </Table>
                           </SplitItem>
                           <SplitItem isFilled>
-                            <Table aria-label="Key limits" variant="compact" borders={false}>
+                            <Table
+                              aria-label={t(
+                                'pages.apiKeys.labels.keyLimitsAriaLabel',
+                                'Key limits',
+                              )}
+                              variant="compact"
+                              borders={false}
+                            >
                               <Tbody>
                                 <Tr>
                                   <Th scope="row">
@@ -2108,7 +2122,10 @@ curl -X POST ${litellmApiUrl}/v1/chat/completions \\
                   title={t('pages.apiKeys.modals.keyArchived', 'Key Archived')}
                   style={{ marginTop: '1rem' }}
                 >
-                  {t('pages.apiKeys.messages.keyArchivedMessage', 'This key has been archived and is no longer active.')}
+                  {t(
+                    'pages.apiKeys.messages.keyArchivedMessage',
+                    'This key has been archived and is no longer active.',
+                  )}
                 </Alert>
               )}
             </>

--- a/frontend/src/pages/UsagePage.tsx
+++ b/frontend/src/pages/UsagePage.tsx
@@ -115,7 +115,7 @@ const UsagePage: React.FC = () => {
       enabled: !!filters.startDate && !!filters.endDate,
       onError: (error) => {
         handleError(error, {
-          fallbackMessageKey: 'usage.errors.fetchMetrics',
+          fallbackMessageKey: 'adminUsage.errors.fetchMetrics',
         });
       },
       select: (data) => transformAnalyticsForComponent(data),
@@ -130,7 +130,7 @@ const UsagePage: React.FC = () => {
   const handleModelFilterChange = (modelIds: string[]) => {
     setSelectedModelIds(modelIds);
     announce(
-      t('usage.modelFilterChanged', 'Filtering by {{count}} model(s)', {
+      t('adminUsage.modelFilterChanged', 'Filtering by {{count}} model(s)', {
         count: modelIds.length,
       }),
     );
@@ -139,7 +139,7 @@ const UsagePage: React.FC = () => {
   const handleApiKeyFilterChange = (apiKeyIds: string[]) => {
     setSelectedApiKeyIds(apiKeyIds);
     announce(
-      t('usage.apiKeyFilterChanged', 'Filtering by {{count}} API key(s)', {
+      t('adminUsage.apiKeyFilterChanged', 'Filtering by {{count}} API key(s)', {
         count: apiKeyIds.length,
       }),
     );
@@ -184,7 +184,7 @@ const UsagePage: React.FC = () => {
               onPresetChange={(preset) => {
                 setDatePreset(preset);
                 announce(
-                  t('usage.dateRangeChanged', 'Date range changed to {{preset}}', { preset }),
+                  t('adminUsage.dateRangeChanged', 'Date range changed to {{preset}}', { preset }),
                 );
               }}
               customStartDate={customStartDate}


### PR DESCRIPTION
## Summary
- Fix Usage page components referencing non-existent `usage.*` translation namespace — corrected to use existing `adminUsage.*` keys, which caused non-English locales to always show English fallback text
- Replace hardcoded user-facing strings with `t()` calls in ErrorBoundary, NotificationDrawer, BackupTab, and ApiKeysPage
- Add missing translation keys and translations across all 9 locales
- Remove orphaned keys from non-English locale files

Closes #163

## Test plan
- [x] `npm run check:translations` — all 8 locales at 100% (1736/1736 keys)
- [x] TypeScript compiles clean (`npx tsc --noEmit`)
- [x] ESLint passes on all modified files
- [x] All tests pass (1346 passed, 2 pre-existing failures in accessibility suite)
- [x] Switch to a non-English locale and verify Usage page shows translated text