### PR TITLE
feat: add Function Calling category filter to models page

### DIFF
--- a/frontend/src/i18n/locales/de/translation.json
+++ b/frontend/src/i18n/locales/de/translation.json
@@ -1103,6 +1103,7 @@
       },
       "categories": {
         "audio": "Audio",
+        "functionCalling": "Funktionsaufruf",
         "imageGeneration": "Bildgenerierung",
         "languageModel": "Sprachmodell",
         "multimodal": "Multimodal"

--- a/frontend/src/i18n/locales/elv/translation.json
+++ b/frontend/src/i18n/locales/elv/translation.json
@@ -1103,6 +1103,7 @@
       },
       "categories": {
         "audio": "Lindir",
+        "functionCalling": "Yulma Quetië",
         "imageGeneration": "Tirion Gwaith",
         "languageModel": "Lammen Sador",
         "multimodal": "Mornië Sador"

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -1103,6 +1103,7 @@
       },
       "categories": {
         "audio": "Audio",
+        "functionCalling": "Function Calling",
         "imageGeneration": "Image Generation",
         "languageModel": "Language Model",
         "multimodal": "Multimodal"

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -1103,6 +1103,7 @@
       },
       "categories": {
         "audio": "Audio",
+        "functionCalling": "Llamada de Funciones",
         "imageGeneration": "Generación de Imágenes",
         "languageModel": "Modelo de Lenguaje",
         "multimodal": "Multimodal"

--- a/frontend/src/i18n/locales/fr/translation.json
+++ b/frontend/src/i18n/locales/fr/translation.json
@@ -1103,6 +1103,7 @@
       },
       "categories": {
         "audio": "Audio",
+        "functionCalling": "Appel de Fonctions",
         "imageGeneration": "Génération d'Images",
         "languageModel": "Modèle de Langage",
         "multimodal": "Multimodal"

--- a/frontend/src/i18n/locales/it/translation.json
+++ b/frontend/src/i18n/locales/it/translation.json
@@ -1103,6 +1103,7 @@
       },
       "categories": {
         "audio": "Audio",
+        "functionCalling": "Chiamata di Funzioni",
         "imageGeneration": "Generazione di Immagini",
         "languageModel": "Modello Linguistico",
         "multimodal": "Multimodale"

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -1103,6 +1103,7 @@
       },
       "categories": {
         "audio": "音声",
+        "functionCalling": "関数呼び出し",
         "imageGeneration": "画像生成",
         "languageModel": "言語モデル",
         "multimodal": "マルチモーダル"

--- a/frontend/src/i18n/locales/ko/translation.json
+++ b/frontend/src/i18n/locales/ko/translation.json
@@ -1103,6 +1103,7 @@
       },
       "categories": {
         "audio": "오디오",
+        "functionCalling": "함수 호출",
         "imageGeneration": "이미지 생성",
         "languageModel": "언어 모델",
         "multimodal": "멀티모달"

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -1103,6 +1103,7 @@
       },
       "categories": {
         "audio": "音频",
+        "functionCalling": "函数调用",
         "imageGeneration": "图像生成",
         "languageModel": "语言模型",
         "multimodal": "多模态"

--- a/frontend/src/pages/ModelsPage.tsx
+++ b/frontend/src/pages/ModelsPage.tsx
@@ -181,9 +181,10 @@ const ModelsPage: React.FC = () => {
 
       if (selectedCategory !== 'all' && selectedCategory !== 'Multimodal') {
         filteredModels = response.models.filter((model) => {
+          if (selectedCategory === 'Function Calling') {
+            return model.supportsFunctionCalling === true;
+          }
           if (selectedCategory === 'Language Model') {
-            // Language Model includes all models except pure image/audio generation
-            // (includes multimodal since they also have language capabilities)
             return model.category === 'Language Model' || model.category === 'Multimodal';
           }
           return model.category === selectedCategory;
@@ -254,7 +255,7 @@ const ModelsPage: React.FC = () => {
   }, [page, perPage]);
 
   // Define all available categories (static list)
-  const categories = ['all', 'Language Model', 'Multimodal', 'Image Generation', 'Audio'];
+  const categories = ['all', 'Language Model', 'Multimodal', 'Function Calling', 'Image Generation', 'Audio'];
 
   // Translation function for category names
   const getCategoryLabel = (category: string) => {
@@ -262,6 +263,7 @@ const ModelsPage: React.FC = () => {
     if (category === 'Language Model') return t('pages.models.categories.languageModel');
     if (category === 'Multimodal') return t('pages.models.categories.multimodal');
     if (category === 'Image Generation') return t('pages.models.categories.imageGeneration');
+    if (category === 'Function Calling') return t('pages.models.categories.functionCalling');
     if (category === 'Audio') return t('pages.models.categories.audio');
     return category;
   };


### PR DESCRIPTION
## Summary
- Adds **Function Calling** as a new category filter option in the "All Categories" dropdown on the Models page
- Filters models based on the existing `supportsFunctionCalling` field in model info
- Includes translations for all 9 locales (en, es, fr, de, ja, it, ko, zh, elv)

## Context
Users in `#forum-demo-redhat-com` requested the ability to filter models by tool/function calling support. The backend already tracks `supports_function_calling` per model via LiteLLM's `model_info` — this PR exposes that as a frontend filter.

## Changes
- `ModelsPage.tsx`: Added "Function Calling" to the categories array, label translation mapping, and client-side filtering logic (`model.supportsFunctionCalling === true`)
- `i18n/locales/*/translation.json`: Added `functionCalling` translation key to all 9 locale files

## Test plan
- [ ] Select "Function Calling" from the categories dropdown
- [ ] Verify only models with `supportsFunctionCalling: true` are shown
- [ ] Verify other category filters still work correctly
- [ ] Verify translations render in non-English locales

🤖 Generated with [Claude Code](https://claude.com/claude-code)