### PR TITLE
feat: add column sorting to Users Management table

### DIFF
--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -15,7 +15,17 @@ interface UserListQuery {
   search?: string;
   role?: string;
   isActive?: boolean;
+  sortBy?: string;
+  sortOrder?: 'asc' | 'desc';
 }
+
+const SORTABLE_COLUMNS: Record<string, string> = {
+  username: 'username',
+  email: 'email',
+  fullName: 'full_name',
+  status: 'is_active',
+  createdAt: 'created_at',
+};
 
 interface FastifyError extends Error {
   statusCode?: number;
@@ -345,6 +355,8 @@ const usersRoutes: FastifyPluginAsync = async (fastify) => {
           search: { type: 'string' },
           role: { type: 'string' },
           isActive: { type: 'boolean' },
+          sortBy: { type: 'string', enum: ['username', 'email', 'fullName', 'status', 'createdAt'] },
+          sortOrder: { type: 'string', enum: ['asc', 'desc'], default: 'asc' },
         },
       },
       response: {
@@ -382,7 +394,7 @@ const usersRoutes: FastifyPluginAsync = async (fastify) => {
     },
     preHandler: [fastify.authenticate, fastify.requirePermission('users:read')],
     handler: async (request, _reply) => {
-      const { page = 1, limit = 20, search, role, isActive } = request.query as UserListQuery;
+      const { page = 1, limit = 20, search, role, isActive, sortBy, sortOrder = 'asc' } = request.query as UserListQuery;
 
       try {
         const offset = (page - 1) * limit;
@@ -410,7 +422,9 @@ const usersRoutes: FastifyPluginAsync = async (fastify) => {
           params.push(isActive);
         }
 
-        query += ` ORDER BY created_at DESC LIMIT $${params.length + 1} OFFSET $${params.length + 2}`;
+        const orderColumn = (sortBy && SORTABLE_COLUMNS[sortBy]) || 'created_at';
+        const orderDirection = sortOrder === 'desc' ? 'DESC' : 'ASC';
+        query += ` ORDER BY ${orderColumn} ${orderDirection} LIMIT $${params.length + 1} OFFSET $${params.length + 2}`;
         params.push(limit, offset);
 
         // Get count

--- a/frontend/src/pages/UsersPage.tsx
+++ b/frontend/src/pages/UsersPage.tsx
@@ -39,7 +39,7 @@ import {
   TimesCircleIcon,
   UserIcon,
 } from '@patternfly/react-icons';
-import { Table, Thead, Tbody, Tr, Th, Td, ActionsColumn } from '@patternfly/react-table';
+import { Table, Thead, Tbody, Tr, Th, Td, ActionsColumn, ThProps } from '@patternfly/react-table';
 import { useAuth } from '../contexts/AuthContext';
 import { useNotifications } from '../contexts/NotificationContext';
 import { usersService } from '../services/users.service';
@@ -63,6 +63,8 @@ const UsersPage: React.FC = () => {
   const [isStatusFilterOpen, setIsStatusFilterOpen] = useState(false);
   const [page, setPage] = useState(parseInt(searchParams.get('page') || '1', 10));
   const [perPage, setPerPage] = useState(parseInt(searchParams.get('limit') || '10', 10));
+  const [sortBy, setSortBy] = useState(searchParams.get('sortBy') || '');
+  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>((searchParams.get('sortOrder') as 'asc' | 'desc') || 'asc');
 
   // Modal focus management ref
   const editModalTriggerRef = useRef<HTMLElement | null>(null);
@@ -79,6 +81,7 @@ const UsersPage: React.FC = () => {
     ...(roleFilter && { role: roleFilter }),
     ...(statusFilter === 'active' && { isActive: true }),
     ...(statusFilter === 'inactive' && { isActive: false }),
+    ...(sortBy && { sortBy, sortOrder }),
   };
 
   // Fetch users data with React Query
@@ -109,9 +112,11 @@ const UsersPage: React.FC = () => {
     if (searchValue) newParams.set('search', searchValue);
     if (roleFilter) newParams.set('role', roleFilter);
     if (statusFilter) newParams.set('status', statusFilter);
+    if (sortBy) newParams.set('sortBy', sortBy);
+    if (sortBy) newParams.set('sortOrder', sortOrder);
 
     setSearchParams(newParams);
-  }, [page, perPage, searchValue, roleFilter, statusFilter, setSearchParams]);
+  }, [page, perPage, searchValue, roleFilter, statusFilter, sortBy, sortOrder, setSearchParams]);
 
   // Helper functions
   const getStatusBadge = (isActive: boolean) => {
@@ -170,6 +175,22 @@ const UsersPage: React.FC = () => {
     }
     setIsEditModalOpen(true);
   };
+
+  const handleSort = (columnKey: string) => {
+    const newOrder = sortBy === columnKey && sortOrder === 'asc' ? 'desc' : 'asc';
+    setSortBy(columnKey);
+    setSortOrder(newOrder);
+    setPage(1);
+  };
+
+  const getSortParams = (columnKey: string): ThProps['sort'] => ({
+    sortBy:
+      sortBy === columnKey
+        ? { index: 0, direction: sortOrder }
+        : {},
+    onSort: () => handleSort(columnKey),
+    columnIndex: 0,
+  });
 
   const clearAllFilters = () => {
     setSearchValue('');
@@ -388,11 +409,11 @@ const UsersPage: React.FC = () => {
                   </caption>
                   <Thead>
                     <Tr>
-                      <Th width={20}>{t('users.table.username')}</Th>
-                      <Th width={25}>{t('users.table.email')}</Th>
-                      <Th width={20}>{t('users.table.fullName')}</Th>
+                      <Th width={20} sort={getSortParams('username')}>{t('users.table.username')}</Th>
+                      <Th width={25} sort={getSortParams('email')}>{t('users.table.email')}</Th>
+                      <Th width={20} sort={getSortParams('fullName')}>{t('users.table.fullName')}</Th>
                       <Th width={25}>{t('users.table.roles')}</Th>
-                      <Th width={10}>{t('users.table.status')}</Th>
+                      <Th width={10} sort={getSortParams('status')}>{t('users.table.status')}</Th>
                       <Th screenReaderText={t('users.table.actions')}></Th>
                     </Tr>
                   </Thead>

--- a/frontend/src/services/users.service.ts
+++ b/frontend/src/services/users.service.ts
@@ -41,6 +41,12 @@ export class UsersService {
     if (typeof params.isActive === 'boolean') {
       searchParams.append('isActive', params.isActive.toString());
     }
+    if (params.sortBy) {
+      searchParams.append('sortBy', params.sortBy);
+    }
+    if (params.sortOrder) {
+      searchParams.append('sortOrder', params.sortOrder);
+    }
 
     const queryString = searchParams.toString();
     const url = queryString ? `/users?${queryString}` : '/users';

--- a/frontend/src/test/components/UsersPage.test.tsx
+++ b/frontend/src/test/components/UsersPage.test.tsx
@@ -864,6 +864,130 @@ describe('UsersPage', () => {
     });
   });
 
+  describe('4b. Column Sorting', () => {
+    it('should render sortable column headers for Username, Email, Full Name, and Status', () => {
+      renderWithAuth(<UsersPage />, { user: mockAdminUser });
+
+      const headers = screen.getAllByRole('columnheader');
+      // 6 columns: Username, Email, Full Name, Roles, Status, Actions
+      expect(headers).toHaveLength(6);
+
+      // Sortable columns should contain a button (PatternFly SortColumn renders a button)
+      const usernameHeader = headers[0];
+      const emailHeader = headers[1];
+      const fullNameHeader = headers[2];
+      const rolesHeader = headers[3];
+      const statusHeader = headers[4];
+
+      expect(within(usernameHeader).getByRole('button')).toBeInTheDocument();
+      expect(within(emailHeader).getByRole('button')).toBeInTheDocument();
+      expect(within(fullNameHeader).getByRole('button')).toBeInTheDocument();
+      expect(within(statusHeader).getByRole('button')).toBeInTheDocument();
+
+      // Roles column should NOT be sortable (no button)
+      expect(within(rolesHeader).queryByRole('button')).not.toBeInTheDocument();
+    });
+
+    it('should update URL params when a sortable column header is clicked', async () => {
+      const user = userEvent.setup();
+      renderWithAuth(<UsersPage />, { user: mockAdminUser });
+
+      const headers = screen.getAllByRole('columnheader');
+      const usernameButton = within(headers[0]).getByRole('button');
+      await user.click(usernameButton);
+
+      await waitFor(() => {
+        const calls = mockSetSearchParams.mock.calls;
+        const lastCall = calls[calls.length - 1];
+        const params = lastCall[0] as URLSearchParams;
+        expect(params.get('sortBy')).toBe('username');
+        expect(params.get('sortOrder')).toBe('asc');
+      });
+    });
+
+    it('should toggle sort direction when clicking the same column again', async () => {
+      const user = userEvent.setup();
+      renderWithAuth(<UsersPage />, { user: mockAdminUser });
+
+      const headers = screen.getAllByRole('columnheader');
+      const usernameButton = within(headers[0]).getByRole('button');
+
+      // First click — asc
+      await user.click(usernameButton);
+      await waitFor(() => {
+        const calls = mockSetSearchParams.mock.calls;
+        const params = calls[calls.length - 1][0] as URLSearchParams;
+        expect(params.get('sortOrder')).toBe('asc');
+      });
+
+      // Second click — desc
+      await user.click(usernameButton);
+      await waitFor(() => {
+        const calls = mockSetSearchParams.mock.calls;
+        const params = calls[calls.length - 1][0] as URLSearchParams;
+        expect(params.get('sortOrder')).toBe('desc');
+      });
+    });
+
+    it('should reset to page 1 when sort column is clicked', async () => {
+      const user = userEvent.setup();
+      renderWithAuth(<UsersPage />, { user: mockAdminUser });
+
+      const headers = screen.getAllByRole('columnheader');
+      const emailButton = within(headers[1]).getByRole('button');
+      await user.click(emailButton);
+
+      await waitFor(() => {
+        const calls = mockSetSearchParams.mock.calls;
+        const params = calls[calls.length - 1][0] as URLSearchParams;
+        // Page should not be set (defaults to 1)
+        expect(params.has('page')).toBe(false);
+      });
+    });
+
+    it('should include sort params in React Query key', async () => {
+      const user = userEvent.setup();
+      renderWithAuth(<UsersPage />, { user: mockAdminUser });
+
+      const headers = screen.getAllByRole('columnheader');
+      const fullNameButton = within(headers[2]).getByRole('button');
+      await user.click(fullNameButton);
+
+      await waitFor(() => {
+        const lastCall = vi.mocked(useQuery).mock.calls[vi.mocked(useQuery).mock.calls.length - 1];
+        const queryKey = lastCall[0] as [string, any];
+        expect(queryKey[1]).toMatchObject({
+          sortBy: 'fullName',
+          sortOrder: 'asc',
+        });
+      });
+    });
+
+    it('should switch sort column when clicking a different column', async () => {
+      const user = userEvent.setup();
+      renderWithAuth(<UsersPage />, { user: mockAdminUser });
+
+      const headers = screen.getAllByRole('columnheader');
+
+      // Click Username first
+      await user.click(within(headers[0]).getByRole('button'));
+      await waitFor(() => {
+        const calls = mockSetSearchParams.mock.calls;
+        const params = calls[calls.length - 1][0] as URLSearchParams;
+        expect(params.get('sortBy')).toBe('username');
+      });
+
+      // Click Email — should switch column and reset to asc
+      await user.click(within(headers[1]).getByRole('button'));
+      await waitFor(() => {
+        const calls = mockSetSearchParams.mock.calls;
+        const params = calls[calls.length - 1][0] as URLSearchParams;
+        expect(params.get('sortBy')).toBe('email');
+        expect(params.get('sortOrder')).toBe('asc');
+      });
+    });
+  });
+
   describe('5. Permissions', () => {
     it('should show access denied message when user cannot read users', () => {
       vi.mocked(usersService.canReadUsers).mockReturnValue(false);

--- a/frontend/src/test/services/users.service.test.ts
+++ b/frontend/src/test/services/users.service.test.ts
@@ -246,6 +246,56 @@ describe('UsersService', () => {
       expect(result.data[0].username).toBe('jane_admin');
     });
 
+    it('should include sortBy and sortOrder params when provided', async () => {
+      vi.mocked(apiClient.get).mockResolvedValueOnce({
+        data: mockUsers,
+        pagination: { page: 1, limit: 20, total: 3, totalPages: 1 },
+      });
+
+      await usersService.getUsers({ sortBy: 'username', sortOrder: 'asc' });
+
+      expect(apiClient.get).toHaveBeenCalledWith('/users?sortBy=username&sortOrder=asc');
+    });
+
+    it('should include sortBy with desc order', async () => {
+      vi.mocked(apiClient.get).mockResolvedValueOnce({
+        data: mockUsers,
+        pagination: { page: 1, limit: 20, total: 3, totalPages: 1 },
+      });
+
+      await usersService.getUsers({ sortBy: 'email', sortOrder: 'desc' });
+
+      expect(apiClient.get).toHaveBeenCalledWith('/users?sortBy=email&sortOrder=desc');
+    });
+
+    it('should combine sort params with other filters', async () => {
+      vi.mocked(apiClient.get).mockResolvedValueOnce({
+        data: [mockUsers[0]],
+        pagination: { page: 1, limit: 20, total: 1, totalPages: 1 },
+      });
+
+      await usersService.getUsers({
+        search: 'john',
+        sortBy: 'fullName',
+        sortOrder: 'asc',
+      });
+
+      expect(apiClient.get).toHaveBeenCalledWith(
+        '/users?search=john&sortBy=fullName&sortOrder=asc',
+      );
+    });
+
+    it('should not include sort params when sortBy is not provided', async () => {
+      vi.mocked(apiClient.get).mockResolvedValueOnce({
+        data: mockUsers,
+        pagination: { page: 1, limit: 20, total: 3, totalPages: 1 },
+      });
+
+      await usersService.getUsers({ page: 1 });
+
+      expect(apiClient.get).toHaveBeenCalledWith('/users?page=1');
+    });
+
     it('should handle API errors', async () => {
       const error = new Error('Forbidden');
       (error as any).response = { status: 403, data: { message: 'Forbidden', statusCode: 403 } };

--- a/frontend/src/types/users.ts
+++ b/frontend/src/types/users.ts
@@ -15,6 +15,8 @@ export interface UserListParams {
   search?: string;
   role?: string;
   isActive?: boolean;
+  sortBy?: string;
+  sortOrder?: 'asc' | 'desc';
 }
 
 export interface UserUpdateData {


### PR DESCRIPTION
## Summary

- Add server-side sorting to the Users Management table via sortable column headers (Username, Email, Full Name, Status)
- Backend accepts `sortBy` and `sortOrder` query params with a SQL column whitelist to prevent injection
- Sort state persists in URL search params for bookmarkable/shareable views
- Roles column intentionally left unsortable (array column)

## Changes

**Backend** (`backend/src/routes/users.ts`):
- Added `sortBy` (enum: username, email, fullName, status, createdAt) and `sortOrder` (asc, desc) query parameters
- Whitelist-based mapping from API field names to safe SQL column names

**Frontend**:
- `UserListParams` type extended with `sortBy` and `sortOrder`
- `users.service.ts` passes sort params to API
- `UsersPage.tsx` adds sort state, URL persistence, and PatternFly `Th` sort props (following existing `UserBreakdownTable` pattern)

**Tests** (10 new tests, all passing):
- 6 component tests: sortable headers render, URL params update, direction toggle, page reset, query key inclusion, column switching
- 4 service tests: sort param serialization, desc order, combined filters, absence when unused

## Test plan

- [ ] Click each sortable column header — sort indicator appears, data re-fetches sorted
- [ ] Click same column again — toggles between ascending and descending
- [ ] Click a different column — switches sort column, resets to ascending
- [ ] Verify Roles column has no sort button
- [ ] Sort params appear in URL (`?sortBy=username&sortOrder=asc`)
- [ ] Refreshing page with sort params in URL restores sort state
- [ ] Changing sort resets pagination to page 1
- [ ] `npm test` passes (74 passing, 31 skipped — pre-existing skips)

🤖 Generated with [Claude Code](https://claude.com/claude-code)