### PR TITLE
Release v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1] - 2026-08-12
+
+### Added
+
+- **Reasoning field support in chatbot playground**: The playground now renders the thinking trace when the provider returns it in a dedicated payload field (`reasoning_content`, also mirrored under `provider_specific_fields`) instead of inline `<think>` tags — as served by e.g. DeepSeek R1 distills through LiteLLM
+  - New `ReasoningFields` type and optional `reasoning` field on `ChatMessage`; `extractReasoning()` and `resolveThinking()` helpers where a dedicated reasoning field takes precedence over inline tag parsing
+  - Streaming path captures `reasoning_content` deltas separately from content and reports them as they arrive
+- **Thinking tag formatting in chatbot playground**: Parse `<think>...</think>` tags in assistant responses and render them as a collapsible section above the main response; during streaming the block stays expanded with a "Thinking..." label, then collapses to "Thought" once complete (#71)
+  - `ThinkingBlock` component built on PatternFly `ExpandableSection`, `thinkingParser` utility with full test coverage, and i18n across all 9 locales
+- **Function Calling category filter**: New "Function Calling" option in the models page category dropdown, showing only models with `supportsFunctionCalling` enabled, with translations across all 9 locales (#175)
+- **Column sorting on Users Management table**: Admins can sort the Users Management table by Username, Email, Full Name, or Status via clickable column headers, with sort state persisted in URL search params; sorting is server-side. Roles is intentionally left unsortable as an array column (#170)
+
+### Fixed
+
+- **API key deletion no longer loses usage attribution**: User self-service key deletion now soft-deletes (archives) the key instead of hard-deleting the row. The key is still revoked in LiteLLM immediately, but the database row is preserved (`is_active=false`, `archived_at` set) so the usage enrichment pipeline can still map historical usage back to the user. Admin permanent delete (`?permanent=true`) remains a hard delete for compliance/GDPR use cases (#172)
+- **Email NOT NULL constraint violation on user update**: The OIDC update path set `email` to null when the provider omitted the email claim, violating the `users.email` NOT NULL constraint; it now falls back to `preferred_username`, matching the insert path (#167, #173)
+- **Ingress resources blocked on OpenShift**: Removed the `platform == "kubernetes"` guard from the frontend and LiteLLM ingress templates so `Ingress` resources are deployable on OpenShift as well as Kubernetes whenever `ingress.enabled` is set — enabling cert-manager-based TLS on OpenShift, which relies on Ingress annotations (#168, #169)
+- **Frontend initContainer permission**: Removed the hardcoded `runAsUser: 65534` on the frontend initContainer that could block startup under restrictive security contexts
+- **Backup restore progress reporting**: Progress messages during database restore now report reliably at each 10,000-statement interval instead of only on exact multiples
+
+### Contributors
+
+- Guillaume Moutier
+- Chris Brown
+- ashok jammula (new contributor)
+- FlorentMair80 (new contributor)
+- Co-authored-by: Claude (AI pair programming assistant)
+
 ## [0.5.0] - 2026-06-26
 
 ### Added

--- a/backend/src/routes/api-keys.ts
+++ b/backend/src/routes/api-keys.ts
@@ -415,11 +415,15 @@ const apiKeysRoutes: FastifyPluginAsync = async (fastify) => {
       const { id } = request.params;
 
       try {
-        await apiKeyService.deleteApiKey(id, user.userId);
+        // Soft-delete (archive) instead of hard delete so the key_hash row
+        // remains in the database and the usage enrichment pipeline can still
+        // map historical LiteLLM usage data back to this user.
+        // The key is still deleted from LiteLLM, preventing further use.
+        const { archivedAt } = await apiKeyService.archiveApiKey(id, user.userId);
 
         return {
           message: 'API key deleted successfully',
-          deletedAt: new Date().toISOString(),
+          deletedAt: archivedAt.toISOString(),
         };
       } catch (error) {
         fastify.log.error(error, 'Failed to delete API key');

--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -15,7 +15,17 @@ interface UserListQuery {
   search?: string;
   role?: string;
   isActive?: boolean;
+  sortBy?: string;
+  sortOrder?: 'asc' | 'desc';
 }
+
+const SORTABLE_COLUMNS: Record<string, string> = {
+  username: 'username',
+  email: 'email',
+  fullName: 'full_name',
+  status: 'is_active',
+  createdAt: 'created_at',
+};
 
 interface FastifyError extends Error {
   statusCode?: number;
@@ -345,6 +355,8 @@ const usersRoutes: FastifyPluginAsync = async (fastify) => {
           search: { type: 'string' },
           role: { type: 'string' },
           isActive: { type: 'boolean' },
+          sortBy: { type: 'string', enum: ['username', 'email', 'fullName', 'status', 'createdAt'] },
+          sortOrder: { type: 'string', enum: ['asc', 'desc'], default: 'asc' },
         },
       },
       response: {
@@ -382,7 +394,7 @@ const usersRoutes: FastifyPluginAsync = async (fastify) => {
     },
     preHandler: [fastify.authenticate, fastify.requirePermission('users:read')],
     handler: async (request, _reply) => {
-      const { page = 1, limit = 20, search, role, isActive } = request.query as UserListQuery;
+      const { page = 1, limit = 20, search, role, isActive, sortBy, sortOrder = 'asc' } = request.query as UserListQuery;
 
       try {
         const offset = (page - 1) * limit;
@@ -410,7 +422,9 @@ const usersRoutes: FastifyPluginAsync = async (fastify) => {
           params.push(isActive);
         }
 
-        query += ` ORDER BY created_at DESC LIMIT $${params.length + 1} OFFSET $${params.length + 2}`;
+        const orderColumn = (sortBy && SORTABLE_COLUMNS[sortBy]) || 'created_at';
+        const orderDirection = sortOrder === 'desc' ? 'DESC' : 'ASC';
+        query += ` ORDER BY ${orderColumn} ${orderDirection} LIMIT $${params.length + 1} OFFSET $${params.length + 2}`;
         params.push(limit, offset);
 
         // Get count

--- a/backend/src/scripts/restore-backup.ts
+++ b/backend/src/scripts/restore-backup.ts
@@ -110,6 +110,7 @@ async function streamRestoreSQL(backupPath: string, client: PoolClient): Promise
     const readStream = createReadStream(backupPath);
     let buffer = '';
     let statementsExecuted = 0;
+    let lastReportedAt = 0;
 
     gunzip.on('data', (chunk: Buffer) => {
       buffer += chunk.toString('utf-8');
@@ -129,8 +130,9 @@ async function streamRestoreSQL(backupPath: string, client: PoolClient): Promise
         gunzip.pause();
         statementsExecuted += statements.length;
 
-        if (statementsExecuted % 10000 === 0) {
+        if (statementsExecuted - lastReportedAt >= 10000) {
           process.stdout.write(`  ... ${statementsExecuted} statements executed\n`);
+          lastReportedAt = statementsExecuted;
         }
 
         const batch = statements.join('\n');

--- a/backend/src/services/oauth.service.ts
+++ b/backend/src/services/oauth.service.ts
@@ -984,7 +984,7 @@ export class OAuthService extends BaseService {
          WHERE id = $5`,
         [
           userInfo.preferred_username,
-          userInfo.email || null,
+          userInfo.email || userInfo.preferred_username,
           userInfo.name || null,
           mergedRoles,
           existingUser.id as string,

--- a/backend/tests/unit/services/admin-usage/admin-usage-aggregation.service.test.ts
+++ b/backend/tests/unit/services/admin-usage/admin-usage-aggregation.service.test.ts
@@ -851,6 +851,112 @@ describe('AdminUsageAggregationService', () => {
   });
 
   // ============================================================================
+  // enrichWithUserMapping — soft-deleted key usage attribution
+  // ============================================================================
+
+  describe('enrichWithUserMapping: soft-deleted keys preserve usage attribution', () => {
+    const callEnrich = async (dayData: LiteLLMDayData): Promise<EnrichedDayData> => {
+      return (aggregationService as any).enrichWithUserMapping(dayData);
+    };
+
+    const dayData: LiteLLMDayData = {
+      date: '2025-07-01',
+      metrics: {
+        api_requests: 10,
+        total_tokens: 500,
+        prompt_tokens: 300,
+        completion_tokens: 200,
+        spend: 0.25,
+        successful_requests: 0,
+        failed_requests: 0,
+      },
+      breakdown: {
+        models: {
+          'openai/gpt-4': {
+            metrics: {
+              api_requests: 10,
+              total_tokens: 500,
+              prompt_tokens: 300,
+              completion_tokens: 200,
+              spend: 0.25,
+            },
+            api_keys: {
+              hash_deleted: {
+                metrics: {
+                  api_requests: 10,
+                  total_tokens: 500,
+                  prompt_tokens: 300,
+                  completion_tokens: 200,
+                  spend: 0.25,
+                  successful_requests: 9,
+                  failed_requests: 1,
+                },
+              },
+            },
+          },
+        },
+        api_keys: {},
+        providers: {},
+      },
+    };
+
+    it('should map usage to the correct user when key is soft-deleted (archived/revoked)', async () => {
+      vi.spyOn(aggregationService as any, 'isDatabaseUnavailable').mockReturnValue(false);
+      vi.spyOn(aggregationService as any, 'executeQuery')
+        .mockResolvedValueOnce({
+          rows: [
+            {
+              litellm_key_alias: 'sk-deleted',
+              key_hash: 'hash_deleted',
+              user_id: 'user-deleted-key',
+              key_name: 'Deleted Key',
+              username: 'bob',
+              email: 'bob@example.com',
+              role: 'user',
+            },
+          ],
+        })
+        .mockResolvedValueOnce({ rows: [] });
+
+      const result = await callEnrich(dayData);
+
+      // Usage should be attributed to bob, not Unknown User
+      expect(result.breakdown.users['user-deleted-key']).toBeDefined();
+      expect(result.breakdown.users['user-deleted-key'].username).toBe('bob');
+      expect(result.breakdown.users['user-deleted-key'].email).toBe('bob@example.com');
+      expect(result.breakdown.users['user-deleted-key'].metrics.api_requests).toBe(10);
+      expect(result.breakdown.users['user-deleted-key'].metrics.spend).toBeCloseTo(0.25);
+
+      // Unknown User should NOT exist
+      expect(result.breakdown.users['00000000-0000-0000-0000-000000000000']).toBeUndefined();
+
+      vi.restoreAllMocks();
+    });
+
+    it('should attribute usage to Unknown User when key is hard-deleted (row gone)', async () => {
+      vi.spyOn(aggregationService as any, 'isDatabaseUnavailable').mockReturnValue(false);
+      // Empty rows: the key_hash no longer exists in the database
+      vi.spyOn(aggregationService as any, 'executeQuery')
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [] });
+
+      const result = await callEnrich(dayData);
+
+      // Usage should fall to Unknown User
+      const unknownUser = result.breakdown.users['00000000-0000-0000-0000-000000000000'];
+      expect(unknownUser).toBeDefined();
+      expect(unknownUser.username).toBe('Unknown User');
+      expect(unknownUser.metrics.api_requests).toBe(10);
+      expect(unknownUser.metrics.spend).toBeCloseTo(0.25);
+
+      // The original user should NOT exist
+      expect(result.breakdown.users['user-deleted-key']).toBeUndefined();
+
+      vi.restoreAllMocks();
+    });
+  });
+
+  // ============================================================================
   // enrichWithUserMapping — total_tokens reconciliation
   // ============================================================================
 

--- a/backend/tests/unit/services/oauth.service.test.ts
+++ b/backend/tests/unit/services/oauth.service.test.ts
@@ -475,6 +475,21 @@ describe('OAuthService', () => {
       await expect(service.processOAuthUser(mockUserInfo)).rejects.toThrow('DB error');
     });
 
+    it('should use preferred_username as email fallback when updating existing user without email claim', async () => {
+      const existingUser = { ...mockUserDbRow };
+      mockFastify.dbUtils.queryOne = vi.fn().mockResolvedValue(existingUser);
+      mockFastify.dbUtils.query = vi.fn().mockResolvedValue({ rowCount: 1 });
+      mockLiteLLMService.getUserInfo = vi.fn().mockResolvedValue(null);
+
+      const noEmailUserInfo = { ...mockUserInfo, email: undefined };
+      await service.processOAuthUser(noEmailUserInfo);
+
+      expect(mockFastify.dbUtils.query).toHaveBeenCalledWith(
+        expect.stringContaining('UPDATE users'),
+        expect.arrayContaining([noEmailUserInfo.preferred_username, noEmailUserInfo.preferred_username]),
+      );
+    });
+
     it('should preserve application-set admin role even with basic OpenShift groups', async () => {
       const adminUser = { ...mockUserDbRow, roles: ['user', 'admin'] };
       mockFastify.dbUtils.queryOne = vi.fn().mockResolvedValue(adminUser);

--- a/deployment/helm/litemaas/Chart.yaml
+++ b/deployment/helm/litemaas/Chart.yaml
@@ -3,7 +3,7 @@ name: litemaas
 description: LiteMaaS - Model subscription and management platform with LiteLLM integration
 type: application
 version: 0.1.0
-appVersion: "0.5.0"
+appVersion: "0.5.1"
 keywords:
   - litemaas
   - litellm

--- a/deployment/helm/litemaas/templates/frontend-ingress.yaml
+++ b/deployment/helm/litemaas/templates/frontend-ingress.yaml
@@ -1,4 +1,4 @@
-{{- if and (eq .Values.global.platform "kubernetes") .Values.ingress.enabled .Values.ingress.frontend.host }}
+{{- if .Values.ingress.enabled .Values.ingress.frontend.host }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/deployment/helm/litemaas/templates/frontend-ingress.yaml
+++ b/deployment/helm/litemaas/templates/frontend-ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ingress.enabled .Values.ingress.frontend.host }}
+{{- if and .Values.ingress.enabled .Values.ingress.frontend.host }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/deployment/helm/litemaas/templates/litellm-ingress.yaml
+++ b/deployment/helm/litemaas/templates/litellm-ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ingress.enabled .Values.ingress.litellm.enabled .Values.ingress.litellm.host }}
+{{- if and .Values.ingress.enabled .Values.ingress.litellm.enabled .Values.ingress.litellm.host }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/deployment/helm/litemaas/templates/litellm-ingress.yaml
+++ b/deployment/helm/litemaas/templates/litellm-ingress.yaml
@@ -1,4 +1,4 @@
-{{- if and (eq .Values.global.platform "kubernetes") .Values.ingress.enabled .Values.ingress.litellm.enabled .Values.ingress.litellm.host }}
+{{- if .Values.ingress.enabled .Values.ingress.litellm.enabled .Values.ingress.litellm.host }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/deployment/kustomize/kustomization.yaml.template
+++ b/deployment/kustomize/kustomization.yaml.template
@@ -43,9 +43,9 @@ resources:
 # Images - can be overridden for different environments
 images:
   - name: quay.io/rh-aiservices-bu/litemaas-backend
-    newTag: latest
+    newTag: "${LITEMAAS_VERSION}"
   - name: quay.io/rh-aiservices-bu/litemaas-frontend
-    newTag: latest
+    newTag: "${LITEMAAS_VERSION}"
 # Resource patches - can be uncommented and customized as needed
 # patches:
 #   # Example: Increase backend replicas for production

--- a/frontend/src/components/chat/ThinkingBlock.css
+++ b/frontend/src/components/chat/ThinkingBlock.css
@@ -1,0 +1,16 @@
+.thinking-block {
+  margin-bottom: var(--pf-t--global--spacer--sm);
+}
+
+.thinking-block__expandable {
+  border-left: 3px solid var(--pf-t--global--border--color--default);
+  padding-left: var(--pf-t--global--spacer--md);
+}
+
+.thinking-block__content {
+  font-style: italic;
+  color: var(--pf-t--global--text--color--subtle);
+  white-space: pre-wrap;
+  font-size: var(--pf-t--global--font--size--sm);
+  line-height: var(--pf-t--global--font--line-height--body);
+}

--- a/frontend/src/components/chat/ThinkingBlock.tsx
+++ b/frontend/src/components/chat/ThinkingBlock.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { ExpandableSection } from '@patternfly/react-core';
+import { useTranslation } from 'react-i18next';
+
+import './ThinkingBlock.css';
+
+interface ThinkingBlockProps {
+  content: string;
+  isStreaming?: boolean;
+}
+
+const ThinkingBlock: React.FC<ThinkingBlockProps> = ({ content, isStreaming = false }) => {
+  const { t } = useTranslation();
+  const [isExpanded, setIsExpanded] = React.useState(isStreaming);
+
+  React.useEffect(() => {
+    if (isStreaming) {
+      setIsExpanded(true);
+    }
+  }, [isStreaming]);
+
+  return (
+    <div className="thinking-block">
+      <ExpandableSection
+        toggleText={
+          isStreaming
+            ? t('pages.chatbot.thinking.thinkingInProgress')
+            : t('pages.chatbot.thinking.thought')
+        }
+        onToggle={(_event, expanded) => setIsExpanded(expanded)}
+        isExpanded={isExpanded}
+        className="thinking-block__expandable"
+      >
+        <div className="thinking-block__content">{content}</div>
+      </ExpandableSection>
+    </div>
+  );
+};
+
+export default ThinkingBlock;

--- a/frontend/src/i18n/locales/de/translation.json
+++ b/frontend/src/i18n/locales/de/translation.json
@@ -905,6 +905,10 @@
         "welcomeDescription": "Beginnen Sie eine Unterhaltung, um Ihr ausgewähltes Modell und den API-Schlüssel zu testen",
         "welcomeTitle": "Modell-Test-Assistent"
       },
+      "thinking": {
+        "thought": "Gedanke",
+        "thinkingInProgress": "Denkt nach..."
+      },
       "configuration": {
         "advancedSettings": "Erweiterte Einstellungen",
         "apiKey": "API-Schlüssel auswählen",

--- a/frontend/src/i18n/locales/de/translation.json
+++ b/frontend/src/i18n/locales/de/translation.json
@@ -1103,6 +1103,7 @@
       },
       "categories": {
         "audio": "Audio",
+        "functionCalling": "Funktionsaufruf",
         "imageGeneration": "Bildgenerierung",
         "languageModel": "Sprachmodell",
         "multimodal": "Multimodal"

--- a/frontend/src/i18n/locales/elv/translation.json
+++ b/frontend/src/i18n/locales/elv/translation.json
@@ -905,6 +905,10 @@
         "welcomeDescription": "Togo glingad ad prestanno echui a anguirel-API edhellen",
         "welcomeTitle": "Echui-Prestann Orthad-Uin"
       },
+      "thinking": {
+        "thought": "Nauth",
+        "thinkingInProgress": "Nautha..."
+      },
       "configuration": {
         "advancedSettings": "Orthad Govannon",
         "apiKey": "Edhello Anguirel-API",

--- a/frontend/src/i18n/locales/elv/translation.json
+++ b/frontend/src/i18n/locales/elv/translation.json
@@ -1103,6 +1103,7 @@
       },
       "categories": {
         "audio": "Lindir",
+        "functionCalling": "Yulma Quetië",
         "imageGeneration": "Tirion Gwaith",
         "languageModel": "Lammen Sador",
         "multimodal": "Mornië Sador"

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -905,6 +905,10 @@
         "welcomeDescription": "Select an API key and model from the configuration panel to start testing your AI models",
         "welcomeTitle": "Welcome to the AI Chat Interface"
       },
+      "thinking": {
+        "thought": "Thought",
+        "thinkingInProgress": "Thinking..."
+      },
       "configuration": {
         "advancedSettings": "Advanced Settings",
         "apiKey": "API Key",

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -1103,6 +1103,7 @@
       },
       "categories": {
         "audio": "Audio",
+        "functionCalling": "Function Calling",
         "imageGeneration": "Image Generation",
         "languageModel": "Language Model",
         "multimodal": "Multimodal"

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -905,6 +905,10 @@
         "welcomeDescription": "Inicia una conversación para probar tu modelo y clave API seleccionados",
         "welcomeTitle": "Asistente de Prueba de Modelos"
       },
+      "thinking": {
+        "thought": "Pensamiento",
+        "thinkingInProgress": "Pensando..."
+      },
       "configuration": {
         "advancedSettings": "Configuración Avanzada",
         "apiKey": "Seleccionar Clave API",

--- a/frontend/src/i18n/locales/es/translation.json
+++ b/frontend/src/i18n/locales/es/translation.json
@@ -1103,6 +1103,7 @@
       },
       "categories": {
         "audio": "Audio",
+        "functionCalling": "Llamada de Funciones",
         "imageGeneration": "Generación de Imágenes",
         "languageModel": "Modelo de Lenguaje",
         "multimodal": "Multimodal"

--- a/frontend/src/i18n/locales/fr/translation.json
+++ b/frontend/src/i18n/locales/fr/translation.json
@@ -905,6 +905,10 @@
         "welcomeDescription": "Commencez une conversation pour tester votre modèle et clé API sélectionnés",
         "welcomeTitle": "Assistant de Test de Modèles"
       },
+      "thinking": {
+        "thought": "Réflexion",
+        "thinkingInProgress": "Réflexion en cours..."
+      },
       "configuration": {
         "advancedSettings": "Paramètres Avancés",
         "apiKey": "Sélectionner une Clé API",

--- a/frontend/src/i18n/locales/fr/translation.json
+++ b/frontend/src/i18n/locales/fr/translation.json
@@ -1103,6 +1103,7 @@
       },
       "categories": {
         "audio": "Audio",
+        "functionCalling": "Appel de Fonctions",
         "imageGeneration": "Génération d'Images",
         "languageModel": "Modèle de Langage",
         "multimodal": "Multimodal"

--- a/frontend/src/i18n/locales/it/translation.json
+++ b/frontend/src/i18n/locales/it/translation.json
@@ -1103,6 +1103,7 @@
       },
       "categories": {
         "audio": "Audio",
+        "functionCalling": "Chiamata di Funzioni",
         "imageGeneration": "Generazione di Immagini",
         "languageModel": "Modello Linguistico",
         "multimodal": "Multimodale"

--- a/frontend/src/i18n/locales/it/translation.json
+++ b/frontend/src/i18n/locales/it/translation.json
@@ -905,6 +905,10 @@
         "welcomeDescription": "Inizia una conversazione per testare il tuo modello e chiave API selezionati",
         "welcomeTitle": "Assistente Test Modelli"
       },
+      "thinking": {
+        "thought": "Pensiero",
+        "thinkingInProgress": "Sta pensando..."
+      },
       "configuration": {
         "advancedSettings": "Impostazioni Avanzate",
         "apiKey": "Seleziona Chiave API",

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -1103,6 +1103,7 @@
       },
       "categories": {
         "audio": "音声",
+        "functionCalling": "関数呼び出し",
         "imageGeneration": "画像生成",
         "languageModel": "言語モデル",
         "multimodal": "マルチモーダル"

--- a/frontend/src/i18n/locales/ja/translation.json
+++ b/frontend/src/i18n/locales/ja/translation.json
@@ -905,6 +905,10 @@
         "welcomeDescription": "選択したモデルとAPIキーをテストするために会話を開始してください",
         "welcomeTitle": "モデルテストアシスタント"
       },
+      "thinking": {
+        "thought": "思考内容",
+        "thinkingInProgress": "思考中..."
+      },
       "configuration": {
         "advancedSettings": "詳細設定",
         "apiKey": "APIキーを選択",

--- a/frontend/src/i18n/locales/ko/translation.json
+++ b/frontend/src/i18n/locales/ko/translation.json
@@ -1103,6 +1103,7 @@
       },
       "categories": {
         "audio": "오디오",
+        "functionCalling": "함수 호출",
         "imageGeneration": "이미지 생성",
         "languageModel": "언어 모델",
         "multimodal": "멀티모달"

--- a/frontend/src/i18n/locales/ko/translation.json
+++ b/frontend/src/i18n/locales/ko/translation.json
@@ -905,6 +905,10 @@
         "welcomeDescription": "선택한 모델과 API 키를 테스트하기 위해 대화를 시작하세요",
         "welcomeTitle": "모델 테스트 어시스턴트"
       },
+      "thinking": {
+        "thought": "사고",
+        "thinkingInProgress": "생각 중..."
+      },
       "configuration": {
         "advancedSettings": "고급 설정",
         "apiKey": "API 키 선택",

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -905,6 +905,10 @@
         "welcomeDescription": "开始对话来测试您选择的模型和API密钥",
         "welcomeTitle": "模型测试助手"
       },
+      "thinking": {
+        "thought": "思考",
+        "thinkingInProgress": "思考中..."
+      },
       "configuration": {
         "advancedSettings": "高级设置",
         "apiKey": "选择API密钥",

--- a/frontend/src/i18n/locales/zh/translation.json
+++ b/frontend/src/i18n/locales/zh/translation.json
@@ -1103,6 +1103,7 @@
       },
       "categories": {
         "audio": "音频",
+        "functionCalling": "函数调用",
         "imageGeneration": "图像生成",
         "languageModel": "语言模型",
         "multimodal": "多模态"

--- a/frontend/src/pages/ChatbotPage.tsx
+++ b/frontend/src/pages/ChatbotPage.tsx
@@ -73,7 +73,7 @@ import {
 } from '../types/chat';
 
 import ThinkingBlock from '../components/chat/ThinkingBlock';
-import { parseThinkingTags } from '../utils/thinkingParser';
+import { extractReasoning, resolveThinking } from '../utils/thinkingParser';
 import userAvatar from '../../src/assets/images/avatar-placeholder.svg';
 import orb from '../../src/assets/images/orb.svg';
 
@@ -316,7 +316,12 @@ const ChatbotPage: React.FC = () => {
             litellmApiUrl,
             apiKeyToUse,
             request,
-            (content: string, _isComplete: boolean, timeToFirstToken?: number) => {
+            (
+              content: string,
+              reasoning: string,
+              _isComplete: boolean,
+              timeToFirstToken?: number,
+            ) => {
               // Capture TTFT as soon as first chunk arrives
               if (timeToFirstToken && !streamingTTFT) {
                 setStreamingTTFT(timeToFirstToken);
@@ -331,7 +336,9 @@ const ChatbotPage: React.FC = () => {
               // Update the message in the messages array
               setMessages((prev) =>
                 prev.map((msg) =>
-                  msg.id === assistantMessageWithId.id ? { ...msg, content } : msg,
+                  msg.id === assistantMessageWithId.id
+                    ? { ...msg, content, ...(reasoning ? { reasoning } : {}) }
+                    : msg,
                 ),
               );
             },
@@ -358,9 +365,12 @@ const ChatbotPage: React.FC = () => {
 
           // Add assistant response
           if (response.choices && response.choices.length > 0) {
+            const responseMessage = response.choices[0].message;
             const assistantMessage = chatService.createMessage(
               'assistant',
-              response.choices[0].message.content,
+              responseMessage.content,
+              undefined,
+              extractReasoning(responseMessage),
             );
             setMessages((prev) => [...prev, assistantMessage]);
           }
@@ -868,16 +878,18 @@ const ChatbotPage: React.FC = () => {
                               streamingState.isStreaming &&
                               message.id === streamingState.streamingMessageId;
                             const parsed =
-                              isAssistant && message.content
-                                ? parseThinkingTags(message.content)
+                              isAssistant && (message.content || message.reasoning)
+                                ? resolveThinking(
+                                    message.content,
+                                    message.reasoning,
+                                    isCurrentlyStreaming,
+                                  )
                                 : null;
 
                             return (
                               <Message
                                 key={message.id}
-                                role={
-                                  message.role === 'user' ? 'user' : 'bot'
-                                }
+                                role={message.role === 'user' ? 'user' : 'bot'}
                                 content={parsed ? parsed.response : message.content}
                                 extraContent={
                                   parsed?.thinking
@@ -886,8 +898,7 @@ const ChatbotPage: React.FC = () => {
                                           <ThinkingBlock
                                             content={parsed.thinking}
                                             isStreaming={
-                                              isCurrentlyStreaming &&
-                                              !parsed.isThinkingComplete
+                                              isCurrentlyStreaming && !parsed.isThinkingComplete
                                             }
                                           />
                                         ),
@@ -900,7 +911,6 @@ const ChatbotPage: React.FC = () => {
                               />
                             );
                           })
-
                         )}
                         {isSending && !streamingState.isStreaming && (
                           <Message role="bot" content="" isLoading avatar={orb} />

--- a/frontend/src/pages/ChatbotPage.tsx
+++ b/frontend/src/pages/ChatbotPage.tsx
@@ -72,6 +72,8 @@ import {
   StreamingState,
 } from '../types/chat';
 
+import ThinkingBlock from '../components/chat/ThinkingBlock';
+import { parseThinkingTags } from '../utils/thinkingParser';
 import userAvatar from '../../src/assets/images/avatar-placeholder.svg';
 import orb from '../../src/assets/images/orb.svg';
 
@@ -860,26 +862,45 @@ const ChatbotPage: React.FC = () => {
                             description={t('pages.chatbot.welcome.description')}
                           />
                         ) : (
-                          messages.map((message) => (
-                            <Message
-                              key={message.id}
-                              role={
-                                message.role === 'assistant'
-                                  ? 'bot'
-                                  : message.role === 'system'
-                                    ? 'bot'
-                                    : message.role
-                              }
-                              content={message.content}
-                              isLoading={
-                                streamingState.isStreaming &&
-                                message.id === streamingState.streamingMessageId &&
-                                !message.content
-                              }
-                              timestamp={message.timestamp.toLocaleTimeString()}
-                              avatar={message.role === 'assistant' ? orb : userAvatar}
-                            />
-                          ))
+                          messages.map((message) => {
+                            const isAssistant = message.role === 'assistant';
+                            const isCurrentlyStreaming =
+                              streamingState.isStreaming &&
+                              message.id === streamingState.streamingMessageId;
+                            const parsed =
+                              isAssistant && message.content
+                                ? parseThinkingTags(message.content)
+                                : null;
+
+                            return (
+                              <Message
+                                key={message.id}
+                                role={
+                                  message.role === 'user' ? 'user' : 'bot'
+                                }
+                                content={parsed ? parsed.response : message.content}
+                                extraContent={
+                                  parsed?.thinking
+                                    ? {
+                                        beforeMainContent: (
+                                          <ThinkingBlock
+                                            content={parsed.thinking}
+                                            isStreaming={
+                                              isCurrentlyStreaming &&
+                                              !parsed.isThinkingComplete
+                                            }
+                                          />
+                                        ),
+                                      }
+                                    : undefined
+                                }
+                                isLoading={isCurrentlyStreaming && !message.content}
+                                timestamp={message.timestamp.toLocaleTimeString()}
+                                avatar={isAssistant ? orb : userAvatar}
+                              />
+                            );
+                          })
+
                         )}
                         {isSending && !streamingState.isStreaming && (
                           <Message role="bot" content="" isLoading avatar={orb} />

--- a/frontend/src/pages/ModelsPage.tsx
+++ b/frontend/src/pages/ModelsPage.tsx
@@ -181,9 +181,10 @@ const ModelsPage: React.FC = () => {
 
       if (selectedCategory !== 'all' && selectedCategory !== 'Multimodal') {
         filteredModels = response.models.filter((model) => {
+          if (selectedCategory === 'Function Calling') {
+            return model.supportsFunctionCalling === true;
+          }
           if (selectedCategory === 'Language Model') {
-            // Language Model includes all models except pure image/audio generation
-            // (includes multimodal since they also have language capabilities)
             return model.category === 'Language Model' || model.category === 'Multimodal';
           }
           return model.category === selectedCategory;
@@ -254,7 +255,7 @@ const ModelsPage: React.FC = () => {
   }, [page, perPage]);
 
   // Define all available categories (static list)
-  const categories = ['all', 'Language Model', 'Multimodal', 'Image Generation', 'Audio'];
+  const categories = ['all', 'Language Model', 'Multimodal', 'Function Calling', 'Image Generation', 'Audio'];
 
   // Translation function for category names
   const getCategoryLabel = (category: string) => {
@@ -262,6 +263,7 @@ const ModelsPage: React.FC = () => {
     if (category === 'Language Model') return t('pages.models.categories.languageModel');
     if (category === 'Multimodal') return t('pages.models.categories.multimodal');
     if (category === 'Image Generation') return t('pages.models.categories.imageGeneration');
+    if (category === 'Function Calling') return t('pages.models.categories.functionCalling');
     if (category === 'Audio') return t('pages.models.categories.audio');
     return category;
   };

--- a/frontend/src/pages/UsersPage.tsx
+++ b/frontend/src/pages/UsersPage.tsx
@@ -39,7 +39,7 @@ import {
   TimesCircleIcon,
   UserIcon,
 } from '@patternfly/react-icons';
-import { Table, Thead, Tbody, Tr, Th, Td, ActionsColumn } from '@patternfly/react-table';
+import { Table, Thead, Tbody, Tr, Th, Td, ActionsColumn, ThProps } from '@patternfly/react-table';
 import { useAuth } from '../contexts/AuthContext';
 import { useNotifications } from '../contexts/NotificationContext';
 import { usersService } from '../services/users.service';
@@ -63,6 +63,8 @@ const UsersPage: React.FC = () => {
   const [isStatusFilterOpen, setIsStatusFilterOpen] = useState(false);
   const [page, setPage] = useState(parseInt(searchParams.get('page') || '1', 10));
   const [perPage, setPerPage] = useState(parseInt(searchParams.get('limit') || '10', 10));
+  const [sortBy, setSortBy] = useState(searchParams.get('sortBy') || '');
+  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>((searchParams.get('sortOrder') as 'asc' | 'desc') || 'asc');
 
   // Modal focus management ref
   const editModalTriggerRef = useRef<HTMLElement | null>(null);
@@ -79,6 +81,7 @@ const UsersPage: React.FC = () => {
     ...(roleFilter && { role: roleFilter }),
     ...(statusFilter === 'active' && { isActive: true }),
     ...(statusFilter === 'inactive' && { isActive: false }),
+    ...(sortBy && { sortBy, sortOrder }),
   };
 
   // Fetch users data with React Query
@@ -109,9 +112,11 @@ const UsersPage: React.FC = () => {
     if (searchValue) newParams.set('search', searchValue);
     if (roleFilter) newParams.set('role', roleFilter);
     if (statusFilter) newParams.set('status', statusFilter);
+    if (sortBy) newParams.set('sortBy', sortBy);
+    if (sortBy) newParams.set('sortOrder', sortOrder);
 
     setSearchParams(newParams);
-  }, [page, perPage, searchValue, roleFilter, statusFilter, setSearchParams]);
+  }, [page, perPage, searchValue, roleFilter, statusFilter, sortBy, sortOrder, setSearchParams]);
 
   // Helper functions
   const getStatusBadge = (isActive: boolean) => {
@@ -170,6 +175,22 @@ const UsersPage: React.FC = () => {
     }
     setIsEditModalOpen(true);
   };
+
+  const handleSort = (columnKey: string) => {
+    const newOrder = sortBy === columnKey && sortOrder === 'asc' ? 'desc' : 'asc';
+    setSortBy(columnKey);
+    setSortOrder(newOrder);
+    setPage(1);
+  };
+
+  const getSortParams = (columnKey: string): ThProps['sort'] => ({
+    sortBy:
+      sortBy === columnKey
+        ? { index: 0, direction: sortOrder }
+        : {},
+    onSort: () => handleSort(columnKey),
+    columnIndex: 0,
+  });
 
   const clearAllFilters = () => {
     setSearchValue('');
@@ -388,11 +409,11 @@ const UsersPage: React.FC = () => {
                   </caption>
                   <Thead>
                     <Tr>
-                      <Th width={20}>{t('users.table.username')}</Th>
-                      <Th width={25}>{t('users.table.email')}</Th>
-                      <Th width={20}>{t('users.table.fullName')}</Th>
+                      <Th width={20} sort={getSortParams('username')}>{t('users.table.username')}</Th>
+                      <Th width={25} sort={getSortParams('email')}>{t('users.table.email')}</Th>
+                      <Th width={20} sort={getSortParams('fullName')}>{t('users.table.fullName')}</Th>
                       <Th width={25}>{t('users.table.roles')}</Th>
-                      <Th width={10}>{t('users.table.status')}</Th>
+                      <Th width={10} sort={getSortParams('status')}>{t('users.table.status')}</Th>
                       <Th screenReaderText={t('users.table.actions')}></Th>
                     </Tr>
                   </Thead>

--- a/frontend/src/services/chat.service.ts
+++ b/frontend/src/services/chat.service.ts
@@ -84,7 +84,12 @@ export class ChatService {
     litellmUrl: string,
     apiKey: string,
     request: ChatCompletionRequest,
-    onChunk: (content: string, isComplete: boolean, timeToFirstToken?: number) => void,
+    onChunk: (
+      content: string,
+      reasoning: string,
+      isComplete: boolean,
+      timeToFirstToken?: number,
+    ) => void,
     onComplete: (metrics: ResponseMetrics) => void,
     abortController?: AbortController,
   ): Promise<void> {
@@ -120,6 +125,7 @@ export class ChatService {
       const decoder = new TextDecoder();
       let buffer = '';
       let fullContent = '';
+      let fullReasoning = '';
       let finalUsage: TokenUsage | null = null;
       let timeToFirstToken: number | undefined = undefined;
       let firstChunkReceived = false;
@@ -160,7 +166,25 @@ export class ChatService {
 
               try {
                 const chunk: ChatCompletionStreamChunk = JSON.parse(data);
-                const deltaContent = chunk.choices[0]?.delta?.content || '';
+                const delta = chunk.choices[0]?.delta;
+                const deltaContent = delta?.content || '';
+                // Reasoning may stream in a dedicated field (mirrors the non-streaming payload).
+                const deltaReasoning =
+                  delta?.reasoning_content ||
+                  delta?.provider_specific_fields?.reasoning_content ||
+                  delta?.provider_specific_fields?.reasoning ||
+                  '';
+
+                if (deltaReasoning) {
+                  // Capture time to first token on first reasoning chunk too
+                  if (!firstChunkReceived) {
+                    timeToFirstToken = performance.now() - startTime;
+                    firstChunkReceived = true;
+                  }
+
+                  fullReasoning += deltaReasoning;
+                  onChunk(fullContent, fullReasoning, false, timeToFirstToken);
+                }
 
                 if (deltaContent) {
                   // Capture time to first token on first content chunk
@@ -170,7 +194,7 @@ export class ChatService {
                   }
 
                   fullContent += deltaContent;
-                  onChunk(fullContent, false, timeToFirstToken);
+                  onChunk(fullContent, fullReasoning, false, timeToFirstToken);
                 }
 
                 // Save usage data from final chunk
@@ -180,7 +204,7 @@ export class ChatService {
 
                 // Handle completion
                 if (chunk.choices[0]?.finish_reason) {
-                  onChunk(fullContent, true, timeToFirstToken);
+                  onChunk(fullContent, fullReasoning, true, timeToFirstToken);
                 }
               } catch (parseError) {
                 console.warn('Failed to parse streaming chunk:', parseError);
@@ -272,11 +296,17 @@ export class ChatService {
   /**
    * Create a chat message object
    */
-  createMessage(role: 'user' | 'assistant' | 'system', content: string, id?: string): ChatMessage {
+  createMessage(
+    role: 'user' | 'assistant' | 'system',
+    content: string,
+    id?: string,
+    reasoning?: string | null,
+  ): ChatMessage {
     return {
       id: id || this.generateMessageId(),
       role,
       content,
+      ...(reasoning ? { reasoning } : {}),
       timestamp: new Date(),
     };
   }

--- a/frontend/src/services/users.service.ts
+++ b/frontend/src/services/users.service.ts
@@ -41,6 +41,12 @@ export class UsersService {
     if (typeof params.isActive === 'boolean') {
       searchParams.append('isActive', params.isActive.toString());
     }
+    if (params.sortBy) {
+      searchParams.append('sortBy', params.sortBy);
+    }
+    if (params.sortOrder) {
+      searchParams.append('sortOrder', params.sortOrder);
+    }
 
     const queryString = searchParams.toString();
     const url = queryString ? `/users?${queryString}` : '/users';

--- a/frontend/src/test/components/UsersPage.test.tsx
+++ b/frontend/src/test/components/UsersPage.test.tsx
@@ -864,6 +864,130 @@ describe('UsersPage', () => {
     });
   });
 
+  describe('4b. Column Sorting', () => {
+    it('should render sortable column headers for Username, Email, Full Name, and Status', () => {
+      renderWithAuth(<UsersPage />, { user: mockAdminUser });
+
+      const headers = screen.getAllByRole('columnheader');
+      // 6 columns: Username, Email, Full Name, Roles, Status, Actions
+      expect(headers).toHaveLength(6);
+
+      // Sortable columns should contain a button (PatternFly SortColumn renders a button)
+      const usernameHeader = headers[0];
+      const emailHeader = headers[1];
+      const fullNameHeader = headers[2];
+      const rolesHeader = headers[3];
+      const statusHeader = headers[4];
+
+      expect(within(usernameHeader).getByRole('button')).toBeInTheDocument();
+      expect(within(emailHeader).getByRole('button')).toBeInTheDocument();
+      expect(within(fullNameHeader).getByRole('button')).toBeInTheDocument();
+      expect(within(statusHeader).getByRole('button')).toBeInTheDocument();
+
+      // Roles column should NOT be sortable (no button)
+      expect(within(rolesHeader).queryByRole('button')).not.toBeInTheDocument();
+    });
+
+    it('should update URL params when a sortable column header is clicked', async () => {
+      const user = userEvent.setup();
+      renderWithAuth(<UsersPage />, { user: mockAdminUser });
+
+      const headers = screen.getAllByRole('columnheader');
+      const usernameButton = within(headers[0]).getByRole('button');
+      await user.click(usernameButton);
+
+      await waitFor(() => {
+        const calls = mockSetSearchParams.mock.calls;
+        const lastCall = calls[calls.length - 1];
+        const params = lastCall[0] as URLSearchParams;
+        expect(params.get('sortBy')).toBe('username');
+        expect(params.get('sortOrder')).toBe('asc');
+      });
+    });
+
+    it('should toggle sort direction when clicking the same column again', async () => {
+      const user = userEvent.setup();
+      renderWithAuth(<UsersPage />, { user: mockAdminUser });
+
+      const headers = screen.getAllByRole('columnheader');
+      const usernameButton = within(headers[0]).getByRole('button');
+
+      // First click — asc
+      await user.click(usernameButton);
+      await waitFor(() => {
+        const calls = mockSetSearchParams.mock.calls;
+        const params = calls[calls.length - 1][0] as URLSearchParams;
+        expect(params.get('sortOrder')).toBe('asc');
+      });
+
+      // Second click — desc
+      await user.click(usernameButton);
+      await waitFor(() => {
+        const calls = mockSetSearchParams.mock.calls;
+        const params = calls[calls.length - 1][0] as URLSearchParams;
+        expect(params.get('sortOrder')).toBe('desc');
+      });
+    });
+
+    it('should reset to page 1 when sort column is clicked', async () => {
+      const user = userEvent.setup();
+      renderWithAuth(<UsersPage />, { user: mockAdminUser });
+
+      const headers = screen.getAllByRole('columnheader');
+      const emailButton = within(headers[1]).getByRole('button');
+      await user.click(emailButton);
+
+      await waitFor(() => {
+        const calls = mockSetSearchParams.mock.calls;
+        const params = calls[calls.length - 1][0] as URLSearchParams;
+        // Page should not be set (defaults to 1)
+        expect(params.has('page')).toBe(false);
+      });
+    });
+
+    it('should include sort params in React Query key', async () => {
+      const user = userEvent.setup();
+      renderWithAuth(<UsersPage />, { user: mockAdminUser });
+
+      const headers = screen.getAllByRole('columnheader');
+      const fullNameButton = within(headers[2]).getByRole('button');
+      await user.click(fullNameButton);
+
+      await waitFor(() => {
+        const lastCall = vi.mocked(useQuery).mock.calls[vi.mocked(useQuery).mock.calls.length - 1];
+        const queryKey = lastCall[0] as [string, any];
+        expect(queryKey[1]).toMatchObject({
+          sortBy: 'fullName',
+          sortOrder: 'asc',
+        });
+      });
+    });
+
+    it('should switch sort column when clicking a different column', async () => {
+      const user = userEvent.setup();
+      renderWithAuth(<UsersPage />, { user: mockAdminUser });
+
+      const headers = screen.getAllByRole('columnheader');
+
+      // Click Username first
+      await user.click(within(headers[0]).getByRole('button'));
+      await waitFor(() => {
+        const calls = mockSetSearchParams.mock.calls;
+        const params = calls[calls.length - 1][0] as URLSearchParams;
+        expect(params.get('sortBy')).toBe('username');
+      });
+
+      // Click Email — should switch column and reset to asc
+      await user.click(within(headers[1]).getByRole('button'));
+      await waitFor(() => {
+        const calls = mockSetSearchParams.mock.calls;
+        const params = calls[calls.length - 1][0] as URLSearchParams;
+        expect(params.get('sortBy')).toBe('email');
+        expect(params.get('sortOrder')).toBe('asc');
+      });
+    });
+  });
+
   describe('5. Permissions', () => {
     it('should show access denied message when user cannot read users', () => {
       vi.mocked(usersService.canReadUsers).mockReturnValue(false);

--- a/frontend/src/test/services/users.service.test.ts
+++ b/frontend/src/test/services/users.service.test.ts
@@ -246,6 +246,56 @@ describe('UsersService', () => {
       expect(result.data[0].username).toBe('jane_admin');
     });
 
+    it('should include sortBy and sortOrder params when provided', async () => {
+      vi.mocked(apiClient.get).mockResolvedValueOnce({
+        data: mockUsers,
+        pagination: { page: 1, limit: 20, total: 3, totalPages: 1 },
+      });
+
+      await usersService.getUsers({ sortBy: 'username', sortOrder: 'asc' });
+
+      expect(apiClient.get).toHaveBeenCalledWith('/users?sortBy=username&sortOrder=asc');
+    });
+
+    it('should include sortBy with desc order', async () => {
+      vi.mocked(apiClient.get).mockResolvedValueOnce({
+        data: mockUsers,
+        pagination: { page: 1, limit: 20, total: 3, totalPages: 1 },
+      });
+
+      await usersService.getUsers({ sortBy: 'email', sortOrder: 'desc' });
+
+      expect(apiClient.get).toHaveBeenCalledWith('/users?sortBy=email&sortOrder=desc');
+    });
+
+    it('should combine sort params with other filters', async () => {
+      vi.mocked(apiClient.get).mockResolvedValueOnce({
+        data: [mockUsers[0]],
+        pagination: { page: 1, limit: 20, total: 1, totalPages: 1 },
+      });
+
+      await usersService.getUsers({
+        search: 'john',
+        sortBy: 'fullName',
+        sortOrder: 'asc',
+      });
+
+      expect(apiClient.get).toHaveBeenCalledWith(
+        '/users?search=john&sortBy=fullName&sortOrder=asc',
+      );
+    });
+
+    it('should not include sort params when sortBy is not provided', async () => {
+      vi.mocked(apiClient.get).mockResolvedValueOnce({
+        data: mockUsers,
+        pagination: { page: 1, limit: 20, total: 3, totalPages: 1 },
+      });
+
+      await usersService.getUsers({ page: 1 });
+
+      expect(apiClient.get).toHaveBeenCalledWith('/users?page=1');
+    });
+
     it('should handle API errors', async () => {
       const error = new Error('Forbidden');
       (error as any).response = { status: 403, data: { message: 'Forbidden', statusCode: 403 } };

--- a/frontend/src/test/utils/thinkingParser.test.ts
+++ b/frontend/src/test/utils/thinkingParser.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseThinkingTags } from '../../utils/thinkingParser';
+import { extractReasoning, parseThinkingTags, resolveThinking } from '../../utils/thinkingParser';
 
 describe('parseThinkingTags', () => {
   it('should return null thinking for content without think tags', () => {
@@ -61,7 +61,8 @@ describe('parseThinkingTags', () => {
   });
 
   it('should handle multiline thinking content', () => {
-    const content = '<think>Step 1: analyze\nStep 2: compute\nStep 3: respond</think>Here is my answer.';
+    const content =
+      '<think>Step 1: analyze\nStep 2: compute\nStep 3: respond</think>Here is my answer.';
     const result = parseThinkingTags(content);
     expect(result.thinking).toBe('Step 1: analyze\nStep 2: compute\nStep 3: respond');
     expect(result.response).toBe('Here is my answer.');
@@ -83,5 +84,96 @@ describe('parseThinkingTags', () => {
     const result = parseThinkingTags(content);
     expect(result.thinking).toBe('some thought');
     expect(result.response).toBe('some response');
+  });
+});
+
+describe('extractReasoning', () => {
+  it('should return null for undefined or null source', () => {
+    expect(extractReasoning(undefined)).toBeNull();
+    expect(extractReasoning(null)).toBeNull();
+  });
+
+  it('should return null when no reasoning fields are present', () => {
+    expect(extractReasoning({})).toBeNull();
+  });
+
+  it('should extract top-level reasoning_content', () => {
+    expect(extractReasoning({ reasoning_content: 'Let me think.' })).toBe('Let me think.');
+  });
+
+  it('should extract reasoning_content from provider_specific_fields', () => {
+    expect(
+      extractReasoning({ provider_specific_fields: { reasoning_content: 'Nested reasoning.' } }),
+    ).toBe('Nested reasoning.');
+  });
+
+  it('should extract reasoning from provider_specific_fields.reasoning', () => {
+    expect(
+      extractReasoning({ provider_specific_fields: { reasoning: 'Provider reasoning.' } }),
+    ).toBe('Provider reasoning.');
+  });
+
+  it('should prefer top-level reasoning_content over provider_specific_fields', () => {
+    expect(
+      extractReasoning({
+        reasoning_content: 'Top level',
+        provider_specific_fields: { reasoning_content: 'Nested', reasoning: 'Provider' },
+      }),
+    ).toBe('Top level');
+  });
+
+  it('should trim reasoning and normalize empty strings to null', () => {
+    expect(extractReasoning({ reasoning_content: '  padded  ' })).toBe('padded');
+    expect(extractReasoning({ reasoning_content: '   ' })).toBeNull();
+    expect(extractReasoning({ reasoning_content: '' })).toBeNull();
+  });
+});
+
+describe('resolveThinking', () => {
+  it('should prefer a dedicated reasoning field over content', () => {
+    const result = resolveThinking('The answer is 42.', 'Dedicated reasoning.');
+    expect(result).toEqual({
+      thinking: 'Dedicated reasoning.',
+      response: 'The answer is 42.',
+      isThinkingComplete: true,
+    });
+  });
+
+  it('should not parse <think> tags out of content when a reasoning field is present', () => {
+    const result = resolveThinking('<think>inline</think>Answer.', 'Dedicated reasoning.');
+    expect(result.thinking).toBe('Dedicated reasoning.');
+    expect(result.response).toBe('<think>inline</think>Answer.');
+  });
+
+  it('should mark reasoning incomplete while streaming with no content yet', () => {
+    const result = resolveThinking('', 'Reasoning so far...', true);
+    expect(result).toEqual({
+      thinking: 'Reasoning so far...',
+      response: '',
+      isThinkingComplete: false,
+    });
+  });
+
+  it('should mark reasoning complete once content starts streaming', () => {
+    const result = resolveThinking('Partial answer', 'Reasoning done.', true);
+    expect(result.isThinkingComplete).toBe(true);
+  });
+
+  it('should fall back to <think> tag parsing when no reasoning field is present', () => {
+    const result = resolveThinking('<think>Reasoning here.</think>Answer.');
+    expect(result).toEqual({
+      thinking: 'Reasoning here.',
+      response: 'Answer.',
+      isThinkingComplete: true,
+    });
+  });
+
+  it('should handle plain content with neither reasoning field nor tags', () => {
+    const result = resolveThinking('Just a plain answer.');
+    expect(result).toEqual({
+      thinking: null,
+      response: 'Just a plain answer.',
+      isThinkingComplete: true,
+    });
   });
 });

--- a/frontend/src/test/utils/thinkingParser.test.ts
+++ b/frontend/src/test/utils/thinkingParser.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { parseThinkingTags } from '../../utils/thinkingParser';
+
+describe('parseThinkingTags', () => {
+  it('should return null thinking for content without think tags', () => {
+    const result = parseThinkingTags('Hello, world!');
+    expect(result).toEqual({
+      thinking: null,
+      response: 'Hello, world!',
+      isThinkingComplete: true,
+    });
+  });
+
+  it('should return null thinking for empty content', () => {
+    const result = parseThinkingTags('');
+    expect(result).toEqual({
+      thinking: null,
+      response: '',
+      isThinkingComplete: true,
+    });
+  });
+
+  it('should parse complete thinking tags', () => {
+    const content = '<think>Let me reason about this.</think>The answer is 42.';
+    const result = parseThinkingTags(content);
+    expect(result).toEqual({
+      thinking: 'Let me reason about this.',
+      response: 'The answer is 42.',
+      isThinkingComplete: true,
+    });
+  });
+
+  it('should handle incomplete thinking tags during streaming', () => {
+    const content = '<think>Still working on this...';
+    const result = parseThinkingTags(content);
+    expect(result).toEqual({
+      thinking: 'Still working on this...',
+      response: '',
+      isThinkingComplete: false,
+    });
+  });
+
+  it('should handle empty thinking tags', () => {
+    const content = '<think></think>The answer is 42.';
+    const result = parseThinkingTags(content);
+    expect(result).toEqual({
+      thinking: null,
+      response: 'The answer is 42.',
+      isThinkingComplete: true,
+    });
+  });
+
+  it('should handle thinking with no response after', () => {
+    const content = '<think>Just thinking out loud.</think>';
+    const result = parseThinkingTags(content);
+    expect(result).toEqual({
+      thinking: 'Just thinking out loud.',
+      response: '',
+      isThinkingComplete: true,
+    });
+  });
+
+  it('should handle multiline thinking content', () => {
+    const content = '<think>Step 1: analyze\nStep 2: compute\nStep 3: respond</think>Here is my answer.';
+    const result = parseThinkingTags(content);
+    expect(result.thinking).toBe('Step 1: analyze\nStep 2: compute\nStep 3: respond');
+    expect(result.response).toBe('Here is my answer.');
+    expect(result.isThinkingComplete).toBe(true);
+  });
+
+  it('should handle open tag only during early streaming', () => {
+    const content = '<think>';
+    const result = parseThinkingTags(content);
+    expect(result).toEqual({
+      thinking: null,
+      response: '',
+      isThinkingComplete: false,
+    });
+  });
+
+  it('should trim whitespace from thinking and response', () => {
+    const content = '<think>  some thought  </think>  some response  ';
+    const result = parseThinkingTags(content);
+    expect(result.thinking).toBe('some thought');
+    expect(result.response).toBe('some response');
+  });
+});

--- a/frontend/src/types/chat.ts
+++ b/frontend/src/types/chat.ts
@@ -6,7 +6,22 @@ export interface ChatMessage {
   id: string;
   role: 'user' | 'assistant' | 'system';
   content: string;
+  /** Reasoning/thinking text returned as a dedicated field by the provider (e.g. `reasoning_content`). */
+  reasoning?: string;
   timestamp: Date;
+}
+
+/**
+ * Some providers/engines return the reasoning trace in a dedicated payload field rather than
+ * embedded in `content` as `<think>...</think>` tags. LiteLLM surfaces this as `reasoning_content`
+ * (and mirrors it under `provider_specific_fields`).
+ */
+export interface ReasoningFields {
+  reasoning_content?: string | null;
+  provider_specific_fields?: {
+    reasoning?: string | null;
+    reasoning_content?: string | null;
+  } | null;
 }
 
 export interface TokenUsage {
@@ -43,7 +58,7 @@ export interface ChatCompletionResponse {
     message: {
       role: 'assistant';
       content: string;
-    };
+    } & ReasoningFields;
     finish_reason: 'stop' | 'length' | 'content_filter' | 'tool_calls' | null;
   }>;
   usage: TokenUsage;
@@ -60,7 +75,7 @@ export interface ChatCompletionStreamChunk {
     delta: {
       role?: 'assistant';
       content?: string;
-    };
+    } & ReasoningFields;
     finish_reason: 'stop' | 'length' | 'content_filter' | 'tool_calls' | null;
   }>;
   usage?: TokenUsage; // Only present in the final chunk

--- a/frontend/src/types/users.ts
+++ b/frontend/src/types/users.ts
@@ -15,6 +15,8 @@ export interface UserListParams {
   search?: string;
   role?: string;
   isActive?: boolean;
+  sortBy?: string;
+  sortOrder?: 'asc' | 'desc';
 }
 
 export interface UserUpdateData {

--- a/frontend/src/utils/thinkingParser.ts
+++ b/frontend/src/utils/thinkingParser.ts
@@ -1,7 +1,56 @@
+import type { ReasoningFields } from '../types/chat';
+
 export interface ParsedThinking {
   thinking: string | null;
   response: string;
   isThinkingComplete: boolean;
+}
+
+/**
+ * Extract reasoning text from a provider payload field.
+ *
+ * Some providers/engines (e.g. DeepSeek R1 distills served through LiteLLM) return the reasoning
+ * trace in a dedicated `reasoning_content` field rather than inline as `<think>...</think>` tags.
+ * LiteLLM also mirrors it under `provider_specific_fields`. This checks all known locations and
+ * returns the trimmed text, or null when absent.
+ */
+export function extractReasoning(source?: ReasoningFields | null): string | null {
+  if (!source) {
+    return null;
+  }
+
+  const reasoning =
+    source.reasoning_content ||
+    source.provider_specific_fields?.reasoning_content ||
+    source.provider_specific_fields?.reasoning;
+
+  const trimmed = reasoning?.trim();
+  return trimmed ? trimmed : null;
+}
+
+/**
+ * Resolve the thinking/response split for an assistant message.
+ *
+ * A dedicated reasoning field (from {@link extractReasoning}) takes precedence over inline
+ * `<think>` tags. When no reasoning field is present, this falls back to parsing tags out of the
+ * content string via {@link parseThinkingTags}.
+ */
+export function resolveThinking(
+  content: string,
+  reasoning?: string | null,
+  isStreaming = false,
+): ParsedThinking {
+  if (reasoning) {
+    return {
+      thinking: reasoning,
+      response: content,
+      // With a dedicated reasoning field, reasoning finishes once the answer begins streaming
+      // (or immediately for a non-streaming response).
+      isThinkingComplete: !isStreaming || content.length > 0,
+    };
+  }
+
+  return parseThinkingTags(content);
 }
 
 export function parseThinkingTags(content: string): ParsedThinking {

--- a/frontend/src/utils/thinkingParser.ts
+++ b/frontend/src/utils/thinkingParser.ts
@@ -1,0 +1,42 @@
+export interface ParsedThinking {
+  thinking: string | null;
+  response: string;
+  isThinkingComplete: boolean;
+}
+
+export function parseThinkingTags(content: string): ParsedThinking {
+  if (!content) {
+    return { thinking: null, response: '', isThinkingComplete: true };
+  }
+
+  const openTag = '<think>';
+  const closeTag = '</think>';
+
+  const openIndex = content.indexOf(openTag);
+  if (openIndex === -1) {
+    return { thinking: null, response: content, isThinkingComplete: true };
+  }
+
+  const thinkingStart = openIndex + openTag.length;
+  const closeIndex = content.indexOf(closeTag, thinkingStart);
+
+  if (closeIndex === -1) {
+    const thinking = content.substring(thinkingStart).trim();
+    return {
+      thinking: thinking || null,
+      response: '',
+      isThinkingComplete: false,
+    };
+  }
+
+  const thinking = content.substring(thinkingStart, closeIndex).trim();
+  const beforeThink = content.substring(0, openIndex);
+  const afterThink = content.substring(closeIndex + closeTag.length);
+  const response = (beforeThink + afterThink).trim();
+
+  return {
+    thinking: thinking || null,
+    response,
+    isThinkingComplete: true,
+  };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "litemaas",
-  "version": "0.4.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "litemaas",
-      "version": "0.4.0",
+      "version": "0.5.1",
       "workspaces": [
         "backend",
         "frontend"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "litemaas",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "LiteLLM User Application - Model subscription and management platform",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
## Release v0.5.1

Release of LiteMaaS **0.5.1** (from `v0.5.0`). See `CHANGELOG.md` for the full entry.

### ✨ Added
- **Reasoning field support in the chatbot playground** — renders the model's thinking trace when returned in a dedicated payload field (`reasoning_content`, also mirrored under `provider_specific_fields`) in addition to inline `<think>` tags, so more models are supported.
- **Thinking-tag formatting** — `<think>...</think>` content is shown as a collapsible section above the response ("Thinking..." while streaming, "Thought" once complete) (#71).
- **Function Calling category filter** on the Models page (#175).
- **Column sorting on the Users Management table** (server-side, sort state persisted in URL) (#170).

### 🐛 Fixed
- **API key deletion no longer loses usage attribution** — user self-service deletion now soft-deletes (archives) keys so historical usage stays mapped to the user, while still revoking the key in LiteLLM. Admin permanent delete remains a hard delete (#172).
- **Email NOT NULL violation on user update** — OIDC update path now falls back to `preferred_username` when the provider omits email, matching the insert path (#167, #173).
- **Ingress blocked on OpenShift** — removed the `platform == "kubernetes"` guard so Ingress is deployable on OpenShift too (unblocks cert-manager TLS). Also fixed a regression in #169 that dropped the `and` keyword and broke chart rendering entirely (#168, #169).
- **Kustomize image tags pinned** — the `images:` transformer no longer forces `latest`; it now resolves to the exact `${LITEMAAS_VERSION}`. (Follow-up tracked in #176.)
- **Frontend initContainer** — removed a hardcoded `runAsUser` that could block startup under restrictive security contexts.
- **Backup restore progress reporting** — now reports reliably at each 10k-statement interval.

### 📦 Release chores
- Version bumped to `0.5.1` (`package.json`, `package-lock.json`, Helm `appVersion`).
- CHANGELOG updated.

### 🙌 Contributors
Guillaume Moutier, Chris Brown, ashok jammula (new), FlorentMair80 (new).

### Follow-ups
- #176 — revise deployment mechanism (publish Helm chart, deprecate Kustomize).