### PR TITLE
fix: use preferred_username as email fallback on user update

### DIFF
--- a/backend/src/services/oauth.service.ts
+++ b/backend/src/services/oauth.service.ts
@@ -984,7 +984,7 @@ export class OAuthService extends BaseService {
          WHERE id = $5`,
         [
           userInfo.preferred_username,
-          userInfo.email || null,
+          userInfo.email || userInfo.preferred_username,
           userInfo.name || null,
           mergedRoles,
           existingUser.id as string,

--- a/backend/tests/unit/services/oauth.service.test.ts
+++ b/backend/tests/unit/services/oauth.service.test.ts
@@ -475,6 +475,21 @@ describe('OAuthService', () => {
       await expect(service.processOAuthUser(mockUserInfo)).rejects.toThrow('DB error');
     });
 
+    it('should use preferred_username as email fallback when updating existing user without email claim', async () => {
+      const existingUser = { ...mockUserDbRow };
+      mockFastify.dbUtils.queryOne = vi.fn().mockResolvedValue(existingUser);
+      mockFastify.dbUtils.query = vi.fn().mockResolvedValue({ rowCount: 1 });
+      mockLiteLLMService.getUserInfo = vi.fn().mockResolvedValue(null);
+
+      const noEmailUserInfo = { ...mockUserInfo, email: undefined };
+      await service.processOAuthUser(noEmailUserInfo);
+
+      expect(mockFastify.dbUtils.query).toHaveBeenCalledWith(
+        expect.stringContaining('UPDATE users'),
+        expect.arrayContaining([noEmailUserInfo.preferred_username, noEmailUserInfo.preferred_username]),
+      );
+    });
+
     it('should preserve application-set admin role even with basic OpenShift groups', async () => {
       const adminUser = { ...mockUserDbRow, roles: ['user', 'admin'] };
       mockFastify.dbUtils.queryOne = vi.fn().mockResolvedValue(adminUser);


### PR DESCRIPTION
## Summary

Fixes #167.

- The `UPDATE` path in `processOAuthUser` set `email = null` when the OIDC provider omitted the email claim, crashing on reconnect with a `NOT NULL` constraint violation
- The `INSERT` path already fell back to `preferred_username` — this aligns the `UPDATE` path to match
- Added a unit test covering the no-email-claim update scenario

## Test plan

- [x] New unit test: `should use preferred_username as email fallback when updating existing user without email claim`
- [x] All 36 OAuth service unit tests pass
- [ ] Manual test: configure an OIDC provider that omits the email claim, verify login → logout → login succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)