### PR TITLE
fix: soft-delete API keys to preserve usage data attribution

### DIFF
--- a/backend/src/routes/api-keys.ts
+++ b/backend/src/routes/api-keys.ts
@@ -415,11 +415,15 @@ const apiKeysRoutes: FastifyPluginAsync = async (fastify) => {
       const { id } = request.params;
 
       try {
-        await apiKeyService.deleteApiKey(id, user.userId);
+        // Soft-delete (archive) instead of hard delete so the key_hash row
+        // remains in the database and the usage enrichment pipeline can still
+        // map historical LiteLLM usage data back to this user.
+        // The key is still deleted from LiteLLM, preventing further use.
+        const { archivedAt } = await apiKeyService.archiveApiKey(id, user.userId);
 
         return {
           message: 'API key deleted successfully',
-          deletedAt: new Date().toISOString(),
+          deletedAt: archivedAt.toISOString(),
         };
       } catch (error) {
         fastify.log.error(error, 'Failed to delete API key');

--- a/backend/tests/unit/services/admin-usage/admin-usage-aggregation.service.test.ts
+++ b/backend/tests/unit/services/admin-usage/admin-usage-aggregation.service.test.ts
@@ -851,6 +851,112 @@ describe('AdminUsageAggregationService', () => {
   });
 
   // ============================================================================
+  // enrichWithUserMapping — soft-deleted key usage attribution
+  // ============================================================================
+
+  describe('enrichWithUserMapping: soft-deleted keys preserve usage attribution', () => {
+    const callEnrich = async (dayData: LiteLLMDayData): Promise<EnrichedDayData> => {
+      return (aggregationService as any).enrichWithUserMapping(dayData);
+    };
+
+    const dayData: LiteLLMDayData = {
+      date: '2025-07-01',
+      metrics: {
+        api_requests: 10,
+        total_tokens: 500,
+        prompt_tokens: 300,
+        completion_tokens: 200,
+        spend: 0.25,
+        successful_requests: 0,
+        failed_requests: 0,
+      },
+      breakdown: {
+        models: {
+          'openai/gpt-4': {
+            metrics: {
+              api_requests: 10,
+              total_tokens: 500,
+              prompt_tokens: 300,
+              completion_tokens: 200,
+              spend: 0.25,
+            },
+            api_keys: {
+              hash_deleted: {
+                metrics: {
+                  api_requests: 10,
+                  total_tokens: 500,
+                  prompt_tokens: 300,
+                  completion_tokens: 200,
+                  spend: 0.25,
+                  successful_requests: 9,
+                  failed_requests: 1,
+                },
+              },
+            },
+          },
+        },
+        api_keys: {},
+        providers: {},
+      },
+    };
+
+    it('should map usage to the correct user when key is soft-deleted (archived/revoked)', async () => {
+      vi.spyOn(aggregationService as any, 'isDatabaseUnavailable').mockReturnValue(false);
+      vi.spyOn(aggregationService as any, 'executeQuery')
+        .mockResolvedValueOnce({
+          rows: [
+            {
+              litellm_key_alias: 'sk-deleted',
+              key_hash: 'hash_deleted',
+              user_id: 'user-deleted-key',
+              key_name: 'Deleted Key',
+              username: 'bob',
+              email: 'bob@example.com',
+              role: 'user',
+            },
+          ],
+        })
+        .mockResolvedValueOnce({ rows: [] });
+
+      const result = await callEnrich(dayData);
+
+      // Usage should be attributed to bob, not Unknown User
+      expect(result.breakdown.users['user-deleted-key']).toBeDefined();
+      expect(result.breakdown.users['user-deleted-key'].username).toBe('bob');
+      expect(result.breakdown.users['user-deleted-key'].email).toBe('bob@example.com');
+      expect(result.breakdown.users['user-deleted-key'].metrics.api_requests).toBe(10);
+      expect(result.breakdown.users['user-deleted-key'].metrics.spend).toBeCloseTo(0.25);
+
+      // Unknown User should NOT exist
+      expect(result.breakdown.users['00000000-0000-0000-0000-000000000000']).toBeUndefined();
+
+      vi.restoreAllMocks();
+    });
+
+    it('should attribute usage to Unknown User when key is hard-deleted (row gone)', async () => {
+      vi.spyOn(aggregationService as any, 'isDatabaseUnavailable').mockReturnValue(false);
+      // Empty rows: the key_hash no longer exists in the database
+      vi.spyOn(aggregationService as any, 'executeQuery')
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [] });
+
+      const result = await callEnrich(dayData);
+
+      // Usage should fall to Unknown User
+      const unknownUser = result.breakdown.users['00000000-0000-0000-0000-000000000000'];
+      expect(unknownUser).toBeDefined();
+      expect(unknownUser.username).toBe('Unknown User');
+      expect(unknownUser.metrics.api_requests).toBe(10);
+      expect(unknownUser.metrics.spend).toBeCloseTo(0.25);
+
+      // The original user should NOT exist
+      expect(result.breakdown.users['user-deleted-key']).toBeUndefined();
+
+      vi.restoreAllMocks();
+    });
+  });
+
+  // ============================================================================
   // enrichWithUserMapping — total_tokens reconciliation
   // ============================================================================
 


### PR DESCRIPTION
## Summary

- When a user deleted an API key, the `key_hash` row was hard-deleted from the database. The usage enrichment pipeline (`enrichWithUserMapping()`) joins on `api_keys` to map LiteLLM usage data back to users — so deleting a key caused all its historical usage to be attributed to "Unknown User."
- The user self-service delete endpoint now calls `archiveApiKey()` (soft-delete) instead of `deleteApiKey()` (hard delete). The key is still immediately revoked in LiteLLM preventing further use, but the database row is preserved with `is_active=false` and `archived_at` set.
- The key list endpoint already filters out archived keys by default (`AND ak.archived_at IS NULL`), so the user experience is unchanged — deleted keys disappear from their view.
- Admin permanent delete (`?permanent=true`) remains as a hard delete for compliance/GDPR use cases.

## Test plan

- [x] All 1001 unit tests pass (1 pre-existing date-validation failure unrelated)
- [ ] Delete a key via user self-service, verify it disappears from the key list
- [ ] Verify the deleted key's historical usage data still appears under the correct user in admin Usage Analytics
- [ ] Verify admin permanent delete (`?permanent=true`) still performs a hard delete

🤖 Generated with [Claude Code](https://claude.com/claude-code)